### PR TITLE
Fix/conversion widget whatsapp templates metrics filter

### DIFF
--- a/insights/metrics/meta/clients.py
+++ b/insights/metrics/meta/clients.py
@@ -130,6 +130,7 @@ class MetaGraphAPIClient:
         end_date: date,
         include_data_points: bool = True,
         return_exceptions: bool = False,
+        tz_name: str | None = None,
     ):
         url = f"{self.base_host_url}/{waba_id}/template_analytics?"
 
@@ -146,12 +147,14 @@ class MetaGraphAPIClient:
         start = (
             start_date.timestamp()
             if isinstance(start_date, datetime)
-            else convert_date_to_unix_timestamp(start_date)
+            else convert_date_to_unix_timestamp(start_date, tz_name=tz_name)
         )
         end = (
             end_date.timestamp()
             if isinstance(end_date, datetime)
-            else convert_date_to_unix_timestamp(end_date, use_max_time=True)
+            else convert_date_to_unix_timestamp(
+                end_date, use_max_time=True, tz_name=tz_name
+            )
         )
 
         now = int(datetime.now().timestamp())
@@ -220,14 +223,17 @@ class MetaGraphAPIClient:
         template_id: str,
         start_date: date,
         end_date: date,
+        tz_name: str | None = None,
     ):
         metrics_types = [
             MetricsTypes.SENT.value,
             MetricsTypes.CLICKED.value,
         ]
 
-        start = convert_date_to_unix_timestamp(start_date)
-        end = convert_date_to_unix_timestamp(end_date, use_max_time=True)
+        start = convert_date_to_unix_timestamp(start_date, tz_name=tz_name)
+        end = convert_date_to_unix_timestamp(
+            end_date, use_max_time=True, tz_name=tz_name
+        )
 
         now = int(datetime.now().timestamp())
 

--- a/insights/metrics/meta/clients.py
+++ b/insights/metrics/meta/clients.py
@@ -145,12 +145,12 @@ class MetaGraphAPIClient:
             template_id = ",".join(template_id)
 
         start = (
-            start_date.timestamp()
+            int(start_date.timestamp())
             if isinstance(start_date, datetime)
             else convert_date_to_unix_timestamp(start_date, tz_name=tz_name)
         )
         end = (
-            end_date.timestamp()
+            int(end_date.timestamp())
             if isinstance(end_date, datetime)
             else convert_date_to_unix_timestamp(
                 end_date, use_max_time=True, tz_name=tz_name
@@ -230,9 +230,17 @@ class MetaGraphAPIClient:
             MetricsTypes.CLICKED.value,
         ]
 
-        start = convert_date_to_unix_timestamp(start_date, tz_name=tz_name)
-        end = convert_date_to_unix_timestamp(
-            end_date, use_max_time=True, tz_name=tz_name
+        start = (
+            int(start_date.timestamp())
+            if isinstance(start_date, datetime)
+            else convert_date_to_unix_timestamp(start_date, tz_name=tz_name)
+        )
+        end = (
+            int(end_date.timestamp())
+            if isinstance(end_date, datetime)
+            else convert_date_to_unix_timestamp(
+                end_date, use_max_time=True, tz_name=tz_name
+            )
         )
 
         now = int(datetime.now().timestamp())

--- a/insights/metrics/meta/services.py
+++ b/insights/metrics/meta/services.py
@@ -60,6 +60,7 @@ class MetaMessageTemplatesService:
             **valid_filters,
             include_data_points=include_data_points,
             return_exceptions=return_exceptions,
+            tz_name=timezone_name,
         )
 
     def get_buttons_analytics(self, filters: dict, timezone_name: str | None = None):
@@ -69,4 +70,4 @@ class MetaMessageTemplatesService:
 
         valid_filters = validate_analytics_kwargs(filters, timezone_name=timezone_name)
 
-        return self.client.get_buttons_analytics(**valid_filters)
+        return self.client.get_buttons_analytics(**valid_filters, tz_name=timezone_name)

--- a/insights/sources/vtex_conversions/serializers.py
+++ b/insights/sources/vtex_conversions/serializers.py
@@ -20,8 +20,8 @@ class OrdersConversionsFiltersSerializer(serializers.Serializer):
     ended_at__gte = serializers.DateTimeField(required=True, write_only=True)
     ended_at__lte = serializers.DateTimeField(required=True, write_only=True)
 
-    start_date = serializers.DateField(read_only=True)
-    end_date = serializers.DateField(read_only=True)
+    start_date = serializers.DateTimeField(read_only=True)
+    end_date = serializers.DateTimeField(read_only=True)
 
     def validate(self, attrs):
         start_date = attrs.get("ended_at__gte")

--- a/insights/sources/vtex_conversions/serializers.py
+++ b/insights/sources/vtex_conversions/serializers.py
@@ -24,11 +24,8 @@ class OrdersConversionsFiltersSerializer(serializers.Serializer):
     end_date = serializers.DateField(read_only=True)
 
     def validate(self, attrs):
-        ended_at__gte = attrs.get("ended_at__gte")
-        ended_at__lte = attrs.get("ended_at__lte")
-
-        start_date = ended_at__gte.date()
-        end_date = ended_at__lte.date()
+        start_date = attrs.get("ended_at__gte")
+        end_date = attrs.get("ended_at__lte")
 
         if start_date > end_date:
             raise serializers.ValidationError(
@@ -36,7 +33,9 @@ class OrdersConversionsFiltersSerializer(serializers.Serializer):
                 code="end_date_before_start_date",
             )
 
-        validate_analytics_selected_period(start_date, field_name="ended_at__gte")
+        validate_analytics_selected_period(
+            start_date.date(), field_name="ended_at__gte"
+        )
 
         attrs["start_date"] = start_date
         attrs["end_date"] = end_date

--- a/insights/sources/vtex_conversions/services.py
+++ b/insights/sources/vtex_conversions/services.py
@@ -1,3 +1,4 @@
+import pytz
 from datetime import date
 from logging import getLogger
 
@@ -119,11 +120,30 @@ class VTEXOrdersConversionsService:
         serializer = OrdersConversionsFiltersSerializer(data=filters)
         serializer.is_valid(raise_exception=True)
 
+        tz_name = self.project.timezone
+
+        start_date = serializer.validated_data["start_date"]
+        end_date = serializer.validated_data["end_date"]
+
+        if tz_name:
+            project_tz = pytz.timezone(tz_name)
+
+            # Convert start_date to project timezone
+            if start_date and start_date.tzinfo is None:
+                start_date = project_tz.localize(start_date)
+            elif start_date and start_date.tzinfo:
+                start_date = start_date.astimezone(project_tz)
+
+            if end_date and end_date.tzinfo is None:
+                end_date = project_tz.localize(end_date)
+            elif end_date and end_date.tzinfo:
+                end_date = end_date.astimezone(project_tz)
+
         metrics_data = self.get_message_metrics(
             serializer.validated_data["waba_id"],
             serializer.validated_data["template_id"],
-            serializer.validated_data["start_date"],
-            serializer.validated_data["end_date"],
+            start_date,
+            end_date,
         )
 
         graph_data_fields = {}
@@ -135,8 +155,8 @@ class VTEXOrdersConversionsService:
             )
 
         orders_data = self.get_orders_metrics(
-            serializer.validated_data["start_date"],
-            serializer.validated_data["end_date"],
+            start_date,
+            end_date,
             serializer.validated_data["utm_source"],
         )
 

