### PR TITLE
Feature/custom widget on conversations dashboard

### DIFF
--- a/insights/metrics/conversations/integrations/datalake/services.py
+++ b/insights/metrics/conversations/integrations/datalake/services.py
@@ -71,6 +71,18 @@ class BaseConversationsMetricsService(ABC):
         Get conversations totals from Datalake.
         """
 
+    @abstractmethod
+    def get_generic_metrics_grouped_by_value(
+        self,
+        project_uuid: UUID,
+        agent_uuid: str,
+        start_date: datetime,
+        end_date: datetime,
+    ) -> dict:
+        """
+        Get generic metrics grouped by value from Datalake.
+        """
+
 
 class DatalakeConversationsMetricsService(BaseConversationsMetricsService):
     """
@@ -622,3 +634,16 @@ class DatalakeConversationsMetricsService(BaseConversationsMetricsService):
             )
 
         return results
+
+    @abstractmethod
+    def get_generic_metrics_grouped_by_value(
+        self,
+        project_uuid: UUID,
+        agent_uuid: str,
+        start_date: datetime,
+        end_date: datetime,
+    ) -> dict:
+        """
+        Get generic metrics grouped by value from Datalake.
+        """
+        return {}  # TODO

--- a/insights/metrics/conversations/integrations/datalake/services.py
+++ b/insights/metrics/conversations/integrations/datalake/services.py
@@ -72,7 +72,7 @@ class BaseConversationsMetricsService(ABC):
         """
 
     @abstractmethod
-    def get_generic_metrics_grouped_by_value(
+    def get_generic_metrics_by_key(
         self,
         project_uuid: UUID,
         agent_uuid: str,
@@ -636,14 +636,68 @@ class DatalakeConversationsMetricsService(BaseConversationsMetricsService):
         return results
 
     @abstractmethod
-    def get_generic_metrics_grouped_by_value(
+    def get_generic_metrics_by_key(
         self,
         project_uuid: UUID,
         agent_uuid: str,
         start_date: datetime,
         end_date: datetime,
+        key: str,
     ) -> dict:
         """
         Get generic metrics grouped by value from Datalake.
         """
-        return {}  # TODO
+        cache_key = self._get_cache_key(
+            data_type="get_generic_metrics_by_key",
+            project_uuid=project_uuid,
+            agent_uuid=agent_uuid,
+            start_date=start_date,
+            end_date=end_date,
+            key=key,
+        )
+
+        if self.cache_results:
+            if cached_results := self._get_cached_results(cache_key):
+                if not isinstance(cached_results, dict):
+                    cached_results = json.loads(cached_results)
+
+                return cached_results
+
+        try:
+            events = self.events_client.get_events_count_by_group(
+                key=key,
+                event_name=self.event_name,
+                project=project_uuid,
+                date_start=start_date,
+                date_end=end_date,
+                metadata_key="agent_uuid",
+                metadata_value=agent_uuid,
+            )
+        except Exception as e:
+            logger.error("Failed to get generic metrics by key: %s", e)
+            capture_exception(e)
+
+            raise e
+
+        values = {}
+
+        for count in events:
+            payload_value = count.get("payload_value")
+
+            if payload_value is None:
+                continue
+
+            if isinstance(payload_value, int):
+                payload_value = str(payload_value)
+
+            payload_value = payload_value.strip('"')
+
+            if payload_value in values:
+                values[payload_value] += count.get("count", 0)
+            else:
+                values[payload_value] = count.get("count", 0)
+
+        if self.cache_results:
+            self._save_results_to_cache(cache_key, values)
+
+        return values

--- a/insights/metrics/conversations/integrations/datalake/services.py
+++ b/insights/metrics/conversations/integrations/datalake/services.py
@@ -635,7 +635,6 @@ class DatalakeConversationsMetricsService(BaseConversationsMetricsService):
 
         return results
 
-    @abstractmethod
     def get_generic_metrics_by_key(
         self,
         project_uuid: UUID,

--- a/insights/metrics/conversations/integrations/datalake/tests/mock_services.py
+++ b/insights/metrics/conversations/integrations/datalake/tests/mock_services.py
@@ -85,3 +85,13 @@ class MockDatalakeConversationsMetricsService(BaseConversationsMetricsService):
             unresolved=ConversationsTotalsMetric(value=40, percentage=40),
             transferred_to_human=ConversationsTotalsMetric(value=0, percentage=0),
         )
+
+    def get_generic_metrics_by_key(
+        self,
+        project_uuid: UUID,
+        agent_uuid: str,
+        start_date: datetime,
+        end_date: datetime,
+        key: str,
+    ) -> dict:
+        return {str(i): 10 for i in range(0, 11)}

--- a/insights/metrics/conversations/serializers.py
+++ b/insights/metrics/conversations/serializers.py
@@ -221,3 +221,29 @@ class NpsMetricsSerializer(serializers.Serializer):
     passives = serializers.IntegerField()
     detractors = serializers.IntegerField()
     score = serializers.IntegerField()
+
+
+class CustomMetricsQueryParamsSerializer(ConversationBaseQueryParamsSerializer):
+    """
+    Serializer for custom metrics query params
+    """
+
+    widget_uuid = serializers.UUIDField(required=True)
+
+    def validate(self, attrs: dict) -> dict:
+        """
+        Validate query params
+        """
+        attrs = super().validate(attrs)
+
+        widget = Widget.objects.filter(
+            uuid=attrs["widget_uuid"], dashboard__project=attrs["project"]
+        ).first()
+
+        if not widget:
+            raise serializers.ValidationError(
+                {"widget_uuid": "Widget not found"}, code="widget_not_found"
+            )
+
+        attrs["widget"] = widget
+        return attrs

--- a/insights/metrics/conversations/services.py
+++ b/insights/metrics/conversations/services.py
@@ -625,3 +625,29 @@ class ConversationsMetricsService(ConversationsServiceCachingMixin):
         return self._get_nps_metrics_from_datalake(
             project_uuid, agent_uuid, start_date, end_date
         )
+
+    def get_generic_metrics_by_key(
+        self,
+        project_uuid: UUID,
+        widget: Widget,
+        start_date: datetime,
+        end_date: datetime,
+    ):
+        """
+        Get generic metrics by key
+        """
+        agent_uuid = widget.config.get("datalake_config", {}).get("agent_uuid")
+
+        if not agent_uuid:
+            raise ConversationsMetricsError(
+                "Agent UUID is required in the widget config"
+            )
+
+        key = widget.config.get("datalake_config", {}).get("key")
+
+        if not key:
+            raise ConversationsMetricsError("Key is required in the widget config")
+
+        return self.datalake_service.get_generic_metrics_by_key(
+            project_uuid, agent_uuid, start_date, end_date, key
+        )

--- a/insights/metrics/conversations/services.py
+++ b/insights/metrics/conversations/services.py
@@ -648,6 +648,25 @@ class ConversationsMetricsService(ConversationsServiceCachingMixin):
         if not key:
             raise ConversationsMetricsError("Key is required in the widget config")
 
-        return self.datalake_service.get_generic_metrics_by_key(
+        metrics = self.datalake_service.get_generic_metrics_by_key(
             project_uuid, agent_uuid, start_date, end_date, key
         )
+
+        total_count = sum(metrics.values())
+
+        results = {
+            "results": [
+                {
+                    "label": score,
+                    "value": (
+                        round((score_count / total_count) * 100, 2)
+                        if total_count
+                        else 0
+                    ),
+                    "full_value": score_count,
+                }
+                for score, score_count in metrics.items()
+            ]
+        }
+
+        return results

--- a/insights/metrics/conversations/tests/test_views.py
+++ b/insights/metrics/conversations/tests/test_views.py
@@ -101,6 +101,11 @@ class BaseTestConversationsMetricsViewSet(APITestCase):
 
         return self.client.get(url, query_params, format="json")
 
+    def get_custom_metrics(self, query_params: dict) -> Response:
+        url = reverse("conversations-custom")
+
+        return self.client.get(url, query_params, format="json")
+
 
 class TestConversationsMetricsViewSetAsAnonymousUser(
     BaseTestConversationsMetricsViewSet
@@ -152,6 +157,11 @@ class TestConversationsMetricsViewSetAsAnonymousUser(
 
     def test_cannot_get_nps_metrics_when_unauthenticated(self):
         response = self.get_nps_metrics({})
+
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    def test_cannot_get_custom_metrics_when_unauthenticated(self):
+        response = self.get_custom_metrics({})
 
         self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
 
@@ -525,6 +535,60 @@ class TestConversationsMetricsViewSetAsAuthenticatedUser(
                 "start_date": "2024-01-01",
                 "end_date": "2024-01-31",
                 "type": NpsMetricsType.AI,
+            }
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_cannot_get_custom_metrics_without_permission(self):
+        response = self.get_custom_metrics(
+            {
+                "project_uuid": self.project.uuid,
+                "widget_uuid": uuid.uuid4(),
+                "start_date": "2024-01-01",
+                "end_date": "2024-01-31",
+            }
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_cannot_get_custom_metrics_without_project_uuid(self):
+        response = self.get_custom_metrics({})
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.data["project_uuid"][0].code, "required")
+
+    @with_project_auth
+    def test_cannot_get_custom_metrics_without_required_params(self):
+        response = self.get_custom_metrics({"project_uuid": self.project.uuid})
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.data["widget_uuid"][0].code, "required")
+        self.assertEqual(response.data["start_date"][0].code, "required")
+        self.assertEqual(response.data["end_date"][0].code, "required")
+
+    @with_project_auth
+    def test_get_custom_metrics(self):
+        widget = Widget.objects.create(
+            name="Test Widget",
+            dashboard=self.dashboard,
+            source="conversations.custom",
+            type="custom",
+            position=[1, 2],
+            config={
+                "datalake_config": {
+                    "agent_uuid": str(uuid.uuid4()),
+                    "key": "test_key",
+                },
+            },
+        )
+
+        response = self.get_custom_metrics(
+            {
+                "project_uuid": self.project.uuid,
+                "widget_uuid": widget.uuid,
+                "start_date": "2024-01-01",
+                "end_date": "2024-01-31",
             }
         )
 

--- a/insights/metrics/conversations/views.py
+++ b/insights/metrics/conversations/views.py
@@ -13,6 +13,7 @@ from insights.metrics.conversations.serializers import (
     ConversationTotalsMetricsSerializer,
     CreateTopicSerializer,
     CsatMetricsQueryParamsSerializer,
+    CustomMetricsQueryParamsSerializer,
     DeleteTopicSerializer,
     GetTopicsQueryParamsSerializer,
     NpsMetricsQueryParamsSerializer,
@@ -358,3 +359,31 @@ class ConversationsMetricsViewSet(GenericViewSet):
             ConversationTotalsMetricsSerializer(totals).data,
             status=status.HTTP_200_OK,
         )
+
+    @action(
+        detail=False,
+        methods=["get"],
+        url_path="custom",
+        url_name="custom",
+    )
+    def custom_metrics(self, request: "Request", *args, **kwargs) -> Response:
+        """
+        Get custom metrics
+        """
+        serializer = CustomMetricsQueryParamsSerializer(data=request.query_params)
+        serializer.is_valid(raise_exception=True)
+
+        try:
+            metrics = self.service.get_generic_metrics_by_key(
+                project_uuid=serializer.validated_data["project_uuid"],
+                widget=serializer.validated_data["widget"],
+                start_date=serializer.validated_data["start_date"],
+                end_date=serializer.validated_data["end_date"],
+            )
+        except ConversationsMetricsError as e:
+            return Response(
+                {"error": str(e)},
+                status=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            )
+
+        return Response(metrics, status=status.HTTP_200_OK)


### PR DESCRIPTION
### What
This pull request introduces an endpoint to get custom metrics from the datalake, based on generic events saved there.

### Why
The frontend application will allow, in the conversations dashboard, the creation of custom widgets, so that users can easily get metrics from its own agents.