### PR TITLE
Feature/Add internal authentication permission for skills metrics

### DIFF
--- a/insights/authentication/permissions.py
+++ b/insights/authentication/permissions.py
@@ -1,5 +1,7 @@
 from rest_framework import permissions
 from rest_framework.exceptions import PermissionDenied
+from rest_framework.request import Request
+from rest_framework.views import APIView
 
 from insights.projects.models import Project, ProjectAuth
 
@@ -38,3 +40,8 @@ class ProjectAuthQueryParamPermission(permissions.BasePermission):
         return ProjectAuth.objects.filter(
             project__uuid=project_uuid, user=request.user, role=1
         ).exists()
+
+
+class InternalAuthenticationPermission(permissions.BasePermission):
+    def has_permission(self, request: Request, view: APIView) -> bool:
+        return request.user.has_perm("users.can_communicate_internally")

--- a/insights/authentication/tests/decorators.py
+++ b/insights/authentication/tests/decorators.py
@@ -1,5 +1,12 @@
 import functools
+
+from django.contrib.auth.models import Permission
+from django.contrib.contenttypes.models import ContentType
+from django.contrib.auth import get_user_model
+
 from insights.projects.models import ProjectAuth
+
+User = get_user_model()
 
 
 def with_project_auth(func):
@@ -9,6 +16,22 @@ def with_project_auth(func):
         user = self.user
 
         ProjectAuth.objects.create(project=project, user=user, role=1)
+
+        return func(self, *args, **kwargs)
+
+    return wrapper
+
+
+def with_internal_auth(func):
+    @functools.wraps(func)
+    def wrapper(self, *args, **kwargs):
+        content_type = ContentType.objects.get_for_model(User)
+        user = self.user
+        permission, _ = Permission.objects.get_or_create(
+            codename="can_communicate_internally",
+            content_type=content_type,
+        )
+        user.user_permissions.add(permission)
 
         return func(self, *args, **kwargs)
 

--- a/insights/metrics/skills/tests/test_views.py
+++ b/insights/metrics/skills/tests/test_views.py
@@ -140,40 +140,7 @@ class TestSkillsMetricsViewAsInternalUser(BaseTestSkillsMetrisView):
         "insights.metrics.skills.services.abandoned_cart.AbandonedCartSkillService.get_metrics"
     )
     def test_can_get_metrics_for_skill(self, mock_metrics):
