### PR TITLE
Fix/topics percentage round decimal place

### DIFF
--- a/insights/metrics/conversations/services.py
+++ b/insights/metrics/conversations/services.py
@@ -369,7 +369,7 @@ class ConversationsMetricsService(ConversationsServiceCachingMixin):
                         name=subtopic_data.get("name"),
                         quantity=subtopic_data.get("count"),
                         percentage=(
-                            ((subtopic_data.get("count") / topic_count) * 100)
+                            round(((subtopic_data.get("count") / topic_count) * 100), 2)
                             if topic_count
                             else 0
                         ),
@@ -382,7 +382,7 @@ class ConversationsMetricsService(ConversationsServiceCachingMixin):
                     name=topic_data.get("name"),
                     quantity=topic_data.get("count"),
                     percentage=(
-                        ((topic_data.get("count") / total_count) * 100)
+                        round(((topic_data.get("count") / total_count) * 100), 2)
                         if total_count
                         else 0
                     ),


### PR DESCRIPTION
Round percentage calculations for topic and subtopic counts to two decimal places in ConversationsMetricsService