### PR TITLE
feature: initialize project attribute in AuthRestClient constructor

### DIFF
--- a/insights/sources/vtexcredentials/clients.py
+++ b/insights/sources/vtexcredentials/clients.py
@@ -10,6 +10,7 @@ from insights.sources.vtexcredentials.typing import VtexCredentialsDTO
 
 class AuthRestClient(InternalAuthentication):
     def __init__(self, project: str) -> None:
+        self.project = project
         self.url = f"{settings.INTEGRATIONS_URL}/api/v1/apptypes/vtex/integration-details/{project}"
 
     def get_vtex_auth(self) -> VtexCredentialsDTO:


### PR DESCRIPTION
### What
Set self.project in VTEX's AuthRestClient (class responsible for getting the credentials from Integrations)

### Why
self.project is used when logging the 404 errors, but it's not set