### PR TITLE
Fix/adjust meta filter end date

### DIFF
--- a/insights/metrics/meta/clients.py
+++ b/insights/metrics/meta/clients.py
@@ -140,10 +140,10 @@ class MetaGraphAPIClient:
         start = convert_date_to_unix_timestamp(start_date)
         end = convert_date_to_unix_timestamp(end_date, use_max_date=True)
 
-        now = datetime.now()
+        now = int(datetime.now().timestamp())
 
-        if end > datetime.now().timestamp():
-            end = now.timestamp()
+        if end > now:
+            end = now
 
         params = {
             "granularity": AnalyticsGranularity.DAILY.value,
@@ -206,10 +206,10 @@ class MetaGraphAPIClient:
         start = convert_date_to_unix_timestamp(start_date)
         end = convert_date_to_unix_timestamp(end_date, use_max_date=True)
 
-        now = datetime.now()
+        now = int(datetime.now().timestamp())
 
-        if end > datetime.now().timestamp():
-            end = now.timestamp()
+        if end > now:
+            end = now
 
         params = {
             "granularity": AnalyticsGranularity.DAILY.value,

--- a/insights/metrics/meta/clients.py
+++ b/insights/metrics/meta/clients.py
@@ -137,7 +137,7 @@ class MetaGraphAPIClient:
             template_id = ",".join(template_id)
 
         start = convert_date_to_unix_timestamp(start_date)
-        end = convert_date_to_unix_timestamp(end_date, use_max_date=True)
+        end = convert_date_to_unix_timestamp(end_date, use_max_time=True)
 
         now = int(datetime.now().timestamp())
 
@@ -203,7 +203,7 @@ class MetaGraphAPIClient:
         ]
 
         start = convert_date_to_unix_timestamp(start_date)
-        end = convert_date_to_unix_timestamp(end_date, use_max_date=True)
+        end = convert_date_to_unix_timestamp(end_date, use_max_time=True)
 
         now = int(datetime.now().timestamp())
 

--- a/insights/metrics/meta/clients.py
+++ b/insights/metrics/meta/clients.py
@@ -2,10 +2,9 @@ import json
 import logging
 import requests
 
-from datetime import date, timedelta, datetime
+from datetime import date, datetime
 
 from django.conf import settings
-from django.utils import timezone
 from rest_framework.exceptions import ValidationError, NotFound
 
 from insights.metrics.meta.enums import AnalyticsGranularity, MetricsTypes

--- a/insights/metrics/meta/clients.py
+++ b/insights/metrics/meta/clients.py
@@ -203,12 +203,18 @@ class MetaGraphAPIClient:
             MetricsTypes.CLICKED.value,
         ]
 
