### PR TITLE
Fix/delete old fields when updating widget

### DIFF
--- a/insights/widgets/viewsets.py
+++ b/insights/widgets/viewsets.py
@@ -30,9 +30,9 @@ class WidgetListUpdateViewSet(
         report_name = update_data.pop("report_name", None)
 
         config = widget.config
+
         if "config" in update_data:
             config = update_data["config"]
-            update_data["config"] = config
 
         serializer = self._update(widget, update_data, partial)
         widget.refresh_from_db()

--- a/insights/widgets/viewsets.py
+++ b/insights/widgets/viewsets.py
@@ -31,7 +31,7 @@ class WidgetListUpdateViewSet(
 
         config = widget.config
         if "config" in update_data:
-            config.update(update_data["config"])
+            config = update_data["config"]
             update_data["config"] = config
 
         serializer = self._update(widget, update_data, partial)


### PR DESCRIPTION
### What
Change widgets's update logic, to fully replace its config with a new one when the frontend application requests it.

### Why
Currently, when the frontend app updates a widget, it doesn't fully replace the its config (which is a JSON field). Instead, only the fields present in the request are updated, as well as new fields are stored in it. The backend is keeping old fields, that are supposed to be used anymore.