### PR TITLE
Feature/csat metrics from datalake

### DIFF
--- a/insights/metrics/conversations/integrations/datalake/services.py
+++ b/insights/metrics/conversations/integrations/datalake/services.py
@@ -5,7 +5,7 @@ from datetime import datetime
 from uuid import UUID
 
 from django.conf import settings
-
+from sentry_sdk import capture_exception
 
 from insights.sources.cache import CacheClient
 from insights.sources.dl_events.clients import (
@@ -116,7 +116,7 @@ class DatalakeConversationsMetricsService(BaseConversationsMetricsService):
             return cached_results
 
         try:
-            csat_metrics = self.events_client.get_csat_metrics(
+            csat_metrics = self.events_client.get_events_count_by_group(
                 event_name=self.event_name,
                 project=project_uuid,
                 agent_uuid=agent_uuid,
@@ -125,3 +125,6 @@ class DatalakeConversationsMetricsService(BaseConversationsMetricsService):
             )
         except Exception as e:
             logger.error("Failed to get csat metrics: %s", e)
+            capture_exception(e)
+
+            raise e

--- a/insights/metrics/conversations/integrations/datalake/services.py
+++ b/insights/metrics/conversations/integrations/datalake/services.py
@@ -128,3 +128,25 @@ class DatalakeConversationsMetricsService(BaseConversationsMetricsService):
             capture_exception(e)
 
             raise e
+
+        # The frontend application will display fixed labels for the CSAT scores
+        # For example, "1" can be displayed as "1 - Very dissatisfied"
+        scores = {
+            "1": 0,
+            "2": 0,
+            "3": 0,
+            "4": 0,
+            "5": 0,
+        }
+
+        # Each metric is a dict grouped by the event's value
+        # (in this case, the event's value is the CSAT score)
+        for metric in csat_metrics:
+            if metric.get("group_value") not in scores:
+                # We ignore metrics that are not CSAT scores
+                # This is a safety measure to avoid unexpected values
+                continue
+
+            scores[metric.get("group_value")] += metric.get("count")
+
+        return scores

--- a/insights/metrics/conversations/integrations/datalake/tests/mock_services.py
+++ b/insights/metrics/conversations/integrations/datalake/tests/mock_services.py
@@ -26,13 +26,11 @@ class MockDatalakeConversationsMetricsService(BaseConversationsMetricsService):
         end_date: datetime,
     ) -> dict:
         return {
-            "results": [
-                {"label": "5", "value": 20.99, "full_value": 17},
-                {"label": "4", "value": 16.05, "full_value": 13},
-                {"label": "3", "value": 14.81, "full_value": 12},
-                {"label": "2", "value": 9.88, "full_value": 8},
-                {"label": "1", "value": 8.64, "full_value": 7},
-            ]
+            "1": 10,
+            "2": 20,
+            "3": 30,
+            "4": 40,
+            "5": 50,
         }
 
     def get_topics_distribution(

--- a/insights/metrics/conversations/services.py
+++ b/insights/metrics/conversations/services.py
@@ -48,10 +48,16 @@ class ConversationsMetricsService:
         )
 
     def _get_csat_metrics_from_datalake(
-        self, agent_uuid: UUID, start_date: datetime, end_date: datetime
+        self,
+        project_uuid: UUID,
+        agent_uuid: UUID,
+        start_date: datetime,
+        end_date: datetime,
     ) -> dict:
         # TODO
-        return {}
+        return self.datalake_service.get_csat_metrics(
+            project_uuid, agent_uuid, start_date, end_date
+        )
 
     def get_csat_metrics(
         self,
@@ -93,4 +99,6 @@ class ConversationsMetricsService:
                 "Agent UUID is required in the widget config"
             )
 
-        return self._get_csat_metrics_from_datalake(agent_uuid, start_date, end_date)
+        return self._get_csat_metrics_from_datalake(
+            project_uuid, agent_uuid, start_date, end_date
+        )

--- a/insights/metrics/conversations/services.py
+++ b/insights/metrics/conversations/services.py
@@ -473,9 +473,7 @@ class ConversationsMetricsService(ConversationsServiceCachingMixin):
             )
 
         # AI
-        agent_uuid = (
-            widget.config.get("filter", {}).get("datalake_config", {}).get("agent_uuid")
-        )
+        agent_uuid = widget.config.get("datalake_config", {}).get("agent_uuid")
 
         if not agent_uuid:
             raise ConversationsMetricsError(

--- a/insights/metrics/conversations/services.py
+++ b/insights/metrics/conversations/services.py
@@ -423,9 +423,24 @@ class ConversationsMetricsService(ConversationsServiceCachingMixin):
         end_date: datetime,
     ) -> dict:
         # TODO
-        return self.datalake_service.get_csat_metrics(
+        metrics = self.datalake_service.get_csat_metrics(
             project_uuid, agent_uuid, start_date, end_date
         )
+
+        total_count = sum(metrics.values())
+
+        results = {
+            "results": [
+                {
+                    "label": score,
+                    "value": round((score_count / total_count) * 100, 2),
+                    "full_value": score_count,
+                }
+                for score, score_count in metrics.items()
+            ]
+        }
+
+        return results
 
     def get_csat_metrics(
         self,


### PR DESCRIPTION
### What
This pull request introduces a method to fetch CSAT metrics from the datalake, transforming in the format compatible with the already used by the frontend application in the flowruns' (recurrence) case

### Why
This data will be used to display the CSAT metrics related to the AI agents.