### PR TITLE
Feature/set human support chart time window

### DIFF
--- a/insights/widgets/usecases/get_source_data.py
+++ b/insights/widgets/usecases/get_source_data.py
@@ -120,6 +120,10 @@ def simple_source_data_operation(
     if project_timezone:
         query_kwargs["timezone"] = project_timezone
 
+    if widget.name == "human_service_dashboard.peaks_in_human_service" and limit == 12:
+        query_kwargs["start_hour"] = 7
+        query_kwargs["end_hour"] = 18
+
     default_filters["project"] = str(widget.project.uuid)
     serialized_source = source_query.execute(
         filters=default_filters,


### PR DESCRIPTION
### What
- Adds configurable arguments to override the default time window (0h - 23h) for the timeseries_hour_group_count operation.
- Sets a fixed time window for the human service timeseries chart widget, specifically from 7h to 18h, to better represent peak hours.

### Why
Currently, the human service timeseries chart widget displays a 12-hour window of data, but the window is not fixed. This PR introduces a fixed time range from 7h to 18h (the complete data, for 24h, can be accessed through the report linked to this widget).