### PR TITLE
Fix/wpp-integration-dashboard-unique-verification

### DIFF
--- a/insights/metrics/meta/tests/test_whatsapp_integration_webhook.py
+++ b/insights/metrics/meta/tests/test_whatsapp_integration_webhook.py
@@ -96,7 +96,7 @@ class TestWhatsAppIntegrationWebhookAsAuthenticatedUser(
                 "waba_id": waba_id,
                 "app_uuid": str(uuid.uuid4()),
                 "phone_number": {
-                    "id": "556622598897977",
+                    "id": "996622598897977",
                     "display_phone_number": "+55 82 98877 6655",
                 },
             },

--- a/insights/metrics/meta/views.py
+++ b/insights/metrics/meta/views.py
@@ -281,7 +281,7 @@ class WhatsappIntegrationWebhookView(APIView):
 
         existing_dashboard = Dashboard.objects.filter(
             project=project,
-            config__waba_id=serializer.validated_data["waba_id"],
+            config__phone_number__id=serializer.validated_data["phone_number"]["id"],
             config__is_whatsapp_integration=True,
         ).first()
 


### PR DESCRIPTION
### What
This pull request addresses an issue where WhatsApp integration dashboards were not being uniquely verified. The changes modify the dashboard creation logic to use the phone number ID instead of the WABA ID for identifying existing dashboards. The test case was also updated to reflect this change.

### Why
This ensures that dashboards are uniquely created based on the WhatsApp phone number associated with the integration, as the waba_id can be used for multiple numbers.