--- a/insights/sources/vtex_conversions/services.py
+++ b/insights/sources/vtex_conversions/services.py
@@ -92,7 +92,7 @@ class VTEXOrdersConversionsService:
 
         metrics_data = (
             self.meta_api_client.get_messages_analytics(
-                waba_id, template_id, start_date, end_date
+                waba_id, template_id, start_date, end_date, tz_name=tz_name
             )
             .get("data", {})
             .get("status_count")

--- a/insights/sources/vtex_conversions/services.py
+++ b/insights/sources/vtex_conversions/services.py
@@ -20,7 +20,6 @@ from insights.sources.vtex_conversions.serializers import (
     OrdersConversionsFiltersSerializer,
     OrdersConversionsMetricsSerializer,
 )
-from insights.utils import convert_dt_to_localized_dt
 
 logger = getLogger(__name__)
 
@@ -86,9 +85,6 @@ class VTEXOrdersConversionsService:
 
         project = Project.objects.filter(uuid=self.project.uuid).first()
         tz_name = project.timezone if project else get_current_timezone_name()
-
-        start_date = convert_dt_to_localized_dt(start_date, tz_name).date()
-        end_date = convert_dt_to_localized_dt(end_date, tz_name).date()
 
         metrics_data = (
             self.meta_api_client.get_messages_analytics(

--- a/insights/utils.py
+++ b/insights/utils.py
@@ -3,6 +3,8 @@ from datetime import date, datetime
 
 import pytz
 
+from django.utils.timezone import get_current_timezone_name
+
 from insights.authentication.authentication import FlowsInternalAuthentication
 
 logger = logging.getLogger(__name__)
@@ -28,10 +30,15 @@ def format_to_iso_utc(date_str, end_of_day=False):
         return None
 
 
-def convert_date_to_unix_timestamp(dt: date, use_max_time=False) -> int:
+def convert_date_to_unix_timestamp(
+    dt: date, use_max_time=False, tz_name: str | None = None
+) -> int:
     t = datetime.max.time() if use_max_time else datetime.min.time()
 
-    return int(datetime.combine(dt, t).timestamp())
+    if not tz_name:
+        tz_name = get_current_timezone_name()
+
+    return int(datetime.combine(dt, t, tzinfo=pytz.timezone(tz_name)).timestamp())
 
 
 def convert_date_str_to_datetime_date(date_str: str) -> date:


### PR DESCRIPTION
### What
Fixes the start and end datetime filters for the conversions widget (WhatsApp's template messages metrics part) by correctly applying the project timezone.

### Why
The timezone conversion was not being done the right way for this widget, causing the end timestamp to be incorrect.