### PR TITLE
Fix/meta timezone adjustment

### DIFF
--- a/insights/metrics/meta/services.py
+++ b/insights/metrics/meta/services.py
@@ -37,20 +37,20 @@ class MetaMessageTemplatesService:
 
         return self.client.get_template_preview(template_id=template_id)
 
-    def get_messages_analytics(self, filters: dict, timezone: str | None = None):
+    def get_messages_analytics(self, filters: dict, timezone_name: str | None = None):
         """
         Get analytics data for messages sent using a message template.
         """
 
-        valid_filters = validate_analytics_kwargs(filters, timezone=timezone)
+        valid_filters = validate_analytics_kwargs(filters, timezone_name=timezone_name)
 
         return self.client.get_messages_analytics(**valid_filters)
 
-    def get_buttons_analytics(self, filters: dict, timezone: str | None = None):
+    def get_buttons_analytics(self, filters: dict, timezone_name: str | None = None):
         """
         Get analytics data for buttons in a message template.
         """
 
-        valid_filters = validate_analytics_kwargs(filters, timezone=timezone)
+        valid_filters = validate_analytics_kwargs(filters, timezone_name=timezone_name)
 
         return self.client.get_buttons_analytics(**valid_filters)

--- a/insights/metrics/meta/services.py
+++ b/insights/metrics/meta/services.py
@@ -37,20 +37,20 @@ class MetaMessageTemplatesService:
 
         return self.client.get_template_preview(template_id=template_id)
 
-    def get_messages_analytics(self, filters: dict):
+    def get_messages_analytics(self, filters: dict, timezone: str | None = None):
         """
         Get analytics data for messages sent using a message template.
         """
 
-        valid_filters = validate_analytics_kwargs(filters)
+        valid_filters = validate_analytics_kwargs(filters, timezone=timezone)
 
         return self.client.get_messages_analytics(**valid_filters)
 
-    def get_buttons_analytics(self, filters: dict):
+    def get_buttons_analytics(self, filters: dict, timezone: str | None = None):
         """
         Get analytics data for buttons in a message template.
         """
 
-        valid_filters = validate_analytics_kwargs(filters)
+        valid_filters = validate_analytics_kwargs(filters, timezone=timezone)
 
         return self.client.get_buttons_analytics(**valid_filters)

--- a/insights/metrics/meta/validators.py
+++ b/insights/metrics/meta/validators.py
@@ -55,10 +55,10 @@ def validate_analytics_kwargs(filters: dict, timezone_name: str | None = None) -
             ) from err
 
         now = datetime.now(tz=tz_info)
-        diff = (now - tz.localize(datetime.combine(dt, datetime.min.time()))).days
+        diff = (now - tz.localize(datetime.combine(dt, now.time()))).days
+        dt = (now - timedelta(diff)).date()
 
-        dt = now - timedelta(diff)
-        analytics_kwargs[dt_field] = dt.date()
+        analytics_kwargs[dt_field] = dt
 
     validate_analytics_selected_period(analytics_kwargs.get("start_date"))
 

--- a/insights/metrics/meta/validators.py
+++ b/insights/metrics/meta/validators.py
@@ -13,12 +13,12 @@ MAX_ANALYTICS_DAYS_PERIOD_FILTER = 90
 ANALYTICS_REQUIRED_FIELDS = ["waba_id", "template_id", "start_date", "end_date"]
 
 
-def validate_analytics_kwargs(filters: dict, timezone: str | None = None) -> dict:
-    if not timezone:
-        timezone = get_current_timezone_name()
+def validate_analytics_kwargs(filters: dict, timezone_name: str | None = None) -> dict:
+    if not timezone_name:
+        timezone_name = get_current_timezone_name()
 
-    tz_info = ZoneInfo(timezone)
-    tz = pytz.timezone(timezone)
+    tz_info = ZoneInfo(timezone_name)
+    tz = pytz.timezone(timezone_name)
 
     analytics_kwargs = {k: None for k in ANALYTICS_REQUIRED_FIELDS}
     missing_fields = []

--- a/insights/metrics/meta/validators.py
+++ b/insights/metrics/meta/validators.py
@@ -1,10 +1,6 @@
-from datetime import date, datetime
-from zoneinfo import ZoneInfo
-
 from django.utils import timezone
