### PR TITLE
Feature/extend abandoned cart skill date range

### DIFF
--- a/insights/metrics/skills/services/abandoned_cart.py
+++ b/insights/metrics/skills/services/abandoned_cart.py
@@ -52,7 +52,7 @@ class AbandonedCartSkillService(BaseSkillMetricsService):
         if valid_fields["start_date"] > valid_fields["end_date"]:
             raise InvalidDateRangeError("End date must be greater than start date")
 
-        if valid_fields["start_date"] < (
+        if valid_fields["start_date"] <= (
             timezone.now().date()
             - timedelta(days=ABANDONED_CART_METRICS_START_DATE_MAX_DAYS)
         ):

--- a/insights/metrics/skills/tests/test_views.py
+++ b/insights/metrics/skills/tests/test_views.py
@@ -84,22 +84,18 @@ class TestSkillsMetricsViewAsAuthenticatedUser(BaseTestSkillsMetrisView):
             {
                 "id": "sent-messages",
                 "value": 50,
-                "percentage": 100.0,
             },
             {
                 "id": "delivered-messages",
                 "value": 45,
-                "percentage": 125.0,
             },
             {
                 "id": "read-messages",
                 "value": 40,
-                "percentage": 166.67,
             },
             {
                 "id": "interactions",
                 "value": 35,
-                "percentage": 250,
             },
             {
                 "id": "utm-revenue",


### PR DESCRIPTION
### What
This pull request extends the date range for abandoned cart skill metrics and refactors the message template metrics calculation. Specifically, it increases the maximum allowed start date for metrics from 45 to 90 days and modifies the _get_message_templates_metrics method to directly use the provided start and end dates for fetching metrics, removing the previous period comparison logic. It also removes the percentage calculations from the returned metrics.

### Why
The 45 days limit was set considering that a comparison was made between the selected period and the past period. This comparision will no longer be available, making it possible to extend the period date range.