### PR TITLE
Feature/recurrence widget

### DIFF
--- a/insights/widgets/tests/test_update_widget.py
+++ b/insights/widgets/tests/test_update_widget.py
@@ -25,7 +25,7 @@ class TestUpdateWidget(APITestCase):
             source="",
             position={"rows": [1, 3], "columns": [9, 12]},
             config={},
-            type="recurrence",
+            type="empty_column",
         )
 
         self.token = Token.objects.create(user=self.user)

--- a/insights/widgets/tests/test_update_widget.py
+++ b/insights/widgets/tests/test_update_widget.py
@@ -1,0 +1,66 @@
+from rest_framework import status
+from rest_framework.authtoken.models import Token
+from rest_framework.test import APITestCase
+
+from insights.dashboards.models import Dashboard
+from insights.projects.models import Project, ProjectAuth, Roles
+from insights.users.models.user import User
+from insights.widgets.models import Widget
+
+
+class TestUpdateWidget(APITestCase):
+    def setUp(self):
+        self.user = User.objects.create(email="user@email.com")
+        project = Project.objects.create()
+
+        ProjectAuth.objects.create(user=self.user, project=project, role=Roles.ADMIN)
+
+        dashboard = Dashboard.objects.create(
+            project=project,
+            name="test",
+            description="test",
+        )
+        self.widget = Widget.objects.create(
+            dashboard=dashboard,
+            source="",
+            position={"rows": [1, 3], "columns": [9, 12]},
+            config={},
+            type="recurrence",
+        )
+
+        self.token = Token.objects.create(user=self.user)
+        self.client.force_authenticate(user=self.user, token=self.token)
+
+    def test_update_and_configure_recurrence_widget(self):
+        self.assertFalse(hasattr(self.widget, "report"))
+
+        payload = {
+            "type": "recurrence",
+            "source": "flowruns",
+            "config": {
+                "operation": "recurrence",
+                "limit": 5,
+                "filter": {"flow": "cce1d832-c36f-49a7-9181-d65d3e7ff262"},
+            },
+        }
+
+        url = f"/v1/widgets/{self.widget.uuid}/"
+        response = self.client.patch(
+            url,
+            payload,
+            format="json",
+        )
+
+        self.widget.refresh_from_db()
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertTrue(hasattr(self.widget, "report"))
+
+        expected_report_config = {
+            "operation": self.widget.config.get("operation"),
+            "op_field": self.widget.config.get("op_field"),
+            "filter": self.widget.config.get("filter"),
+            "data_suffix": "%",
+        }
+
+        self.assertEqual(self.widget.report.config, expected_report_config)

--- a/insights/widgets/tests/test_update_widget.py
+++ b/insights/widgets/tests/test_update_widget.py
@@ -39,6 +39,7 @@ class TestUpdateWidget(APITestCase):
             "source": "flowruns",
             "config": {
                 "operation": "recurrence",
+                "op_field": "example",
                 "limit": 5,
                 "filter": {"flow": "cce1d832-c36f-49a7-9181-d65d3e7ff262"},
             },

--- a/insights/widgets/viewsets.py
+++ b/insights/widgets/viewsets.py
@@ -34,7 +34,7 @@ class WidgetListUpdateViewSet(
             config.update(update_data["config"])
             update_data["config"] = config
 
-        if widget.type != "card":
+        if widget.type not in {"card", "recurrence"}:
             serializer = self._update(widget, update_data, partial)
             return Response(serializer.data)
 
@@ -47,6 +47,10 @@ class WidgetListUpdateViewSet(
             return Response(serializer.data)
 
         config["limit"] = 1
+
+        if widget.type == "recurrence":
+            config["limit"] = min(update_data.get("limit", 1), 5)
+
         serializer = self._update(widget, update_data, partial)
         widget.refresh_from_db()
         try:

--- a/insights/widgets/viewsets.py
+++ b/insights/widgets/viewsets.py
@@ -35,6 +35,7 @@ class WidgetListUpdateViewSet(
             update_data["config"] = config
 
         serializer = self._update(widget, update_data, partial)
+        widget.refresh_from_db()
 
         if widget.type not in {"card", "recurrence"}:
             return Response(serializer.data)
@@ -51,7 +52,6 @@ class WidgetListUpdateViewSet(
         if widget.type == "recurrence":
             config["limit"] = min(update_data.get("limit", 1), 5)
 
-        widget.refresh_from_db()
         try:
             report = widget.report
         except Report.DoesNotExist:

--- a/insights/widgets/viewsets.py
+++ b/insights/widgets/viewsets.py
@@ -34,8 +34,9 @@ class WidgetListUpdateViewSet(
             config.update(update_data["config"])
             update_data["config"] = config
 
+        serializer = self._update(widget, update_data, partial)
+
         if widget.type not in {"card", "recurrence"}:
-            serializer = self._update(widget, update_data, partial)
             return Response(serializer.data)
 
         if config.get("operation") != "recurrence":
@@ -43,7 +44,6 @@ class WidgetListUpdateViewSet(
                 widget.report.delete()
             except Report.DoesNotExist:
                 pass
-            serializer = self._update(widget, update_data, partial)
             return Response(serializer.data)
 
         config["limit"] = 1
@@ -51,7 +51,6 @@ class WidgetListUpdateViewSet(
         if widget.type == "recurrence":
             config["limit"] = min(update_data.get("limit", 1), 5)
 
-        serializer = self._update(widget, update_data, partial)
         widget.refresh_from_db()
         try:
             report = widget.report


### PR DESCRIPTION
### What
This update modifies the recurrence widget configuration to return a maximum of 5 recurrence data points upon widget update. Additionally, it allows a report generation feature specifically for this type of widget (with both the type and operation being "recurrence").

### Why
Improve the frontend application's ability to display a preview of the recurrence data within the widget. Users will be able to view more comprehensive data by clicking the widget, which will open a detailed report.