### PR TITLE
Feature/Return Meta's exceptions in internal metrics endpoint

### DIFF
--- a/insights/metrics/meta/clients.py
+++ b/insights/metrics/meta/clients.py
@@ -6,6 +6,7 @@ from datetime import date, datetime
 
 from django.conf import settings
 from rest_framework.exceptions import ValidationError, NotFound
+from sentry_sdk import capture_exception
 
 from insights.metrics.meta.enums import AnalyticsGranularity, MetricsTypes
 from insights.metrics.meta.utils import (
@@ -74,9 +75,11 @@ class MetaGraphAPIClient:
                 err,
                 exc_info=True,
             )
+            event_id = capture_exception(err)
 
             raise ValidationError(
-                {"error": "An error has occurred"}, code="meta_api_error"
+                {"error": f"An error has occurred. Event ID: {event_id}"},
+                code="meta_api_error",
             ) from err
 
         return response.json()
@@ -102,9 +105,11 @@ class MetaGraphAPIClient:
                 err,
                 exc_info=True,
             )
+            event_id = capture_exception(err)
 
             raise ValidationError(
-                {"error": "An error has occurred"}, code="meta_api_error"
+                {"error": f"An error has occurred. Event ID: {event_id}"},
+                code="meta_api_error",
             ) from err
 
         response = response.json()
@@ -124,6 +129,7 @@ class MetaGraphAPIClient:
         start_date: date,
         end_date: date,
         include_data_points: bool = True,
+        return_exceptions: bool = False,
     ):
         url = f"{self.base_host_url}/{waba_id}/template_analytics?"
 
@@ -182,9 +188,14 @@ class MetaGraphAPIClient:
                 err,
                 exc_info=True,
             )
+            event_id = capture_exception(err)
+
+            if return_exceptions:
+                raise err
 
             raise ValidationError(
-                {"error": "An error has occurred"}, code="meta_api_error"
+                {"error": f"An error has occurred. Event ID: {event_id}"},
+                code="meta_api_error",
             ) from err
 
         meta_response = response.json()
@@ -272,9 +283,11 @@ class MetaGraphAPIClient:
                 err,
                 exc_info=True,
             )
+            event_id = capture_exception(err)
 
             raise ValidationError(
-                {"error": "An error has occurred"}, code="meta_api_error"
+                {"error": f"An error has occurred. Event ID: {event_id}"},
+                code="meta_api_error",
             ) from err
 
         meta_response = response.json()

--- a/insights/metrics/meta/services.py
+++ b/insights/metrics/meta/services.py
@@ -43,6 +43,7 @@ class MetaMessageTemplatesService:
         timezone_name: str | None = None,
         skip_kwargs_validation: bool = False,
         include_data_points: bool = True,
+        return_exceptions: bool = False,
     ):
         """
         Get analytics data for messages sent using a message template.
@@ -56,7 +57,9 @@ class MetaMessageTemplatesService:
             valid_filters = filters
 
         return self.client.get_messages_analytics(
-            **valid_filters, include_data_points=include_data_points
+            **valid_filters,
+            include_data_points=include_data_points,
+            return_exceptions=return_exceptions,
         )
 
     def get_buttons_analytics(self, filters: dict, timezone_name: str | None = None):

--- a/insights/metrics/meta/views.py
+++ b/insights/metrics/meta/views.py
@@ -404,6 +404,8 @@ class InternalWhatsAppMessageTemplatesView(GenericViewSet):
             filters=filters,
             skip_kwargs_validation=True,
             include_data_points=False,
+            # Returning the original exceptions because this is an internal endpoint
+            return_exceptions=True,
         )
 
         return Response(data, status=status.HTTP_200_OK)


### PR DESCRIPTION
### What
- Introduce return_exceptions parameter to allow original exceptions to be returned in the case of internal endpoint.
- Enhance error handling in MetaGraphAPIClient and related services by capturing exceptions with Sentry. Include event IDs in validation error responses.

### Why
This changes were done to improve error tracking.