### PR TITLE
Feature/set-dashboard-as-default-without-removing-current-one-first

### DIFF
--- a/insights/dashboards/tests/test_serializers/test_dashboard_is_default_serializer.py
+++ b/insights/dashboards/tests/test_serializers/test_dashboard_is_default_serializer.py
@@ -1,0 +1,81 @@
+from django.test import TestCase
+
+from insights.dashboards.models import Dashboard
+from insights.dashboards.serializers import DashboardIsDefaultSerializer
+from insights.projects.models import Project
+
+
+class TestDashboardIsDefaultSerializer(TestCase):
+    def setUp(self):
+        self.project = Project.objects.create(name="Test Project")
+        self.dashboard = Dashboard.objects.create(
+            name="Test Dashboard",
+            project=self.project,
+            is_default=False,
+        )
+
+    def test_set_dashboard_as_default(self):
+        """
+        Test that a dashboard can be set as default
+        """
+        serializer = DashboardIsDefaultSerializer(
+            self.dashboard, data={"is_default": True}, partial=True
+        )
+        serializer.is_valid(raise_exception=True)
+        serializer.save()
+
+        self.dashboard.refresh_from_db(fields=["is_default"])
+        self.assertTrue(self.dashboard.is_default)
+
+    def test_set_dashboard_as_default_when_another_dashboard_is_default(self):
+        """
+        Test that a dashboard can be set as default when another dashboard,
+        from the same project, is default.
+
+        This should update the other dashboard to not be default
+        and leave the dashboard from another project as it is.
+        """
+        another_project_dashboard = Dashboard.objects.create(
+            name="Test Dashboard 2",
+            project=self.project,
+            is_default=True,
+        )
+        dashboard_from_another_project = Dashboard.objects.create(
+            name="Test Dashboard 3",
+            project=Project.objects.create(name="Another Project"),
+            is_default=True,
+        )
+
+        serializer = DashboardIsDefaultSerializer(
+            self.dashboard, data={"is_default": True}, partial=True
+        )
+        serializer.is_valid(raise_exception=True)
+        serializer.save()
+
+        self.dashboard.refresh_from_db(fields=["is_default"])
+        self.assertTrue(self.dashboard.is_default)
+
+        another_project_dashboard.refresh_from_db(fields=["is_default"])
+        self.assertFalse(another_project_dashboard.is_default)
+
+        dashboard_from_another_project.refresh_from_db(fields=["is_default"])
+        self.assertTrue(dashboard_from_another_project.is_default)
+
+    def test_set_dashboard_as_is_default_to_false(self):
+        """
+        Test that a dashboard can be set as is_default to false
+        """
+        Dashboard.objects.filter(project=self.project, is_default=False).update(
+            is_default=True
+        )
+        self.dashboard.refresh_from_db(fields=["is_default"])
+        self.assertTrue(self.dashboard.is_default)
+
+        serializer = DashboardIsDefaultSerializer(
+            self.dashboard, data={"is_default": False}, partial=True
+        )
+        serializer.is_valid(raise_exception=True)
+        serializer.save()
+
+        self.dashboard.refresh_from_db(fields=["is_default"])
+        self.assertFalse(self.dashboard.is_default)

--- a/insights/dashboards/viewsets.py
+++ b/insights/dashboards/viewsets.py
@@ -83,15 +83,16 @@ class DashboardViewSet(
 
     @action(detail=True, methods=["patch"])
     def is_default(self, request, pk=None):
-        dashboard = self.get_object()
+        dashboard: Dashboard = self.get_object()
+
         serializer = DashboardIsDefaultSerializer(
             dashboard, data=request.data, partial=True
         )
-        if serializer.is_valid():
-            serializer.save()
-            return Response(serializer.data)
-        else:
-            return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
+        serializer.is_valid(raise_exception=True)
+        serializer.save()
+
+        return Response(serializer.data, status=status.HTTP_200_OK)
 
     @action(detail=True, methods=["get"])
     def list_widgets(self, request, pk=None):
@@ -243,7 +244,7 @@ class DashboardViewSet(
         methods=["get"],
     )
     def get_custom_status(self, request, project=None):
-        project = Project.objects.get(pk=request.query_params.get('project'))
+        project = Project.objects.get(pk=request.query_params.get("project"))
         custom_status_client = CustomStatusRESTClient(project)
 
         query_filters = dict(request.data or request.query_params or {})


### PR DESCRIPTION
### What
Override DashboardIsDefaultSerializer's save method to ensure that when a new default dashboard is set, the current default dashboard in the project has its is_default flag set to False first.

### Why
Currently, the frontend makes two consecutive requests to the Insights backend to update the default dashboard:
- One request to unset the current default dashboard (is_default = False).
- Another request to set the new dashboard as default (is_default = True).

This is required because of a unique constraint enforcing that only one dashboard per project can have is_default = True.

However, these two requests can be combined into one, allowing the backend to handle the transition seamlessly.