### PR TITLE
Feature/select message templates fields in list

### DIFF
--- a/insights/metrics/meta/clients.py
+++ b/insights/metrics/meta/clients.py
@@ -36,6 +36,7 @@ class MetaGraphAPIClient:
         waba_id: str,
         name: str | None = None,
         limit: int = 9999,
+        fields: list[str] | None = None,
         before: str | None = None,
         after: str | None = None,
         language: str | None = None,
@@ -48,6 +49,7 @@ class MetaGraphAPIClient:
             for filter_name, filter_value in {
                 "name": name,
                 "limit": limit,
+                "fields": ",".join(fields) if fields else None,
                 "language": language,
                 "category": category,
             }.items()

--- a/insights/metrics/meta/clients.py
+++ b/insights/metrics/meta/clients.py
@@ -49,7 +49,7 @@ class MetaGraphAPIClient:
             for filter_name, filter_value in {
                 "name": name,
                 "limit": limit,
-                "fields": ",".join(fields) if fields else None,
+                "fields": fields,
                 "language": language,
                 "category": category,
             }.items()

--- a/insights/metrics/meta/clients.py
+++ b/insights/metrics/meta/clients.py
@@ -49,7 +49,7 @@ class MetaGraphAPIClient:
             for filter_name, filter_value in {
                 "name": name,
                 "limit": limit,
-                "fields": fields,
+                "fields": ",".join(fields) if fields else None,
                 "language": language,
                 "category": category,
             }.items()

--- a/insights/metrics/meta/serializers.py
+++ b/insights/metrics/meta/serializers.py
@@ -25,6 +25,7 @@ class MessageTemplatesQueryParamsSerializer(serializers.Serializer):
     language = serializers.ChoiceField(
         choices=WhatsAppMessageTemplatesLanguages, required=False
     )
+    fields = serializers.ListField(child=serializers.CharField(), required=False)
 
     def validate_limit(self, value):
         max_limit = 20

--- a/insights/metrics/meta/validators.py
+++ b/insights/metrics/meta/validators.py
@@ -85,7 +85,4 @@ def validate_list_templates_filters(filters: dict):
     if "search" in filters:
         valid_filters["name"] = filters["search"]
 
-    if "fields" in filters:
-        valid_filters["fields"] = filters["fields"].split(",")
-
     return valid_filters

--- a/insights/metrics/meta/validators.py
+++ b/insights/metrics/meta/validators.py
@@ -85,4 +85,7 @@ def validate_list_templates_filters(filters: dict):
     if "search" in filters:
         valid_filters["name"] = filters["search"]
 
+    if "fields" in filters:
+        valid_filters["fields"] = filters["fields"].split(",")
+
     return valid_filters

--- a/insights/metrics/meta/validators.py
+++ b/insights/metrics/meta/validators.py
@@ -74,6 +74,7 @@ def validate_list_templates_filters(filters: dict):
         "language",
         "category",
         "search",
+        "fields",
     ]
     valid_filters = {}
 


### PR DESCRIPTION
### What
Add the "fields" filter to the Meta graph API client's list message templates method, as well as to the filters validator and serializer.

### Why
To allow the frontend application to select only the necessary fields to be returned, instead of the whole template data.