### PR TITLE
Feature/add list operation to meta client

### DIFF
--- a/insights/sources/meta_message_templates/clients.py
+++ b/insights/sources/meta_message_templates/clients.py
@@ -29,6 +29,27 @@ class MetaAPIClient:
     def headers(self):
         return {"Authorization": f"Bearer {self.access_token}"}
 
+    def get_templates_list(self, waba_id: str):
+        url = f"{self.base_host_url}/v21.0/{waba_id}/message_templates"
+
+        params = {
+            "limit": 9999,
+        }
+
+        try:
+            response = requests.get(
+                url, headers=self.headers, params=params, timeout=60
+            )
+            response.raise_for_status()
+        except requests.HTTPError as err:
+            print(f"Error ({err.response.status_code}): {err.response.text}")
+
+            raise ValidationError(
+                {"error": "An error has occurred"}, code="meta_api_error"
+            ) from err
+
+        return response.json()
+
     def get_template_preview_cache_key(self, template_id: str) -> str:
         return f"meta_template_preview:{template_id}"
 

--- a/insights/sources/meta_message_templates/clients.py
+++ b/insights/sources/meta_message_templates/clients.py
@@ -18,7 +18,7 @@ from insights.sources.cache import CacheClient
 
 
 class MetaAPIClient:
-    base_host_url = "https://graph.facebook.com"
+    base_host_url = "https://graph.facebook.com/v21.0"
     access_token = settings.WHATSAPP_API_ACCESS_TOKEN
 
     def __init__(self):
@@ -30,7 +30,7 @@ class MetaAPIClient:
         return {"Authorization": f"Bearer {self.access_token}"}
 
     def get_templates_list(self, waba_id: str):
-        url = f"{self.base_host_url}/v21.0/{waba_id}/message_templates"
+        url = f"{self.base_host_url}/{waba_id}/message_templates"
 
         params = {
             "limit": 9999,
@@ -59,7 +59,7 @@ class MetaAPIClient:
         if cached_response := self.cache.get(cache_key):
             return json.loads(cached_response)
 
-        url = f"{self.base_host_url}/v21.0/{template_id}"
+        url = f"{self.base_host_url}/{template_id}"
 
         try:
             response = requests.get(url, headers=self.headers, timeout=60)
@@ -88,7 +88,7 @@ class MetaAPIClient:
         start_date: date,
         end_date: date,
     ):
