### PR TITLE
Feature/return-if-template-is-favorite-on-preview

### DIFF
--- a/insights/metrics/meta/tests/test_message_templates_view.py
+++ b/insights/metrics/meta/tests/test_message_templates_view.py
@@ -217,8 +217,46 @@ class TestMetaMessageTemplatesView(BaseTestMetaMessageTemplatesView):
             }
         )
 
+        expected_response = MOCK_SUCCESS_RESPONSE_BODY.copy()
+        expected_response["is_favorite"] = False
+
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.data, MOCK_SUCCESS_RESPONSE_BODY)
+        self.assertEqual(response.data, expected_response)
+
+    @with_project_auth
+    @patch(
+        "insights.sources.wabas.clients.WeniIntegrationsClient.get_wabas_for_project"
+    )
+    @patch(
+        "insights.sources.meta_message_templates.clients.MetaAPIClient.get_template_preview"
+    )
+    def test_get_preview_for_favorite_template(self, mock_preview, mock_wabas):
+        waba_id = "0000000000000000"
+        template_id = "1234567890987654"
+        dashboard = Dashboard.objects.create(
+            name="test_dashboard", project=self.project, config={"waba_id": waba_id}
+        )
+        FavoriteTemplate.objects.create(
+            dashboard=dashboard, template_id=template_id, name="test_template"
+        )
+        mock_wabas.return_value = [
+            {"waba_id": waba_id},
+        ]
+        mock_preview.return_value = MOCK_SUCCESS_RESPONSE_BODY
+
+        response = self.get_preview(
+            {
+                "waba_id": waba_id,
+                "project_uuid": self.project.uuid,
+                "template_id": template_id,
+            }
+        )
+
+        expected_response = MOCK_SUCCESS_RESPONSE_BODY.copy()
+        expected_response["is_favorite"] = True
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data, expected_response)
 
     @with_project_auth
     @patch(

--- a/insights/metrics/meta/views.py
+++ b/insights/metrics/meta/views.py
@@ -53,6 +53,18 @@ class WhatsAppMessageTemplatesView(GenericViewSet):
             filters=request.query_params, operation=Operations.TEMPLATE_PREVIEW.value
         )
 
+        waba_id = request.query_params.get("waba_id")
+        template_id = request.query_params.get("template_id")
+
+        is_favorite = FavoriteTemplate.objects.filter(
+            dashboard__config__waba_id=waba_id, template_id=template_id
+        ).exists()
+
+        data = {
+            "is_favorite": is_favorite,
+            **data,
+        }
+
         return Response(data, status=status.HTTP_200_OK)
 
     @extend_schema(parameters=WHATSAPP_MESSAGE_TEMPLATES_MSGS_ANALYTICS_PARAMS)


### PR DESCRIPTION
### What
Adding a flag to indicate weather a previewed message template is in the favorites list for the dashboard or not.

### Why
This flag enables the frontend application to visually differentiate between favorited and non-favorited message templates.