### PR TITLE
Fix/whatsapp message templates unix timestamp timezone filter

### DIFF
--- a/insights/metrics/meta/clients.py
+++ b/insights/metrics/meta/clients.py
@@ -130,7 +130,6 @@ class MetaGraphAPIClient:
         end_date: date,
         include_data_points: bool = True,
         return_exceptions: bool = False,
-        tz_name: str | None = None,
     ):
         url = f"{self.base_host_url}/{waba_id}/template_analytics?"
 
@@ -147,14 +146,12 @@ class MetaGraphAPIClient:
         start = (
             int(start_date.timestamp())
             if isinstance(start_date, datetime)
-            else convert_date_to_unix_timestamp(start_date, tz_name=tz_name)
+            else convert_date_to_unix_timestamp(start_date)
         )
         end = (
             int(end_date.timestamp())
             if isinstance(end_date, datetime)
-            else convert_date_to_unix_timestamp(
-                end_date, use_max_time=True, tz_name=tz_name
-            )
+            else convert_date_to_unix_timestamp(end_date, use_max_time=True)
         )
 
         now = int(datetime.now().timestamp())
@@ -223,7 +220,6 @@ class MetaGraphAPIClient:
         template_id: str,
         start_date: date,
         end_date: date,
-        tz_name: str | None = None,
     ):
         metrics_types = [
             MetricsTypes.SENT.value,
@@ -233,14 +229,12 @@ class MetaGraphAPIClient:
         start = (
             int(start_date.timestamp())
             if isinstance(start_date, datetime)
-            else convert_date_to_unix_timestamp(start_date, tz_name=tz_name)
+            else convert_date_to_unix_timestamp(start_date)
         )
         end = (
             int(end_date.timestamp())
             if isinstance(end_date, datetime)
-            else convert_date_to_unix_timestamp(
-                end_date, use_max_time=True, tz_name=tz_name
-            )
+            else convert_date_to_unix_timestamp(end_date, use_max_time=True)
         )
 
         now = int(datetime.now().timestamp())

--- a/insights/metrics/meta/services.py
+++ b/insights/metrics/meta/services.py
@@ -60,7 +60,6 @@ class MetaMessageTemplatesService:
             **valid_filters,
             include_data_points=include_data_points,
             return_exceptions=return_exceptions,
-            tz_name=timezone_name,
         )
 
     def get_buttons_analytics(self, filters: dict, timezone_name: str | None = None):
@@ -70,4 +69,4 @@ class MetaMessageTemplatesService:
 
         valid_filters = validate_analytics_kwargs(filters, timezone_name=timezone_name)
 
-        return self.client.get_buttons_analytics(**valid_filters, tz_name=timezone_name)
+        return self.client.get_buttons_analytics(**valid_filters)

--- a/insights/sources/vtex_conversions/serializers.py
+++ b/insights/sources/vtex_conversions/serializers.py
@@ -20,8 +20,8 @@ class OrdersConversionsFiltersSerializer(serializers.Serializer):
     ended_at__gte = serializers.DateTimeField(required=True, write_only=True)
     ended_at__lte = serializers.DateTimeField(required=True, write_only=True)
 
-    start_date = serializers.DateTimeField(read_only=True)
-    end_date = serializers.DateTimeField(read_only=True)
+    start_date = serializers.DateField(read_only=True)
+    end_date = serializers.DateField(read_only=True)
 
     def validate(self, attrs):
         start_date = attrs.get("ended_at__gte")
@@ -37,8 +37,8 @@ class OrdersConversionsFiltersSerializer(serializers.Serializer):
             start_date.date(), field_name="ended_at__gte"
         )
 
-        attrs["start_date"] = start_date
-        attrs["end_date"] = end_date
+        attrs["start_date"] = start_date.date()
+        attrs["end_date"] = end_date.date()
 
         return attrs
 

