### PR TITLE
Fix/conversations dashboard datetime filters

### DIFF
--- a/insights/metrics/conversations/serializers.py
+++ b/insights/metrics/conversations/serializers.py
@@ -16,8 +16,8 @@ class ConversationBaseQueryParamsSerializer(serializers.Serializer):
     Serializer for conversation base query params
     """
 
-    start_date = serializers.DateField()
-    end_date = serializers.DateField()
+    start_date = serializers.DateTimeField()
+    end_date = serializers.DateTimeField()
     project_uuid = serializers.UUIDField()
 
     def validate(self, attrs: dict) -> dict:
@@ -42,11 +42,11 @@ class ConversationBaseQueryParamsSerializer(serializers.Serializer):
         timezone = pytz.timezone(project.timezone) if project.timezone else pytz.UTC
 
         # Convert start_date to datetime at midnight (00:00:00) in project timezone
-        start_datetime = datetime.combine(attrs["start_date"], time.min)
+        start_datetime = datetime.combine(attrs["start_date"].date(), time.min)
         attrs["start_date"] = timezone.localize(start_datetime)
 
         # Convert end_date to datetime at 23:59:59 in project timezone
-        end_datetime = datetime.combine(attrs["end_date"], time(23, 59, 59))
+        end_datetime = datetime.combine(attrs["end_date"].date(), time(23, 59, 59))
         attrs["end_date"] = timezone.localize(end_datetime)
 
         return attrs

--- a/insights/metrics/conversations/views.py
+++ b/insights/metrics/conversations/views.py
@@ -345,8 +345,8 @@ class ConversationsMetricsViewSet(GenericViewSet):
         try:
             totals = self.service.get_totals(
                 project=query_params_serializer.validated_data["project"],
-                start_date=request.query_params.get("start_date"),
-                end_date=request.query_params.get("end_date"),
+                start_date=query_params_serializer.validated_data["start_date"],
+                end_date=query_params_serializer.validated_data["end_date"],
             )
         except Exception:
             return Response(

--- a/insights/metrics/conversations/views.py
+++ b/insights/metrics/conversations/views.py
@@ -56,8 +56,8 @@ class ConversationsMetricsViewSet(GenericViewSet):
             csat_metrics = self.service.get_csat_metrics(
                 project_uuid=query_params.validated_data["project_uuid"],
                 widget=query_params.validated_data["widget"],
-                start_date=query_params.validated_data["start_date"],
-                end_date=query_params.validated_data["end_date"],
+                start_date=query_params.validated_data["start_date"].isoformat(),
+                end_date=query_params.validated_data["end_date"].isoformat(),
                 metric_type=query_params.validated_data["type"],
             )
         except ConversationsMetricsError as e:
@@ -85,8 +85,8 @@ class ConversationsMetricsViewSet(GenericViewSet):
             nps_metrics = self.service.get_nps_metrics(
                 project_uuid=query_params.validated_data["project_uuid"],
                 widget=query_params.validated_data["widget"],
-                start_date=query_params.validated_data["start_date"],
-                end_date=query_params.validated_data["end_date"],
+                start_date=query_params.validated_data["start_date"].isoformat(),
+                end_date=query_params.validated_data["end_date"].isoformat(),
                 metric_type=query_params.validated_data["type"],
             )
         except ConversationsMetricsError as e:
@@ -121,8 +121,8 @@ class ConversationsMetricsViewSet(GenericViewSet):
         try:
             metrics = self.service.get_topics_distribution(
                 serializer.validated_data["project"],
-                serializer.validated_data["start_date"],
-                serializer.validated_data["end_date"],
+                serializer.validated_data["start_date"].isoformat(),
+                serializer.validated_data["end_date"].isoformat(),
                 serializer.validated_data["type"],
             )
         except ConversationsMetricsError as e:
@@ -345,8 +345,10 @@ class ConversationsMetricsViewSet(GenericViewSet):
         try:
             totals = self.service.get_totals(
                 project=query_params_serializer.validated_data["project"],
-                start_date=query_params_serializer.validated_data["start_date"],
-                end_date=query_params_serializer.validated_data["end_date"],
+                start_date=query_params_serializer.validated_data[
+                    "start_date"
+                ].isoformat(),
+                end_date=query_params_serializer.validated_data["end_date"].isoformat(),
             )
         except Exception:
             return Response(


### PR DESCRIPTION
### What
Fixing the datetime filters format when retrieving metrics from the datalake.

### Why
To fix the problem of not being possible to filter a data from a single day.