### PR TITLE
Feature/return full number in recurrence chart

### DIFF
--- a/insights/sources/flowruns/usecases/query_execute.py
+++ b/insights/sources/flowruns/usecases/query_execute.py
@@ -9,17 +9,25 @@ from insights.sources.flowruns.query_builder import (
 )
 
 
-def transform_terms_count_to_percentage(
+def transform_results_data(
     total: int, others: int, terms_agg_buckets: list[dict]
 ) -> list[dict]:
     transformed_results = []
+
     for term in terms_agg_buckets:
-        value = term.get("doc_count")
-        if value == 0 or value is None:
-            transformed_results.append({"label": term.get("key"), "value": 0})
+        full_value = term.get("doc_count")
+
+        if full_value == 0 or full_value is None:
+            transformed_results.append(
+                {"label": term.get("key"), "value": 0, full_value: 0}
+            )
             continue
-        percent = round(((value / total) * 100), 2)
-        transformed_results.append({"label": term.get("key"), "value": percent})
+
+        percentage = round(((full_value / total) * 100), 2)
+        transformed_results.append(
+            {"label": term.get("key"), "value": percentage, "full_value": full_value}
+        )
+
     return transformed_results
 
 
@@ -47,7 +55,7 @@ class QueryExecutor:
             terms_agg = (
                 response.get("aggregations", {}).get("values", {}).get("agg_field")
             )
-            transformed_terms = transform_terms_count_to_percentage(
+            transformed_terms = transform_results_data(
                 total=terms_agg.get("doc_count", 0),
                 others=terms_agg.get("agg_value", {}).get("sum_other_doc_count", 0),
                 terms_agg_buckets=terms_agg.get("agg_value", {}).get("buckets", []),

--- a/insights/sources/tests/flowruns/test_query_execute.py
+++ b/insights/sources/tests/flowruns/test_query_execute.py
@@ -1,0 +1,27 @@
+from random import randint
+from django.test import TestCase
+from django.utils.crypto import get_random_string
+
+from insights.sources.flowruns.usecases.query_execute import transform_results_data
+
+
+class TestFlowRunDataTransformation(TestCase):
+    def setUp(self):
+        counts = [randint(1, 10) for i in range(2)]
+
+        self.total = sum(counts)
+        self.terms_agg_buckets = []
+
+        for count in counts:
+            self.terms_agg_buckets.append(
+                {"key": get_random_string(10), "doc_count": count}
+            )
+
+    def test_flowrun_data_transformation(self):
+        results = transform_results_data(self.total, 0, self.terms_agg_buckets)
+
+        for result in results:
+            self.assertEqual(
+                result["value"],
+                round(((result["full_value"] / self.total) * 100), 2),
+            )


### PR DESCRIPTION
## What
Adding the full number (that is, the number that is used to calculate the percentage) for each result in the flowrun's query execute data transformation.

## Why
Currently, only the percentage value is returned, but the frontend application will require the full number for data display.

Current data representation:

![Screenshot 2024-12-24 165540](https://github.com/user-attachments/assets/8bda7219-7029-4c40-bd21-73e542f5b8cd)

![Screenshot 2024-12-24 165614](https://github.com/user-attachments/assets/fb21b8cc-ebd5-4fca-b365-b9e2aa7abcc0)