--- a/insights/sources/vtex_conversions/serializers.py
+++ b/insights/sources/vtex_conversions/serializers.py
@@ -20,8 +20,8 @@ class OrdersConversionsFiltersSerializer(serializers.Serializer):
     ended_at__gte = serializers.DateTimeField(required=True, write_only=True)
     ended_at__lte = serializers.DateTimeField(required=True, write_only=True)
 
-    start_date = serializers.DateField(read_only=True)
-    end_date = serializers.DateField(read_only=True)
+    start_date = serializers.DateTimeField(read_only=True)
+    end_date = serializers.DateTimeField(read_only=True)
 
     def validate(self, attrs):
         start_date = attrs.get("ended_at__gte")
@@ -37,8 +37,8 @@ class OrdersConversionsFiltersSerializer(serializers.Serializer):
             start_date.date(), field_name="ended_at__gte"
         )
 
-        attrs["start_date"] = start_date.date()
-        attrs["end_date"] = end_date.date()
+        attrs["start_date"] = start_date
+        attrs["end_date"] = end_date
 
         return attrs
 

--- a/insights/sources/vtex_conversions/services.py
+++ b/insights/sources/vtex_conversions/services.py
@@ -1,4 +1,3 @@
-import pytz
 from datetime import date
 from logging import getLogger
 

--- a/insights/sources/vtex_conversions/services.py
+++ b/insights/sources/vtex_conversions/services.py
@@ -1,3 +1,4 @@
+import pytz
 from datetime import date
 from logging import getLogger
 
@@ -115,8 +116,24 @@ class VTEXOrdersConversionsService:
         serializer = OrdersConversionsFiltersSerializer(data=filters)
         serializer.is_valid(raise_exception=True)
 
+        tz_name = "UTC"
+
         start_date = serializer.validated_data["start_date"]
         end_date = serializer.validated_data["end_date"]
+
+        if tz_name:
+            project_tz = pytz.timezone(tz_name)
+
+            # Convert start_date to project timezone
+            if start_date and start_date.tzinfo is None:
+                local_start_date = project_tz.localize(start_date)
+            elif start_date and start_date.tzinfo:
+                local_start_date = start_date.astimezone(project_tz)
+
+            if end_date and end_date.tzinfo is None:
+                local_end_date = project_tz.localize(end_date)
+            elif end_date and end_date.tzinfo:
+                local_end_date = end_date.astimezone(project_tz)
 
         metrics_data = self.get_message_metrics(
             serializer.validated_data["waba_id"],
@@ -134,8 +151,8 @@ class VTEXOrdersConversionsService:
             )
 
         orders_data = self.get_orders_metrics(
-            start_date,
-            end_date,
+            local_start_date,
+            local_end_date,
             serializer.validated_data["utm_source"],
         )
 

--- a/insights/sources/vtex_conversions/services.py
+++ b/insights/sources/vtex_conversions/services.py
@@ -115,8 +115,8 @@ class VTEXOrdersConversionsService:
         tz_name = "UTC"
         tz = pytz.timezone(tz_name)
 
-        start_date = datetime.fromisoformat(filters["start_date"])
-        end_date = datetime.fromisoformat(filters["end_date"])
+        start_date = datetime.fromisoformat(filters["ended_at__gte"])
+        end_date = datetime.fromisoformat(filters["ended_at__lte"])
 
         if start_date and start_date.tzinfo is None:
             start_date = tz.localize(start_date)
@@ -128,8 +128,8 @@ class VTEXOrdersConversionsService:
         elif end_date and end_date.tzinfo:
             end_date = end_date.replace(tzinfo=tz)
 
-        filters["start_date"] = start_date
-        filters["end_date"] = end_date
+        filters["ended_at__gte"] = start_date
+        filters["ended_at__lte"] = end_date
 
         serializer = OrdersConversionsFiltersSerializer(data=filters)
         serializer.is_valid(raise_exception=True)

--- a/insights/sources/vtex_conversions/services.py
+++ b/insights/sources/vtex_conversions/services.py
@@ -3,7 +3,6 @@ from datetime import date
 from logging import getLogger
 
 from django.conf import settings
