### PR TITLE
Fix/adjust end date calculation in MetaAPIClient

### DIFF
--- a/insights/sources/meta_message_templates/clients.py
+++ b/insights/sources/meta_message_templates/clients.py
@@ -1,7 +1,7 @@
 import json
 import requests
 
-from datetime import date
+from datetime import date, timedelta
 from django.conf import settings
 from rest_framework.exceptions import ValidationError
 
@@ -119,7 +119,7 @@ class MetaAPIClient:
         params = {
             "granularity": AnalyticsGranularity.DAILY.value,
             "start": convert_date_to_unix_timestamp(start_date),
-            "end": convert_date_to_unix_timestamp(end_date),
+            "end": convert_date_to_unix_timestamp(end_date + timedelta(days=1)),
             "metric_types": ",".join(metrics_types),
             "template_ids": template_id,
             "limit": 9999,
@@ -172,7 +172,7 @@ class MetaAPIClient:
         params = {
             "granularity": AnalyticsGranularity.DAILY.value,
             "start": convert_date_to_unix_timestamp(start_date),
-            "end": convert_date_to_unix_timestamp(end_date),
+            "end": convert_date_to_unix_timestamp(end_date + timedelta(days=1)),
             "metric_types": ",".join(metrics_types),
             "template_ids": template_id,
             "limit": 9999,


### PR DESCRIPTION
### What
Adding one day to the end date filter in MetaAPIClient

### Why
To include the last day in the metrics data points, as it was being excluded from it due to conversion.