### PR TITLE
Fix/waba-phone-number-format

### DIFF
--- a/insights/metrics/meta/serializers.py
+++ b/insights/metrics/meta/serializers.py
@@ -200,6 +200,4 @@ class FavoriteTemplatesQueryParamsSerializer(BaseFavoriteTemplateSerializer):
 
 class WabaSerializer(serializers.Serializer):
     id = serializers.CharField(source="waba_id", read_only=True)
-    phone_number = serializers.CharField(
-        source="phone_number.display_phone_number", read_only=True
-    )
+    phone_number = serializers.CharField(source="phone_number", read_only=True)

--- a/insights/metrics/meta/views.py
+++ b/insights/metrics/meta/views.py
@@ -8,6 +8,7 @@ from rest_framework.response import Response
 from rest_framework.viewsets import GenericViewSet
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.views import APIView
+from sentry_sdk import capture_exception
 
 from insights.authentication.permissions import (
     InternalAuthenticationPermission,
@@ -248,8 +249,14 @@ class WhatsAppMessageTemplatesView(GenericViewSet):
         try:
             wabas_data = WeniIntegrationsClient().get_wabas_for_project(project_uuid)
         except ValueError as e:
+            capture_exception(e)
+            logger.error(
+                "Error fetching wabas for project %s: %s",
+                project_uuid,
+                e,
+            )
             return Response(
-                {"error": "Internal server error"},
+                {"error": "Error fetching wabas"},
                 status=status.HTTP_500_INTERNAL_SERVER_ERROR,
             )
 


### PR DESCRIPTION
### What
Changing the source for "phone_number" in the WabaSerializer, used in the WABAs endpoint

### Why
The integrations backend returns the WhatsApp integration data in a different format now.