-        expected_metrics = [
-            {
-                "id": "sent-messages",
-                "value": 50,
-                "percentage": 100.0,
-            },
-            {
-                "id": "delivered-messages",
-                "value": 45,
-                "percentage": 125.0,
-            },
-            {
-                "id": "read-messages",
-                "value": 40,
-                "percentage": 166.67,
-            },
-            {
-                "id": "interactions",
-                "value": 35,
-                "percentage": 250,
-            },
-            {
-                "id": "utm-revenue",
-                "value": 5000,
-                "percentage": 0,
-                "prefix": "R$",
-            },
-            {
-                "id": "orders-placed",
-                "value": 200,
-                "percentage": 0,
-            },
-        ]
-        mock_metrics.return_value = expected_metrics
+        mock_metrics.return_value = {}
 
         response = self.get_metrics_for_skill(
             {

--- a/insights/metrics/skills/views.py
+++ b/insights/metrics/skills/views.py
@@ -1,3 +1,4 @@
+from django.shortcuts import get_object_or_404
 from drf_spectacular.utils import extend_schema
 from rest_framework import status
 from rest_framework.permissions import IsAuthenticated
@@ -16,6 +17,7 @@ from insights.metrics.skills.exceptions import (
 )
 from insights.metrics.skills.serializers import SkillMetricsQueryParamsSerializer
 from insights.metrics.skills.services.factories import SkillMetricsServiceFactory
+from insights.projects.models import Project
 
 
 class SkillsMetricsView(APIView):
@@ -36,11 +38,15 @@ class SkillsMetricsView(APIView):
         filters.pop("skill", None)
         filters.pop("project_uuid", None)
 
+        project = get_object_or_404(
+            Project, uuid=request.query_params.get("project_uuid")
+        )
+
         try:
             service = SkillMetricsServiceFactory().get_service(
-                request.query_params.get("skill"),
-                request.query_params.get("project_uuid"),
-                filters,
+                skill_name=request.query_params.get("skill"),
+                project=project,
+                filters=filters,
             )
         except ValueError as e:
             return Response({"error": str(e)}, status=status.HTTP_400_BAD_REQUEST)

--- a/insights/metrics/skills/views.py
+++ b/insights/metrics/skills/views.py
@@ -1,3 +1,4 @@
+import logging
 from django.shortcuts import get_object_or_404
 from drf_spectacular.utils import extend_schema
 from rest_framework import status
@@ -18,6 +19,9 @@ from insights.metrics.skills.exceptions import (
 from insights.metrics.skills.serializers import SkillMetricsQueryParamsSerializer
 from insights.metrics.skills.services.factories import SkillMetricsServiceFactory
 from insights.projects.models import Project
+
+
+logger = logging.getLogger(__name__)
 
 
 class SkillsMetricsView(APIView):
@@ -54,9 +58,15 @@ class SkillsMetricsView(APIView):
         try:
             metrics = service.get_metrics()
         except (MissingFiltersError, InvalidDateRangeError) as e:
+            logger.exception(
+                "Error getting metrics for skill: %s", str(e), exc_info=True
+            )
             return Response({"error": str(e)}, status=status.HTTP_400_BAD_REQUEST)
         except Exception as e:
             capture_exception(e)
+            logger.exception(
+                "Error getting metrics for skill: %s", str(e), exc_info=True
+            )
             return Response(
                 {"error": str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR
             )

--- a/insights/metrics/skills/views.py
+++ b/insights/metrics/skills/views.py
@@ -6,7 +6,10 @@ from rest_framework.response import Response
 from rest_framework.request import Request
 from sentry_sdk import capture_exception
 
-from insights.authentication.permissions import ProjectAuthQueryParamPermission
+from insights.authentication.permissions import (
+    InternalAuthenticationPermission,
+    ProjectAuthQueryParamPermission,
+)
 from insights.metrics.skills.exceptions import (
     InvalidDateRangeError,
     MissingFiltersError,
@@ -16,7 +19,10 @@ from insights.metrics.skills.services.factories import SkillMetricsServiceFactor
 
 
 class SkillsMetricsView(APIView):
-    permission_classes = [IsAuthenticated, ProjectAuthQueryParamPermission]
+    permission_classes = [
+        IsAuthenticated,
+        (ProjectAuthQueryParamPermission | InternalAuthenticationPermission),
+    ]
 
     @extend_schema(
         parameters=[SkillMetricsQueryParamsSerializer],

--- a/insights/metrics/skills/views.py
+++ b/insights/metrics/skills/views.py
@@ -15,6 +15,7 @@ from insights.authentication.permissions import (
 from insights.metrics.skills.exceptions import (
     InvalidDateRangeError,
     MissingFiltersError,
+    TemplateNotFound,
 )
 from insights.metrics.skills.serializers import SkillMetricsQueryParamsSerializer
 from insights.metrics.skills.services.factories import SkillMetricsServiceFactory
@@ -57,7 +58,7 @@ class SkillsMetricsView(APIView):
 
         try:
             metrics = service.get_metrics()
-        except (MissingFiltersError, InvalidDateRangeError) as e:
+        except (MissingFiltersError, InvalidDateRangeError, TemplateNotFound) as e:
             logger.exception(
                 "Error getting metrics for skill: %s", str(e), exc_info=True
             )

--- a/insights/sources/wabas/clients.py
+++ b/insights/sources/wabas/clients.py
@@ -1,5 +1,6 @@
 from django.conf import settings
 import requests
+import json
 
 from insights.internals.base import InternalAuthentication
 from insights.sources.cache import CacheClient
@@ -14,11 +15,11 @@ class WeniIntegrationsClient(InternalAuthentication):
 
     def get_wabas_for_project(self):
         if cached_response := self.cache.get(self.cache_key):
-            return cached_response
+            return json.loads(cached_response)
 
         response = requests.get(url=self.url, headers=self.headers, timeout=60)
         wabas = response.json().get("data", [])
 
-        self.cache.set(self.cache_key, wabas, self.cache_ttl)
+        self.cache.set(self.cache_key, json.dumps(wabas), self.cache_ttl)
 
         return wabas


### PR DESCRIPTION
### What
Add permission to allow requests with the internal communication token to get skill metrics data.

### Why
This is necessary to allow other modules to get this data internally.