### PR TITLE
Fix/is-project-active-on-indexer-verification

### DIFF
--- a/insights/projects/services/indexer_activation.py
+++ b/insights/projects/services/indexer_activation.py
@@ -68,7 +68,7 @@ class ProjectIndexerActivationService:
         """
         url = settings.WEBHOOK_URL
         payload = {
-            "project_uuid": activation.project.uuid,
+            "project_uuid": str(activation.project.uuid),
         }
         headers = {"Authorization": f"Bearer {settings.STATIC_TOKEN}"}
 

--- a/insights/projects/services/indexer_activation.py
+++ b/insights/projects/services/indexer_activation.py
@@ -30,7 +30,7 @@ class ProjectIndexerActivationService:
         """
         This method is used to check if the project is active on the indexer.
         """
-        return project.is_allowed or project.uuid in settings.PROJECT_ALLOW_LIST
+        return project.is_allowed or str(project.uuid) in settings.PROJECT_ALLOW_LIST
 
     def add_project_to_queue(self, project: Project):
         """

--- a/insights/projects/tasks.py
+++ b/insights/projects/tasks.py
@@ -52,6 +52,15 @@ def activate_indexer():
             "[ activate_indexer task ] Activating project %s",
             activation.project.uuid,
         )
-        service.activate_project_on_indexer(activation)
+        try:
+            service.activate_project_on_indexer(activation)
+        except Exception as e:
+            logger.error(
+                "[ activate_indexer task ] Error activating project %s: %s",
+                activation.project.uuid,
+                e,
+            )
+            activation.status = ProjectIndexerActivationStatus.FAILED
+            activation.save(update_fields=["status"])
 
     logger.info("[ activate_indexer task ] Finished task")

--- a/insights/projects/tests/test_services/test_indexer_activation_service.py
+++ b/insights/projects/tests/test_services/test_indexer_activation_service.py
@@ -81,7 +81,7 @@ class TestIndexerActivationService(TestCase):
 
         mock_post.assert_called_once_with(
             settings.WEBHOOK_URL,
-            json={"project_uuid": self.project.uuid},
+            json={"project_uuid": str(self.project.uuid)},
             headers={"Authorization": f"Bearer {settings.STATIC_TOKEN}"},
             timeout=60,
         )

--- a/insights/projects/tests/test_services/test_indexer_activation_service.py
+++ b/insights/projects/tests/test_services/test_indexer_activation_service.py
@@ -32,7 +32,7 @@ class TestIndexerActivationService(TestCase):
         self.project.save(update_fields=["is_allowed"])
         self.assertTrue(self.service.is_project_active_on_indexer(self.project))
 
-    @override_settings(PROJECT_ALLOW_LIST=[PROJECT_UUID])
+    @override_settings(PROJECT_ALLOW_LIST=[str(PROJECT_UUID)])
     def test_is_project_active_on_indexer_when_project_is_not_allowed_and_in_allow_list(
         self,
     ):


### PR DESCRIPTION
Fix project UUID check in indexer activation service to ensure UUID is a string before comparison.