### PR TITLE
Fix/optimize elasticsearch flowruns queries

### DIFF
--- a/insights/sources/flowruns/query_builder.py
+++ b/insights/sources/flowruns/query_builder.py
@@ -71,7 +71,10 @@ class FlowRunElasticSearchQueryBuilder:
     def recurrence(self, op_field: str, limit: int = 100, *args, **kwargs):
         aggs = {
             "values": {
-                "nested": {"path": "values"},
+                "nested": {
+                    "path": "values",
+                    "query": {"term": {"values.name": op_field}},
+                },
                 "aggs": {
                     "agg_field": {
                         "filter": {
@@ -79,7 +82,11 @@ class FlowRunElasticSearchQueryBuilder:
                         },
                         "aggs": {
                             "agg_value": {
-                                "terms": {"size": limit, "field": "values.value"}
+                                "terms": {
+                                    "size": limit,
+                                    "field": "values.value",
+                                    "execution_hint": "map",
+                                }
                             }
                         },
                     }


### PR DESCRIPTION
### What
This pull request updates the Elasticsearch query builder for recurrences to improve performance. Specifically:

- It adds a nested filter directly to the query.must clause to exclude irrelevant documents before aggregation, avoiding unnecessary processing.
- It sets execution_hint: "map" on the terms aggregation to force the use of MapStringTermsAggregator instead of GlobalOrdinalsStringTermsAggregator. This is more efficient in this case, as the field has low cardinality (i.e., the values repeat frequently, which is typical in recurrence-based fields).

### Why
Currently, data fetching for metrics—especially for recurrence-based CSAT widgets—is slow. This change significantly reduces query time by avoiding unnecessary nested document processing and using a more efficient aggregation strategy.