### PR TITLE
Fix/Meta metrics formatting error

### DIFF
--- a/insights/metrics/meta/utils.py
+++ b/insights/metrics/meta/utils.py
@@ -72,7 +72,7 @@ def format_button_metrics_data(buttons: list, data_points: list[dict]) -> dict:
         buttons_data[button.get("text")] = {"type": button.get("type"), "clicked": 0}
 
     for data in data_points:
-        sent += data.get("sent")
+        sent += data.get("sent", 0)
 
         if not (clicked_buttons := data.get("clicked", None)):
             continue


### PR DESCRIPTION
### What
Settings messages status default values for WhatsApp's message templates analytics data formatting.

### Why
If the message status counts are not returned by Meta's API for a specific day (behavior observed in Sentry events reports), this causes an error as Insights tries to sum an integer with a None value, causing a TypeError. Setting the default as 0 solves the problem.