### PR TITLE
fix/remove abandoned conversations

### DIFF
--- a/insights/metrics/conversations/dataclass.py
+++ b/insights/metrics/conversations/dataclass.py
@@ -66,7 +66,6 @@ class ConversationsTotalsMetrics:
     total_conversations: ConversationsTotalsMetric
     resolved: ConversationsTotalsMetric
     unresolved: ConversationsTotalsMetric
-    abandoned: ConversationsTotalsMetric
     transferred_to_human: ConversationsTotalsMetric
 
 

--- a/insights/metrics/conversations/integrations/datalake/enums.py
+++ b/insights/metrics/conversations/integrations/datalake/enums.py
@@ -8,4 +8,3 @@ class DatalakeConversationsClassification(models.TextChoices):
 
     RESOLVED = "resolved"
     UNRESOLVED = "unresolved"
-    ABANDONED = "abandoned"

--- a/insights/metrics/conversations/integrations/datalake/services.py
+++ b/insights/metrics/conversations/integrations/datalake/services.py
@@ -526,10 +526,6 @@ class DatalakeConversationsMetricsService(BaseConversationsMetricsService):
                             value=cached_results["unresolved"]["value"],
                             percentage=cached_results["unresolved"]["percentage"],
                         ),
-                        abandoned=ConversationsTotalsMetric(
-                            value=cached_results["abandoned"]["value"],
-                            percentage=cached_results["abandoned"]["percentage"],
-                        ),
                         transferred_to_human=ConversationsTotalsMetric(
                             value=cached_results["transferred_to_human"]["value"],
                             percentage=cached_results["transferred_to_human"][
@@ -557,14 +553,6 @@ class DatalakeConversationsMetricsService(BaseConversationsMetricsService):
                 key="conversation_classification",
                 value="unresolved",
             )[0].get("count", 0)
-            abandoned_events_count = self.events_client.get_events_count(
-                project=project_uuid,
-                date_start=start_date,
-                date_end=end_date,
-                event_name=self.event_name,
-                key="conversation_classification",
-                value="abandoned",
-            )[0].get("count", 0)
             transferred_to_human_events_count = self.events_client.get_events_count(
                 project=project_uuid,
                 date_start=start_date,
@@ -580,9 +568,7 @@ class DatalakeConversationsMetricsService(BaseConversationsMetricsService):
 
             raise e
 
-        total_conversations = (
-            resolved_events_count + unresolved_events_count + abandoned_events_count
-        )
+        total_conversations = resolved_events_count + unresolved_events_count
 
         percentage_resolved = round(
             (
@@ -596,15 +582,6 @@ class DatalakeConversationsMetricsService(BaseConversationsMetricsService):
         percentage_unresolved = round(
             (
                 (unresolved_events_count / total_conversations * 100)
-                if total_conversations > 0
-                else 0
-            ),
-            2,
-        )
-
-        percentage_abandoned = round(
-            (
-                (abandoned_events_count / total_conversations * 100)
                 if total_conversations > 0
                 else 0
             ),
@@ -629,9 +606,6 @@ class DatalakeConversationsMetricsService(BaseConversationsMetricsService):
             ),
             unresolved=ConversationsTotalsMetric(
                 value=unresolved_events_count, percentage=percentage_unresolved
-            ),
-            abandoned=ConversationsTotalsMetric(
-                value=abandoned_events_count, percentage=percentage_abandoned
             ),
             transferred_to_human=ConversationsTotalsMetric(
                 value=transferred_to_human_events_count,

--- a/insights/metrics/conversations/integrations/datalake/tests/mock_services.py
+++ b/insights/metrics/conversations/integrations/datalake/tests/mock_services.py
@@ -83,6 +83,5 @@ class MockDatalakeConversationsMetricsService(BaseConversationsMetricsService):
             total_conversations=ConversationsTotalsMetric(value=100, percentage=100),
             resolved=ConversationsTotalsMetric(value=60, percentage=60),
             unresolved=ConversationsTotalsMetric(value=40, percentage=40),
-            abandoned=ConversationsTotalsMetric(value=0, percentage=0),
             transferred_to_human=ConversationsTotalsMetric(value=0, percentage=0),
         )

--- a/insights/metrics/conversations/serializers.py
+++ b/insights/metrics/conversations/serializers.py
@@ -173,7 +173,6 @@ class ConversationTotalsMetricsSerializer(serializers.Serializer):
     total_conversations = ConversationsTotalsMetricSerializer()
     resolved = ConversationsTotalsMetricSerializer()
     unresolved = ConversationsTotalsMetricSerializer()
-    abandoned = ConversationsTotalsMetricSerializer()
     transferred_to_human = ConversationsTotalsMetricSerializer()
 
 

--- a/insights/metrics/conversations/tests/test_serializers.py
+++ b/insights/metrics/conversations/tests/test_serializers.py
@@ -357,7 +357,6 @@ class TestConversationTotalsMetricsSerializer(TestCase):
             total_conversations=ConversationsTotalsMetric(value=150, percentage=150),
             resolved=ConversationsTotalsMetric(value=100, percentage=100),
             unresolved=ConversationsTotalsMetric(value=50, percentage=50),
-            abandoned=ConversationsTotalsMetric(value=0, percentage=0),
             transferred_to_human=ConversationsTotalsMetric(value=0, percentage=0),
         )
         serializer = ConversationTotalsMetricsSerializer(totals)

--- a/insights/metrics/conversations/tests/test_views.py
+++ b/insights/metrics/conversations/tests/test_views.py
@@ -376,7 +376,6 @@ class TestConversationsMetricsViewSetAsAuthenticatedUser(
             total_conversations=ConversationsTotalsMetric(value=100, percentage=100),
             resolved=ConversationsTotalsMetric(value=60, percentage=60),
             unresolved=ConversationsTotalsMetric(value=40, percentage=40),
-            abandoned=ConversationsTotalsMetric(value=0, percentage=0),
             transferred_to_human=ConversationsTotalsMetric(value=0, percentage=0),
         )
 


### PR DESCRIPTION
### What
Removing the abandoned metric from the totals metrics for the conversations dashboard.

### Why
This metric does not exist anymore.