-from django.utils.timezone import timedelta, get_current_timezone_name
+from django.utils.timezone import get_current_timezone_name
 from django.utils.translation import gettext_lazy as _
-import pytz
 from rest_framework.exceptions import ValidationError
 
 from insights.utils import convert_date_str_to_datetime_date, convert_dt_to_localized_dt
@@ -16,9 +12,6 @@ ANALYTICS_REQUIRED_FIELDS = ["waba_id", "template_id", "start_date", "end_date"]
 def validate_analytics_kwargs(filters: dict, timezone_name: str | None = None) -> dict:
     if not timezone_name:
         timezone_name = get_current_timezone_name()
-
-    tz_info = ZoneInfo(timezone_name)
-    tz = pytz.timezone(timezone_name)
 
     analytics_kwargs = {k: None for k in ANALYTICS_REQUIRED_FIELDS}
     missing_fields = []

--- a/insights/metrics/meta/validators.py
+++ b/insights/metrics/meta/validators.py
@@ -1,3 +1,5 @@
+from datetime import date
+
 from django.utils import timezone
 from django.utils.timezone import get_current_timezone_name
 from django.utils.translation import gettext_lazy as _

--- a/insights/metrics/meta/validators.py
+++ b/insights/metrics/meta/validators.py
@@ -7,7 +7,7 @@ from django.utils.translation import gettext_lazy as _
 import pytz
 from rest_framework.exceptions import ValidationError
 
-from insights.utils import convert_date_str_to_datetime_date
+from insights.utils import convert_date_str_to_datetime_date, convert_dt_to_localized_dt
 
 MAX_ANALYTICS_DAYS_PERIOD_FILTER = 90
 ANALYTICS_REQUIRED_FIELDS = ["waba_id", "template_id", "start_date", "end_date"]
@@ -54,11 +54,9 @@ def validate_analytics_kwargs(filters: dict, timezone_name: str | None = None) -
                 code="invalid_date_format",
             ) from err
 
-        now = datetime.now(tz=tz_info)
-        diff = (now - tz.localize(datetime.combine(dt, now.time()))).days
-        dt = (now - timedelta(diff)).date()
-
-        analytics_kwargs[dt_field] = dt
+        analytics_kwargs[dt_field] = convert_dt_to_localized_dt(
+            dt, timezone_name
+        ).date()
 
     validate_analytics_selected_period(analytics_kwargs.get("start_date"))
 

--- a/insights/metrics/meta/views.py
+++ b/insights/metrics/meta/views.py
@@ -98,7 +98,14 @@ class WhatsAppMessageTemplatesView(GenericViewSet):
         url_path="messages-analytics",
     )
     def messages_analytics(self, request: Request) -> Response:
-        data = self.service.get_messages_analytics(filters=request.query_params)
+        project_uuid = self.request.query_params.get("project_uuid")
+
+        project = Project.objects.filter(uuid=project_uuid).first()
+        timezone = project.timezone if project else None
+
+        data = self.service.get_messages_analytics(
+            filters=request.query_params, timezone=timezone
+        )
 
         return Response(data, status=status.HTTP_200_OK)
 
@@ -110,7 +117,14 @@ class WhatsAppMessageTemplatesView(GenericViewSet):
         url_path="buttons-analytics",
     )
     def buttons_analytics(self, request: Request) -> Response:
-        data = self.service.get_buttons_analytics(filters=request.query_params)
+        project_uuid = self.request.query_params.get("project_uuid")
+
+        project = Project.objects.filter(uuid=project_uuid).first()
+        timezone = project.timezone if project else None
+
+        data = self.service.get_buttons_analytics(
+            filters=request.query_params, timezone=timezone
+        )
 
         return Response(data, status=status.HTTP_200_OK)
 

--- a/insights/metrics/meta/views.py
+++ b/insights/metrics/meta/views.py
@@ -104,7 +104,7 @@ class WhatsAppMessageTemplatesView(GenericViewSet):
         timezone = project.timezone if project else None
 
         data = self.service.get_messages_analytics(
-            filters=request.query_params, timezone=timezone
+            filters=request.query_params, timezone_name=timezone
         )
 
         return Response(data, status=status.HTTP_200_OK)
