### PR TITLE
fix/vtex-order-conversions-waba-permission

### DIFF
--- a/insights/sources/vtex_conversions/services.py
+++ b/insights/sources/vtex_conversions/services.py
@@ -52,7 +52,9 @@ class VTEXOrdersConversionsService:
         except Exception as e:
             raise e
 
-        return waba_id in project_wabas
+        wabas = [waba["waba_id"] for waba in project_wabas]
+
+        return waba_id in wabas
 
     def get_message_metrics(
         self,


### PR DESCRIPTION
### What
Fixing waba permission checking for VTEX orders conversion, by checking if the requested waba_id is inside the project wabas returned by integrations after transforming the data into a list

### Why
The current checking needs this fix because the object returned by the integrations client is a list of objects, not a list of waba_ids.