-from django.utils.timezone import get_current_timezone_name
 from django.utils.translation import gettext_lazy as _
 from rest_framework.exceptions import PermissionDenied
 
@@ -84,12 +83,9 @@ class VTEXOrdersConversionsService:
                 code="project_without_waba_permission",
             )
 
-        project = Project.objects.filter(uuid=self.project.uuid).first()
-        tz_name = project.timezone if project else get_current_timezone_name()
-
         metrics_data = (
             self.meta_api_client.get_messages_analytics(
-                waba_id, template_id, start_date, end_date, tz_name=tz_name
+                waba_id, template_id, start_date, end_date
             )
             .get("data", {})
             .get("status_count")

--- a/insights/sources/vtex_conversions/services.py
+++ b/insights/sources/vtex_conversions/services.py
@@ -1,4 +1,3 @@
-import pytz
 from datetime import date
 from logging import getLogger
 
@@ -116,24 +115,8 @@ class VTEXOrdersConversionsService:
         serializer = OrdersConversionsFiltersSerializer(data=filters)
         serializer.is_valid(raise_exception=True)
 
-        tz_name = "UTC"
-
         start_date = serializer.validated_data["start_date"]
         end_date = serializer.validated_data["end_date"]
-
-        if tz_name:
-            project_tz = pytz.timezone(tz_name)
-
-            # Convert start_date to project timezone
-            if start_date and start_date.tzinfo is None:
-                start_date = project_tz.localize(start_date)
-            elif start_date and start_date.tzinfo:
-                start_date = start_date.astimezone(project_tz)
-
-            if end_date and end_date.tzinfo is None:
-                end_date = project_tz.localize(end_date)
-            elif end_date and end_date.tzinfo:
-                end_date = end_date.astimezone(project_tz)
 
         metrics_data = self.get_message_metrics(
             serializer.validated_data["waba_id"],

--- a/insights/sources/vtex_conversions/services.py
+++ b/insights/sources/vtex_conversions/services.py
@@ -116,30 +116,14 @@ class VTEXOrdersConversionsService:
         serializer = OrdersConversionsFiltersSerializer(data=filters)
         serializer.is_valid(raise_exception=True)
 
-        tz_name = self.project.timezone
-
         start_date = serializer.validated_data["start_date"]
         end_date = serializer.validated_data["end_date"]
-
-        if tz_name:
-            project_tz = pytz.timezone(tz_name)
-
-            # Convert start_date to project timezone
-            if start_date and start_date.tzinfo is None:
-                start_date = project_tz.localize(start_date)
-            elif start_date and start_date.tzinfo:
-                start_date = start_date.astimezone(project_tz)
-
-            if end_date and end_date.tzinfo is None:
-                end_date = project_tz.localize(end_date)
-            elif end_date and end_date.tzinfo:
-                end_date = end_date.astimezone(project_tz)
 
         metrics_data = self.get_message_metrics(
             serializer.validated_data["waba_id"],
             serializer.validated_data["template_id"],
-            start_date,
-            end_date,
+            start_date.date(),
+            end_date.date(),
         )
 
         graph_data_fields = {}

--- a/insights/sources/vtex_conversions/services.py
+++ b/insights/sources/vtex_conversions/services.py
@@ -124,16 +124,16 @@ class VTEXOrdersConversionsService:
         if tz_name:
             project_tz = pytz.timezone(tz_name)
 
-            # Convert start_date to project timezone
+            # Set timezone to UTC without converting the time
             if start_date and start_date.tzinfo is None:
                 start_date = project_tz.localize(start_date)
             elif start_date and start_date.tzinfo:
-                start_date = start_date.astimezone(project_tz)
+                start_date = start_date.replace(tzinfo=project_tz)
 
             if end_date and end_date.tzinfo is None:
                 end_date = project_tz.localize(end_date)
             elif end_date and end_date.tzinfo:
-                end_date = end_date.astimezone(project_tz)
+                end_date = end_date.replace(tzinfo=project_tz)
 
         metrics_data = self.get_message_metrics(
             serializer.validated_data["waba_id"],

--- a/insights/sources/vtex_conversions/services.py
+++ b/insights/sources/vtex_conversions/services.py
@@ -1,3 +1,4 @@
+import pytz
 from datetime import date
 from logging import getLogger
 
@@ -115,14 +116,30 @@ class VTEXOrdersConversionsService:
         serializer = OrdersConversionsFiltersSerializer(data=filters)
         serializer.is_valid(raise_exception=True)
 
+        tz_name = "UTC"
+
         start_date = serializer.validated_data["start_date"]
         end_date = serializer.validated_data["end_date"]
+
+        if tz_name:
+            project_tz = pytz.timezone(tz_name)
+
+            # Convert start_date to project timezone
+            if start_date and start_date.tzinfo is None:
+                start_date = project_tz.localize(start_date)
+            elif start_date and start_date.tzinfo:
+                start_date = start_date.astimezone(project_tz)
+
+            if end_date and end_date.tzinfo is None:
+                end_date = project_tz.localize(end_date)
+            elif end_date and end_date.tzinfo:
+                end_date = end_date.astimezone(project_tz)
 
         metrics_data = self.get_message_metrics(
             serializer.validated_data["waba_id"],
             serializer.validated_data["template_id"],
-            start_date.date(),
-            end_date.date(),
+            start_date,
+            end_date,
         )
 
         graph_data_fields = {}

--- a/insights/sources/vtex_conversions/services.py
+++ b/insights/sources/vtex_conversions/services.py
@@ -126,20 +126,20 @@ class VTEXOrdersConversionsService:
 
             # Convert start_date to project timezone
             if start_date and start_date.tzinfo is None:
-                local_start_date = project_tz.localize(start_date)
+                start_date = project_tz.localize(start_date)
             elif start_date and start_date.tzinfo:
-                local_start_date = start_date.astimezone(project_tz)
+                start_date = start_date.astimezone(project_tz)
 
             if end_date and end_date.tzinfo is None:
-                local_end_date = project_tz.localize(end_date)
+                end_date = project_tz.localize(end_date)
             elif end_date and end_date.tzinfo:
-                local_end_date = end_date.astimezone(project_tz)
+                end_date = end_date.astimezone(project_tz)
 
         metrics_data = self.get_message_metrics(
             serializer.validated_data["waba_id"],
             serializer.validated_data["template_id"],
-            start_date,
-            end_date,
+            start_date.date(),
+            end_date.date(),
         )
 
         graph_data_fields = {}
@@ -151,8 +151,8 @@ class VTEXOrdersConversionsService:
             )
 
         orders_data = self.get_orders_metrics(
-            local_start_date,
-            local_end_date,
+            start_date,
+            end_date,
             serializer.validated_data["utm_source"],
         )
 

--- a/insights/utils.py
+++ b/insights/utils.py
@@ -3,8 +3,6 @@ from datetime import date, datetime
 
 import pytz
 
-from django.utils.timezone import get_current_timezone_name
-
 from insights.authentication.authentication import FlowsInternalAuthentication
 
 logger = logging.getLogger(__name__)
@@ -31,14 +29,12 @@ def format_to_iso_utc(date_str, end_of_day=False):
 
 
 def convert_date_to_unix_timestamp(
-    dt: date, use_max_time=False, tz_name: str | None = None
+    dt: date,
+    use_max_time=False,
 ) -> int:
     t = datetime.max.time() if use_max_time else datetime.min.time()
 
-    if not tz_name:
-        tz_name = get_current_timezone_name()
-
-    return int(datetime.combine(dt, t, tzinfo=pytz.timezone(tz_name)).timestamp())
+    return int(datetime.combine(dt, t).timestamp())
 
 
 def convert_date_str_to_datetime_date(date_str: str) -> date:


### PR DESCRIPTION
Fixing timestamp fields in Meta's metrics API, to only consider UTC time, instead of local timezone, as required by Meta