-        end_date = min((end_date + timedelta(days=1)), timezone.now().date())
+        start = convert_date_to_unix_timestamp(start_date)
+        end = convert_date_to_unix_timestamp(end_date, use_max_date=True)
+
+        now = datetime.now()
+
+        if end > datetime.now().timestamp():
+            end = now.timestamp()
 
         params = {
             "granularity": AnalyticsGranularity.DAILY.value,
-            "start": convert_date_to_unix_timestamp(start_date),
-            "end": convert_date_to_unix_timestamp(end_date),
+            "start": start,
+            "end": end,
             "metric_types": ",".join(metrics_types),
             "template_ids": template_id,
             "limit": 9999,

--- a/insights/metrics/meta/clients.py
+++ b/insights/metrics/meta/clients.py
@@ -2,7 +2,7 @@ import json
 import logging
 import requests
 
-from datetime import date, timedelta
+from datetime import date, timedelta, datetime
 
 from django.conf import settings
 from django.utils import timezone
@@ -137,12 +137,18 @@ class MetaGraphAPIClient:
         if isinstance(template_id, list):
             template_id = ",".join(template_id)
 
-        end_date = min((end_date + timedelta(days=1)), timezone.now().date())
+        start = convert_date_to_unix_timestamp(start_date)
+        end = convert_date_to_unix_timestamp(end_date, use_max_date=True)
+
+        now = datetime.now()
+
+        if end > datetime.now().timestamp():
+            end = now.timestamp()
 
         params = {
             "granularity": AnalyticsGranularity.DAILY.value,
-            "start": convert_date_to_unix_timestamp(start_date),
-            "end": convert_date_to_unix_timestamp(end_date),
+            "start": start,
+            "end": end,
             "metric_types": ",".join(metrics_types),
             "template_ids": template_id,
             "limit": 9999,

--- a/insights/metrics/meta/tests/test_clients.py
+++ b/insights/metrics/meta/tests/test_clients.py
@@ -121,7 +121,7 @@ class TestMetaGraphAPIClient(TestCase):
         params = {
             "granularity": AnalyticsGranularity.DAILY.value,
             "start": convert_date_to_unix_timestamp(start_date),
-            "end": convert_date_to_unix_timestamp(end_date, use_max_date=True),
+            "end": convert_date_to_unix_timestamp(end_date, use_max_time=True),
             "metric_types": ",".join(metrics_types),
             "template_ids": template_id,
             "limit": 9999,
@@ -215,7 +215,7 @@ class TestMetaGraphAPIClient(TestCase):
         params = {
             "granularity": AnalyticsGranularity.DAILY.value,
             "start": convert_date_to_unix_timestamp(start_date),
-            "end": convert_date_to_unix_timestamp(end_date, use_max_date=True),
+            "end": convert_date_to_unix_timestamp(end_date, use_max_time=True),
             "metric_types": ",".join(metrics_types),
             "template_ids": template_id,
             "limit": 9999,

--- a/insights/metrics/meta/tests/test_clients.py
+++ b/insights/metrics/meta/tests/test_clients.py
@@ -1,4 +1,3 @@
-from datetime import timedelta
 import json
 import responses
 

--- a/insights/metrics/meta/tests/test_clients.py
+++ b/insights/metrics/meta/tests/test_clients.py
@@ -121,7 +121,7 @@ class TestMetaGraphAPIClient(TestCase):
         params = {
             "granularity": AnalyticsGranularity.DAILY.value,
             "start": convert_date_to_unix_timestamp(start_date),
-            "end": convert_date_to_unix_timestamp(end_date + timedelta(days=1)),
+            "end": convert_date_to_unix_timestamp(end_date, use_max_date=True),
             "metric_types": ",".join(metrics_types),
             "template_ids": template_id,
             "limit": 9999,
@@ -215,7 +215,7 @@ class TestMetaGraphAPIClient(TestCase):
         params = {
             "granularity": AnalyticsGranularity.DAILY.value,
             "start": convert_date_to_unix_timestamp(start_date),
-            "end": convert_date_to_unix_timestamp(end_date + timedelta(days=1)),
+            "end": convert_date_to_unix_timestamp(end_date, use_max_date=True),
             "metric_types": ",".join(metrics_types),
             "template_ids": template_id,
             "limit": 9999,

--- a/insights/utils.py
+++ b/insights/utils.py
@@ -20,8 +20,10 @@ def format_to_iso_utc(date_str, end_of_day=False):
         return None
 
 
-def convert_date_to_unix_timestamp(dt: date) -> int:
-    return int(datetime.combine(dt, datetime.min.time()).timestamp())
+def convert_date_to_unix_timestamp(dt: date, use_max_date=False) -> int:
+    t = datetime.max.time() if use_max_date else datetime.min.time()
+
+    return int(datetime.combine(dt, t).timestamp())
 
 
 def convert_date_str_to_datetime_date(date_str: str) -> date:

--- a/insights/utils.py
+++ b/insights/utils.py
@@ -20,8 +20,8 @@ def format_to_iso_utc(date_str, end_of_day=False):
         return None
 
 
-def convert_date_to_unix_timestamp(dt: date, use_max_date=False) -> int:
-    t = datetime.max.time() if use_max_date else datetime.min.time()
+def convert_date_to_unix_timestamp(dt: date, use_max_time=False) -> int:
+    t = datetime.max.time() if use_max_time else datetime.min.time()
 
     return int(datetime.combine(dt, t).timestamp())
 


### PR DESCRIPTION
### What
This pull request introduces a fix to the end date filter in the Meta Graph API client, to use the maximum time for cases where the end date is the current date. That is:

If now it's April 30 2025 10AM, then the filter must be 2025-04-30 10:00 (converted to Unix timestamp), not 2025-04-30 00:00 (this is what happens currently).

### Why
This fix is needed to correcly present the data from the current date.