### PR TITLE
Add count initialization for subtopics in DatalakeConversationsMetric…

### DIFF
--- a/insights/metrics/conversations/integrations/datalake/services.py
+++ b/insights/metrics/conversations/integrations/datalake/services.py
@@ -486,7 +486,6 @@ class DatalakeConversationsMetricsService(BaseConversationsMetricsService):
                     "uuid": subtopic_uuid,
                 }
 
-            # TODO
             topics_data[topic_uuid]["subtopics"][subtopic_uuid][
                 "count"
             ] += subtopic_event.get("count", 0)

--- a/insights/metrics/conversations/integrations/datalake/services.py
+++ b/insights/metrics/conversations/integrations/datalake/services.py
@@ -392,6 +392,7 @@ class DatalakeConversationsMetricsService(BaseConversationsMetricsService):
                     topic_subtopics[subtopic_uuid] = {
                         "name": subtopic_data.get("name"),
                         "uuid": subtopic_uuid,
+                        "count": 0,
                     }
 
                 topic_subtopics["OTHER"] = {
@@ -485,6 +486,7 @@ class DatalakeConversationsMetricsService(BaseConversationsMetricsService):
                     "uuid": subtopic_uuid,
                 }
 
+            # TODO
             topics_data[topic_uuid]["subtopics"][subtopic_uuid][
                 "count"
             ] += subtopic_event.get("count", 0)


### PR DESCRIPTION
Add count initialization for subtopics in DatalakeConversationsMetricsService

This commit initializes the 'count' field for subtopics to zero, ensuring accurate tracking of subtopic events. A TODO comment is also added for future enhancements related to subtopic event handling.