### PR TITLE
Fix/Caching method name in Datalake metrics service and empty topics early return

### DIFF
--- a/insights/metrics/conversations/integrations/datalake/services.py
+++ b/insights/metrics/conversations/integrations/datalake/services.py
@@ -213,7 +213,7 @@ class DatalakeConversationsMetricsService(BaseConversationsMetricsService):
                 topics_data[topic_uuid]["count"] += 0
 
         if topics_events == [{}]:
-            return topics_events
+            return topics_data
 
         for topic_event in topics_events:
             topic_uuid = topic_event.get("group_value")

--- a/insights/metrics/conversations/integrations/datalake/services.py
+++ b/insights/metrics/conversations/integrations/datalake/services.py
@@ -286,15 +286,17 @@ class DatalakeConversationsMetricsService(BaseConversationsMetricsService):
         Get conversations totals from Datalake.
         """
 
+        cache_key = self._get_cache_key(
+            data_type="conversations_totals",
+            project_uuid=project_uuid,
+            start_date=start_date,
+            end_date=end_date,
+        )
+
         if self.cache_results:
             try:
                 cached_results = self._get_cached_results(
-                    key=self._get_cache_key(
-                        data_type="conversations_totals",
-                        project_uuid=project_uuid,
-                        start_date=start_date,
-                        end_date=end_date,
-                    )
+                    key=cache_key,
                 )
                 if cached_results:
                     return cached_results
@@ -401,13 +403,9 @@ class DatalakeConversationsMetricsService(BaseConversationsMetricsService):
         )
 
         if self.cache_results:
-            params = {
-                "project_uuid": project_uuid,
-                "start_date": start_date,
-                "end_date": end_date,
-            }
             self._save_results_to_cache(
-                key=self._get_cache_key(**params), value=results
+                key=cache_key,
+                value=results,
             )
 
         return results

--- a/insights/metrics/conversations/integrations/datalake/services.py
+++ b/insights/metrics/conversations/integrations/datalake/services.py
@@ -68,7 +68,7 @@ class DatalakeConversationsMetricsService(BaseConversationsMetricsService):
         self.cache_client = cache_client
         self.cache_ttl = cache_ttl
 
-    def _get_cache_key(self, **params) -> str:
+    def _get_cache_key(self, data_type: str, **params) -> str:
         """
         Get cache key for conversations totals with consistent datetime formatting.
         """
@@ -78,7 +78,7 @@ class DatalakeConversationsMetricsService(BaseConversationsMetricsService):
                 formatted_params[key] = value.isoformat()
             else:
                 formatted_params[key] = str(value)
-        return f"conversations_totals_{json.dumps(formatted_params, sort_keys=True)}"
+        return f"{data_type}_{json.dumps(formatted_params, sort_keys=True)}"
 
     def _save_results_to_cache(self, key: str, value) -> None:
         """
@@ -122,6 +122,7 @@ class DatalakeConversationsMetricsService(BaseConversationsMetricsService):
         Get topics distribution from Datalake.
         """
         cache_key = self._get_cache_key(
+            data_type="topics_distribution",
             project_uuid=project_uuid,
             start_date=start_date,
             end_date=end_date,
@@ -289,6 +290,7 @@ class DatalakeConversationsMetricsService(BaseConversationsMetricsService):
             try:
                 cached_results = self._get_cached_results(
                     key=self._get_cache_key(
+                        data_type="conversations_totals",
                         project_uuid=project_uuid,
                         start_date=start_date,
                         end_date=end_date,

--- a/insights/metrics/conversations/integrations/datalake/services.py
+++ b/insights/metrics/conversations/integrations/datalake/services.py
@@ -272,7 +272,8 @@ class DatalakeConversationsMetricsService(BaseConversationsMetricsService):
                 "count"
             ] -= subtopic_event.get("count", 0)
 
-        self._save_results_to_cache(cache_key, topics_data)
+        if self.cache_results:
+            self._save_results_to_cache(cache_key, topics_data)
 
         return topics_data
 

--- a/insights/metrics/conversations/integrations/datalake/services.py
+++ b/insights/metrics/conversations/integrations/datalake/services.py
@@ -287,7 +287,7 @@ class DatalakeConversationsMetricsService(BaseConversationsMetricsService):
 
         if self.cache_results:
             try:
-                cached_results = self._get_conversations_totals_from_cache(
+                cached_results = self._get_cached_results(
                     key=self._get_cache_key(
                         project_uuid=project_uuid,
                         start_date=start_date,


### PR DESCRIPTION
This pull request fixes:
- the name of the get results from cache method name in the datalake metrics service
- empty topics events results early return