### PR TITLE
Feature/auto select human service dashboard as default when deleting the current default

### DIFF
--- a/insights/dashboards/models.py
+++ b/insights/dashboards/models.py
@@ -67,4 +67,4 @@ class Dashboard(BaseModel, ConfigurableModel):
 
                 return deleted
 
-        deleted = super().delete(using, keep_parents)
+        return super().delete(using, keep_parents)

--- a/insights/dashboards/models.py
+++ b/insights/dashboards/models.py
@@ -1,6 +1,10 @@
-from django.db import models
+from contextlib import suppress
+from django.db import models, transaction
 
 from insights.shared.models import BaseModel, ConfigurableModel
+
+
+HUMAN_SERVICE_DASHBOARD_NAME = "Atendimento humano"
 
 
 class DashboardTemplate(BaseModel, ConfigurableModel):
@@ -48,3 +52,19 @@ class Dashboard(BaseModel, ConfigurableModel):
                 name="unique_default_dashboard_per_project",
             )
         ]
+
+    def delete(self, using=None, keep_parents=False):
+        if self.is_default:
+            with transaction.atomic():
+                deleted = super().delete(using, keep_parents)
+
+                with suppress(Dashboard.DoesNotExist):
+                    human_service_dashboard = Dashboard.objects.get(
+                        project=self.project, name=HUMAN_SERVICE_DASHBOARD_NAME
+                    )
+                    human_service_dashboard.is_default = True
+                    human_service_dashboard.save(update_fields=["is_default"])
+
+                return deleted
+
+        deleted = super().delete(using, keep_parents)

--- a/insights/dashboards/tests/test_models/test_dashboard.py
+++ b/insights/dashboards/tests/test_models/test_dashboard.py
@@ -65,9 +65,11 @@ class TestDashboardModel(TestCase):
             description="Example",
             is_default=False,
         )
+        dashboard_id = dashboard.uuid
 
         dashboard.delete()
 
+        self.assertFalse(Dashboard.objects.filter(uuid=dashboard_id).exists())
         self.human_service_dashboard.refresh_from_db(fields=["is_default"])
         self.assertFalse(self.human_service_dashboard.is_default)
 
@@ -80,8 +82,10 @@ class TestDashboardModel(TestCase):
             description="Example",
             is_default=True,
         )
+        dashboard_id = dashboard.uuid
 
         dashboard.delete()
 
+        self.assertFalse(Dashboard.objects.filter(uuid=dashboard_id).exists())
         self.human_service_dashboard.refresh_from_db(fields=["is_default"])
         self.assertTrue(self.human_service_dashboard.is_default)

--- a/insights/dashboards/usecases/human_service_dashboard_creation.py
+++ b/insights/dashboards/usecases/human_service_dashboard_creation.py
@@ -2,7 +2,7 @@ import copy
 
 from django.db import transaction
 
-from insights.dashboards.models import Dashboard
+from insights.dashboards.models import HUMAN_SERVICE_DASHBOARD_NAME, Dashboard
 from insights.dashboards.usecases.exceptions import (
     InvalidDashboardObject,
     InvalidReportsObject,
@@ -17,7 +17,7 @@ class CreateHumanService:
             with transaction.atomic():
                 atendimento_humano = Dashboard.objects.create(
                     project=project,
-                    name="Atendimento humano",
+                    name=HUMAN_SERVICE_DASHBOARD_NAME,
                     description="Dashboard de atendimento humano",
                     is_default=True,
                     grid=[18, 3],


### PR DESCRIPTION
### What
Overrides the default delete method in the Dashboard model to check if the dashboard being deleted is set as the default for the project. If it is, the system will automatically select the "Human Service Dashboard" as the new default. This dashboard is created automatically and is not deletable by the user.

### Why
This change is necessary to prevent scenarios where the default dashboard is deleted without a replacement, which could result in the frontend application failing to render the insights page properly.