### PR TITLE
Fix/utm source metric filters and improve error handling for VTEX orders metrics retrieval

### DIFF
--- a/insights/metrics/skills/exceptions.py
+++ b/insights/metrics/skills/exceptions.py
@@ -12,3 +12,7 @@ class InvalidDateRangeError(Exception):
 
 class TemplateNotFound(Exception):
     pass
+
+
+class ErrorGettingOrdersMetrics(Exception):
+    pass

--- a/insights/metrics/skills/services/abandoned_cart.py
+++ b/insights/metrics/skills/services/abandoned_cart.py
@@ -94,7 +94,7 @@ class AbandonedCartSkillService(BaseSkillMetricsService):
 
     def _calculate_increase_percentage(self, current: int, past: int):
         if past == 0:
-            return 0
+            return 100 if current > 0 else 0
 
         return round(((current - past) / past) * 100, 2)
 

--- a/insights/metrics/vtex/services/orders_service.py
+++ b/insights/metrics/vtex/services/orders_service.py
@@ -27,16 +27,19 @@ class OrdersService:
         return past_start_date, past_end_date
 
     def _calculate_increase_percentage(self, past_value, current_value):
+        if past_value == 0:
+            return 0
+
         return round(((current_value - past_value) / past_value) * 100, 2)
 
     def get_metrics_from_utm_source(self, utm_source, filters: dict) -> int:
-        filters["utm_source"] = utm_source
+        filters["utm_source"] = (utm_source,)
 
         start_date = filters.pop("start_date")
         end_date = filters.pop("end_date")
 
-        filters["ended_at__gte"] = start_date
-        filters["ended_at__lte"] = end_date
+        filters["ended_at__gte"] = str(start_date)
+        filters["ended_at__lte"] = str(end_date)
 
         # for the current period:
         data = self._get_client().list(filters)
@@ -47,8 +50,8 @@ class OrdersService:
         # for the past period:
         past_start_date, past_end_date = self._get_past_dates(start_date, end_date)
 
-        filters["ended_at__gte"] = past_start_date
-        filters["ended_at__lte"] = past_end_date
+        filters["ended_at__gte"] = str(past_start_date)
+        filters["ended_at__lte"] = str(past_end_date)
 
         past_data = self._get_client().list(filters)
         past_value = past_data.get("accumulatedTotal")

--- a/insights/metrics/vtex/services/orders_service.py
+++ b/insights/metrics/vtex/services/orders_service.py
@@ -28,7 +28,7 @@ class OrdersService:
 
     def _calculate_increase_percentage(self, past_value, current_value):
         if past_value == 0:
-            return 0
+            return 100 if current_value > 0 else 0
 
         return round(((current_value - past_value) / past_value) * 100, 2)
 

--- a/insights/metrics/vtex/services/orders_service.py
+++ b/insights/metrics/vtex/services/orders_service.py
@@ -50,6 +50,7 @@ class OrdersService:
         # for the past period:
         past_start_date, past_end_date = self._get_past_dates(start_date, end_date)
 
+        filters["utm_source"] = (utm_source,)
         filters["ended_at__gte"] = str(past_start_date)
         filters["ended_at__lte"] = str(past_end_date)
 

--- a/insights/sources/orders/clients.py
+++ b/insights/sources/orders/clients.py
@@ -80,7 +80,7 @@ class VtexOrdersRestClient(VtexAuthentication):
         )
         data = response.json()
 
-        if "list" not in data or not data["list"]:
+        if "list" not in data:
             return response.status_code, data
 
         pages = data["paging"]["pages"] if "paging" in data else 1


### PR DESCRIPTION
- Add new ErrorGettingOrdersMetrics exception
- Capture and log exceptions when retrieving orders metrics
- Handle edge cases in percentage calculation for zero past values
- Ensure date filters are converted to strings for VTEX client