-        url = f"{self.base_host_url}/v21.0/{waba_id}/template_analytics?"
+        url = f"{self.base_host_url}/{waba_id}/template_analytics?"
 
         metrics_types = [
             MetricsTypes.SENT.value,
@@ -177,7 +177,7 @@ class MetaAPIClient:
         if buttons == []:
             return {"data": []}
 
-        url = f"{self.base_host_url}/v21.0/{waba_id}/template_analytics?"
+        url = f"{self.base_host_url}/{waba_id}/template_analytics?"
 
         try:
             response = requests.get(

--- a/insights/sources/meta_message_templates/enums.py
+++ b/insights/sources/meta_message_templates/enums.py
@@ -2,6 +2,7 @@ from enum import Enum
 
 
 class Operations(Enum):
+    LIST_TEMPLATES = "list_templates"
     TEMPLATE_PREVIEW = "template_preview"
     MESSAGES_ANALYTICS = "messages_analytics"
     BUTTONS_ANALYTICS = "buttons_analytics"

--- a/insights/sources/meta_message_templates/usecases/query_execute.py
+++ b/insights/sources/meta_message_templates/usecases/query_execute.py
@@ -20,6 +20,12 @@ class QueryExecutor:
         client = MetaAPIClient()
 
         match operation:
+            case Operations.LIST_TEMPLATES.value:
+                if not (waba_id := filters.get("waba_id")):
+                    raise ValidationError("WABA id is required", code="waba_id_missing")
+
+                return client.get_templates_list(waba_id=waba_id)
+
             case Operations.TEMPLATE_PREVIEW.value:
                 if not (template_id := filters.get("template_id")):
                     raise ValidationError(

--- a/insights/sources/tests/meta_message_templates/mock.py
+++ b/insights/sources/tests/meta_message_templates/mock.py
@@ -1,3 +1,64 @@
+MOCK_TEMPLATES_LIST_BODY = {
+    "data": [
+        {
+            "name": "example",
+            "parameter_format": "POSITIONAL",
+            "components": [
+                {
+                    "type": "BODY",
+                    "text": "Hello, {{1}}, this is an example",
+                    "example": {
+                        "body_text": [
+                            [
+                                "Jane",
+                            ]
+                        ]
+                    },
+                },
+                {
+                    "type": "BUTTONS",
+                    "buttons": [
+                        {"type": "QUICK_REPLY", "text": "Continue"},
+                        {"type": "QUICK_REPLY", "text": "Cancel"},
+                    ],
+                },
+            ],
+            "language": "en_US",
+            "status": "APPROVED",
+            "category": "MARKETING",
+            "id": "123456789098765",
+        },
+        {
+            "name": "example_2",
+            "parameter_format": "POSITIONAL",
+            "components": [
+                {
+                    "type": "BODY",
+                    "text": "Hello, {{1}}, this is another example",
+                    "example": {
+                        "body_text": [
+                            [
+                                "Jane",
+                            ]
+                        ]
+                    },
+                },
+                {
+                    "type": "BUTTONS",
+                    "buttons": [
+                        {"type": "QUICK_REPLY", "text": "Continue"},
+                        {"type": "QUICK_REPLY", "text": "Cancel"},
+                    ],
+                },
+            ],
+            "language": "en_US",
+            "status": "APPROVED",
+            "category": "MARKETING",
+            "id": "123456789098767",
+        },
+    ]
+}
+
 MOCK_SUCCESS_RESPONSE_BODY = {
     "name": "testing",
     "parameter_format": "POSITIONAL",

--- a/insights/sources/tests/meta_message_templates/test_clients.py
+++ b/insights/sources/tests/meta_message_templates/test_clients.py
@@ -20,12 +20,12 @@ from insights.sources.tests.meta_message_templates.mock import (
     MOCK_SUCCESS_RESPONSE_BODY,
     MOCK_TEMPLATE_DAILY_ANALYTICS,
     MOCK_TEMPLATE_DAILY_ANALYTICS_INVALID_PERIOD,
+    MOCK_TEMPLATES_LIST_BODY,
 )
 from insights.utils import (
     convert_date_str_to_datetime_date,
     convert_date_to_unix_timestamp,
 )
-from insights.sources.cache import CacheClient
 
 
 class TestMetaAPIClient(TestCase):
@@ -36,6 +36,23 @@ class TestMetaAPIClient(TestCase):
 
     def tearDown(self):
         cache.clear()
+
+    def test_list_templates(self):
+        waba_id = "1234567890987654"
+        url = f"{self.base_host_url}/v21.0/{waba_id}/message_templates"
+
+        with responses.RequestsMock() as rsps:
+            rsps.add(
+                responses.GET,
+                url,
+                status=status.HTTP_200_OK,
+                content_type="application/json",
+                body=json.dumps(MOCK_TEMPLATES_LIST_BODY),
+            )
+
+            response_data = self.client.get_templates_list(waba_id=waba_id)
+            self.assertEqual(response_data, MOCK_TEMPLATES_LIST_BODY)
+            self.assertEqual(len(rsps.calls), 1)
 
     def test_get_template_preview(self):
         template_id = "1234567890987654"

--- a/insights/sources/tests/meta_message_templates/test_query_executor.py
+++ b/insights/sources/tests/meta_message_templates/test_query_executor.py
@@ -19,11 +19,42 @@ from insights.sources.meta_message_templates.enums import Operations
 from insights.sources.tests.meta_message_templates.mock import (
     MOCK_SUCCESS_RESPONSE_BODY,
     MOCK_TEMPLATE_DAILY_ANALYTICS,
+    MOCK_TEMPLATES_LIST_BODY,
 )
 from insights.sources.meta_message_templates.usecases.query_execute import QueryExecutor
 
 
 class TestMessageTemplateQueryExecutor(TestCase):
+    def test_list_templates_operation(self):
+        waba_id = "12345678"
+        url = f"https://graph.facebook.com/v21.0/{waba_id}/message_templates"
+
+        with responses.RequestsMock() as rsps:
+            rsps.add(
+                responses.GET,
+                url,
+                status=status.HTTP_200_OK,
+                content_type="application/json",
+                body=json.dumps(MOCK_TEMPLATES_LIST_BODY),
+            )
+
+            result = QueryExecutor.execute(
+                filters={"waba_id": waba_id},
+                operation=Operations.LIST_TEMPLATES.value,
+                parser=parse_dict_to_json,
+            )
+
+            self.assertEqual(result, MOCK_TEMPLATES_LIST_BODY)
+
+    def test_cannot_list_templates_when_missing_waba_id(self):
+        with self.assertRaises(ValidationError) as context:
+            QueryExecutor.execute(
+                filters={},
+                operation=Operations.LIST_TEMPLATES.value,
+                parser=parse_dict_to_json,
+            )
+            self.assertEqual(context.exception.code, code="waba_id_missing")
+
     def test_template_preview_operation(self):
         template_id = "1234567890987654"
         url = f"https://graph.facebook.com/v21.0/{template_id}"

--- a/insights/sources/tests/meta_message_templates/test_query_executor.py
+++ b/insights/sources/tests/meta_message_templates/test_query_executor.py
@@ -53,7 +53,7 @@ class TestMessageTemplateQueryExecutor(TestCase):
                 operation=Operations.LIST_TEMPLATES.value,
                 parser=parse_dict_to_json,
             )
-            self.assertEqual(context.exception.code, code="waba_id_missing")
+            self.assertEqual(context.exception.code, "waba_id_missing")
 
     def test_template_preview_operation(self):
         template_id = "1234567890987654"

--- a/insights/sources/tests/meta_message_templates/test_query_executor.py
+++ b/insights/sources/tests/meta_message_templates/test_query_executor.py
@@ -1,6 +1,7 @@
 import json
 import responses
 
+from django.core.cache import cache
 from django.test import TestCase
 from django.utils import timezone
 from django.utils.timezone import timedelta
@@ -25,6 +26,12 @@ from insights.sources.meta_message_templates.usecases.query_execute import Query
 
 
 class TestMessageTemplateQueryExecutor(TestCase):
+    def setUp(self):
+        cache.clear()
+
+    def tearDown(self):
+        cache.clear()
+
     def test_list_templates_operation(self):
         waba_id = "12345678"
         url = f"https://graph.facebook.com/v21.0/{waba_id}/message_templates"


### PR DESCRIPTION
### What
Adding operation to list message templates in Meta's client.

### Why
This will be used in future features, such as listing the templates for a WhatsApp account in an endpoint.