### PR TITLE
Feature/message templates status count

### DIFF
--- a/insights/sources/meta_message_templates/clients.py
+++ b/insights/sources/meta_message_templates/clients.py
@@ -10,7 +10,6 @@ from insights.sources.meta_message_templates.enums import (
 )
 from insights.sources.meta_message_templates.utils import (
     format_messages_metrics_data,
-    format_messages_metrics_data_points,
 )
 from insights.utils import convert_date_to_unix_timestamp
 

--- a/insights/sources/meta_message_templates/clients.py
+++ b/insights/sources/meta_message_templates/clients.py
@@ -9,6 +9,7 @@ from insights.sources.meta_message_templates.enums import (
     MetricsTypes,
 )
 from insights.sources.meta_message_templates.utils import (
+    format_messages_metrics_data,
     format_messages_metrics_data_points,
 )
 from insights.utils import convert_date_to_unix_timestamp
@@ -75,15 +76,5 @@ class MetaAPIClient:
             ) from err
 
         meta_response = response.json()
-        data_points = format_messages_metrics_data_points(
-            meta_response.get("data")[0].get("data_points", {})
-        )
 
-        response = {
-            "data": {
-                "granularity": AnalyticsGranularity.DAILY.value,
-                "data_points": data_points,
-            }
-        }
-
-        return response
+        return {"data": format_messages_metrics_data(meta_response.get("data")[0])}

--- a/insights/sources/meta_message_templates/utils.py
+++ b/insights/sources/meta_message_templates/utils.py
@@ -13,10 +13,36 @@ def format_message_metrics_data(data: dict):
     }
 
 
-def format_messages_metrics_data_points(data_points: list[dict]):
-    results = []
+def format_messages_metrics_data(data: dict) -> dict:
+    data_points: dict = data.get("data_points", [])
+
+    status_count = {
+        "sent": {
+            "value": 0,
+        },
+        "delivered": {
+            "value": 0,
+        },
+        "read": {
+            "value": 0,
+        },
+        "clicked": {
+            "value": 0,
+        },
+    }
+    formatted_data_points = []
 
     for data in data_points:
-        results.append(format_message_metrics_data(data))
+        result = format_message_metrics_data(data)
 
-    return results
+        formatted_data_points.append(result)
+
+        for status in ("sent", "delivered", "read", "clicked"):
+            status_count[status]["value"] += result.get(status)
+
+    for status in ("sent", "delivered", "read", "clicked"):
+        status_count[status]["percentage"] = round(
+            (status_count[status]["value"] / status_count["sent"]["value"]) * 100, 2
+        )
+
+    return {"status_count": status_count, "data_points": formatted_data_points}

--- a/insights/sources/meta_message_templates/utils.py
+++ b/insights/sources/meta_message_templates/utils.py
@@ -7,7 +7,7 @@ def format_message_metrics_data(data: dict):
     return {
         "date": dt,
         "sent": data.get("sent"),
-        "delivered": data.get("sent"),
+        "delivered": data.get("delivered"),
         "read": data.get("read"),
         "clicked": sum([btn.get("count", 0) for btn in data.get("clicked", [])]),
     }

--- a/insights/sources/meta_message_templates/utils.py
+++ b/insights/sources/meta_message_templates/utils.py
@@ -40,7 +40,7 @@ def format_messages_metrics_data(data: dict) -> dict:
         for status in ("sent", "delivered", "read", "clicked"):
             status_count[status]["value"] += result.get(status)
 
-    for status in ("sent", "delivered", "read", "clicked"):
+    for status in ("delivered", "read", "clicked"):
         status_count[status]["percentage"] = round(
             (status_count[status]["value"] / status_count["sent"]["value"]) * 100, 2
         )

--- a/insights/sources/tests/meta_message_templates/test_clients.py
+++ b/insights/sources/tests/meta_message_templates/test_clients.py
@@ -6,9 +6,8 @@ from rest_framework import status
 from rest_framework.exceptions import ValidationError
 
 from insights.sources.meta_message_templates.clients import MetaAPIClient
-from insights.sources.meta_message_templates.enums import AnalyticsGranularity
 from insights.sources.meta_message_templates.utils import (
-    format_messages_metrics_data_points,
+    format_messages_metrics_data,
 )
 from insights.sources.tests.meta_message_templates.mock import (
     MOCK_ERROR_RESPONSE_BODY,
@@ -87,14 +86,9 @@ class TestMetaAPIClient(TestCase):
             )
 
             expected_response = {
-                "data": {
-                    "granularity": AnalyticsGranularity.DAILY.value,
-                    "data_points": format_messages_metrics_data_points(
-                        MOCK_TEMPLATE_DAILY_ANALYTICS.get("data")[0].get(
-                            "data_points", {}
-                        )
-                    ),
-                }
+                "data": format_messages_metrics_data(
+                    MOCK_TEMPLATE_DAILY_ANALYTICS.get("data")[0]
+                )
             }
 
             self.assertEqual(preview_response, expected_response)

--- a/insights/sources/tests/meta_message_templates/test_query_executor.py
+++ b/insights/sources/tests/meta_message_templates/test_query_executor.py
@@ -9,11 +9,10 @@ from rest_framework.exceptions import ValidationError
 
 from insights.projects.parsers import parse_dict_to_json
 from insights.sources.meta_message_templates.enums import (
-    AnalyticsGranularity,
     Operations,
 )
 from insights.sources.meta_message_templates.utils import (
-    format_messages_metrics_data_points,
+    format_messages_metrics_data,
 )
 from insights.sources.meta_message_templates.enums import Operations
 from insights.sources.tests.meta_message_templates.mock import (
@@ -89,14 +88,9 @@ class TestMessageTemplateQueryExecutor(TestCase):
                 parser=parse_dict_to_json,
             )
             expected_response = {
-                "data": {
-                    "granularity": AnalyticsGranularity.DAILY.value,
-                    "data_points": format_messages_metrics_data_points(
-                        MOCK_TEMPLATE_DAILY_ANALYTICS.get("data")[0].get(
-                            "data_points", {}
-                        )
-                    ),
-                }
+                "data": format_messages_metrics_data(
+                    MOCK_TEMPLATE_DAILY_ANALYTICS.get("data")[0]
+                )
             }
 
             self.assertEqual(result, expected_response)


### PR DESCRIPTION
### What
Adds the count and percentage for each message template status (sent, delivered, read, clicked). For each status, the count is shown along with the percentage relative to the total "sent" messages.

For example, if 50 messages were sent and 20 were delivered, the "delivered" status will display a count of 20 and a percentage of 40.0%. The "sent" status itself does not display a percentage, as it serves as the reference point for calculating the percentages of other statuses.

### Why
The frontend application needs this data to display above the message status graph.