### PR TITLE
fix: recurrence widget limit on configuration

### DIFF
--- a/insights/widgets/viewsets.py
+++ b/insights/widgets/viewsets.py
@@ -47,10 +47,13 @@ class WidgetListUpdateViewSet(
                 pass
             return Response(serializer.data)
 
-        config["limit"] = 1
-
         if widget.type == "recurrence":
-            config["limit"] = min(update_data.get("limit", 1), 5)
+            config["limit"] = min(config.get("limit", 1), 5)
+        else:
+            config["limit"] = 1
+
+        widget.config = config
+        widget.save()
 
         try:
             report = widget.report


### PR DESCRIPTION
### What
Adding a fix to save the new limit for recurrence widgets in its config

### Why
The number is not being saved, which is necessary for the widget correct display