### PR TITLE
Fix/template-details-list-length-checking

### DIFF
--- a/insights/metrics/meta/utils.py
+++ b/insights/metrics/meta/utils.py
@@ -130,10 +130,18 @@ def get_edit_template_url_from_template_data(
         )
         return None
 
+    if len(template_data) == 0:
+        logger.info(
+            "No template data found for project_uuid=%s, template_id=%s",
+            project_uuid,
+            template_id,
+        )
+        return None
+
     app_uuid = template_data[0].get("app_uuid")
     templates_uuid = template_data[0].get("templates_uuid", [])
 
-    if not app_uuid or len(templates_uuid) < 1:
+    if not app_uuid or not templates_uuid:
         logger.error(
             "No templates_uuid found for project_uuid=%s, template_id=%s",
             project_uuid,


### PR DESCRIPTION
### What
Enhance error handling in get_edit_template_url_from_template_data function by logging when no template data is found for a given project_uuid and template_id.

### Why
If the list of template details is empty, the function get_edit_template_url_from_template_data needs to return None, so the frontend application won't show the "Edit template" buttton as active.