@@ -123,7 +123,7 @@ class WhatsAppMessageTemplatesView(GenericViewSet):
         timezone = project.timezone if project else None
 
         data = self.service.get_buttons_analytics(
-            filters=request.query_params, timezone=timezone
+            filters=request.query_params, timezone_name=timezone
         )
 
         return Response(data, status=status.HTTP_200_OK)

--- a/insights/sources/vtex_conversions/services.py
+++ b/insights/sources/vtex_conversions/services.py
@@ -81,7 +81,7 @@ class VTEXOrdersConversionsService:
 
         metrics_data = (
             self.meta_api_client.get_messages_analytics(
-                waba_id, template_id, start_date, end_date, timezone=timezone
+                waba_id, template_id, start_date, end_date, timezone_name=timezone
             )
             .get("data", {})
             .get("status_count")

--- a/insights/sources/vtex_conversions/services.py
+++ b/insights/sources/vtex_conversions/services.py
@@ -76,9 +76,12 @@ class VTEXOrdersConversionsService:
                 code="project_without_waba_permission",
             )
 
+        project = Project.objects.filter(uuid=self.project.uuid).first()
+        timezone = project.timezone if project else None
+
         metrics_data = (
             self.meta_api_client.get_messages_analytics(
-                waba_id, template_id, start_date, end_date
+                waba_id, template_id, start_date, end_date, timezone=timezone
             )
             .get("data", {})
             .get("status_count")

--- a/insights/sources/vtex_conversions/services.py
+++ b/insights/sources/vtex_conversions/services.py
@@ -1,6 +1,10 @@
 from datetime import date
 from logging import getLogger
 
+from django.conf import settings
+from django.utils.timezone import get_current_timezone_name
+
+
 from django.utils.translation import gettext_lazy as _
 from rest_framework.exceptions import PermissionDenied
 
@@ -18,6 +22,7 @@ from insights.sources.vtex_conversions.serializers import (
     OrdersConversionsFiltersSerializer,
     OrdersConversionsMetricsSerializer,
 )
+from insights.utils import convert_dt_to_localized_dt
 
 
 logger = getLogger(__name__)
@@ -44,6 +49,10 @@ class VTEXOrdersConversionsService:
         """
         Check if the project has permission to access the WABA.
         """
+
+        if test_waba_id := getattr(settings, "WHATSAPP_ABANDONED_CART_WABA_ID", None):
+            # TEMPORARY, this should be used only in the development and staging environments
+            return waba_id == test_waba_id
 
         try:
             project_wabas = self.integrations_client.get_wabas_for_project(
@@ -77,11 +86,14 @@ class VTEXOrdersConversionsService:
             )
 
         project = Project.objects.filter(uuid=self.project.uuid).first()
-        timezone = project.timezone if project else None
+        tz_name = project.timezone if project else get_current_timezone_name()
+
+        start_date = convert_dt_to_localized_dt(start_date, tz_name).date()
+        end_date = convert_dt_to_localized_dt(end_date, tz_name).date()
 
         metrics_data = (
             self.meta_api_client.get_messages_analytics(
-                waba_id, template_id, start_date, end_date, timezone_name=timezone
+                waba_id, template_id, start_date, end_date
             )
             .get("data", {})
             .get("status_count")

--- a/insights/utils.py
+++ b/insights/utils.py
@@ -37,3 +37,22 @@ def get_token_flows_authentication(project_uuid, user_email):
     api_token = token_data.get("api_token")
 
     return api_token
+
+
+def convert_dt_to_localized_dt(dt: datetime, timezone_name: str) -> datetime:
+    tz = pytz.timezone(timezone_name)
+
+    # Get the current time in that timezone
+    now = datetime.now(tz=tz)
+    local_time = now.time()
+
+    # Combine the given date with the current local time
+    combined_local_dt = datetime.combine(dt, local_time)
+
+    # Localize the combined datetime to the given timezone
+    localized_dt = tz.localize(combined_local_dt)
+
+    # Convert to UTC
+    dt_utc = localized_dt.astimezone(pytz.utc)
+
+    return dt_utc


### PR DESCRIPTION
### What
The projects' timezone are now used to convert the date range when requesting analytics data to the Meta API, to avoid sending the wrong dates, as Meta expects UTC, always.

### Why
Meta's Graph API always needs to receive dates in UTC. So we need to convert the date range first.