### PR TITLE
feat: return is_deleted for tag volume metrics

### DIFF
--- a/insights/sources/rooms/query_builder.py
+++ b/insights/sources/rooms/query_builder.py
@@ -137,12 +137,14 @@ class RoomSQLQueryBuilder:
                 sec.name AS sector_name,
                 stg.uuid AS tag_uuid,
                 stg.name AS tag_name,
+                stg.is_deleted AS tag_is_deleted,
+                sec.is_deleted AS sector_is_deleted,
                 COUNT(DISTINCT r.uuid) AS value
             FROM public.rooms_room AS r
             {tag_joins}
             {self.join_clause}
             WHERE {self.where_clause}
-            GROUP BY sec.uuid, sec.name, stg.uuid, stg.name
+            GROUP BY sec.uuid, sec.name, stg.uuid, stg.name, stg.is_deleted, sec.is_deleted
             ORDER BY value DESC, tag_name ASC;
         """
         return query, self.params

--- a/insights/sources/rooms/usecases/query_execute.py
+++ b/insights/sources/rooms/usecases/query_execute.py
@@ -123,7 +123,8 @@ class QueryExecutor:
                 grouped[sector_uuid]["tags"].append(
                     {
                         "tag_name": tag_name,
-                        "is_deleted": tag_is_deleted,
+                        "is_deleted": tag_is_deleted
+                        or grouped[sector_uuid]["is_deleted"],
                         "value": row["value"],
                     }
                 )

--- a/insights/sources/rooms/usecases/query_execute.py
+++ b/insights/sources/rooms/usecases/query_execute.py
@@ -102,13 +102,28 @@ class QueryExecutor:
             for row in query_results:
                 sector_uuid = row["sector_uuid"]
                 if sector_uuid not in grouped:
+                    sector_name = row["sector_name"]
+                    sector_is_deleted = row["sector_is_deleted"]
+
+                    if sector_is_deleted and "_is_deleted_" in sector_name:
+                        sector_name = sector_name.split("_is_deleted_")[0]
+
                     grouped[sector_uuid] = {
-                        "sector_name": row["sector_name"],
+                        "sector_name": sector_name,
+                        "is_deleted": sector_is_deleted,
                         "tags": [],
                     }
+
+                tag_name = row["tag_name"]
+                tag_is_deleted = row["tag_is_deleted"]
+
+                if tag_is_deleted and "_is_deleted_" in tag_name:
+                    tag_name = tag_name.split("_is_deleted_")[0]
+
                 grouped[sector_uuid]["tags"].append(
                     {
-                        "tag_name": row["tag_name"],
+                        "tag_name": tag_name,
+                        "is_deleted": tag_is_deleted,
                         "value": row["value"],
                     }
                 )


### PR DESCRIPTION
### What

- Extended the `group_by_tag_count` SQL query in `RoomSQLQueryBuilder` to include `stg.is_deleted` (tag) and `sec.is_deleted` (sector) columns in both the `SELECT` and `GROUP BY` clauses.
- Updated `QueryExecutor` to expose the `is_deleted` flag for each tag and sector in the API response.
- Added name sanitization logic: when a tag or sector is soft-deleted, the system appends a `_is_deleted_<identifier>` suffix to its name in the database. The executor now strips this suffix so the response returns the original, human-readable name alongside the deletion status.

### Why

Soft-deleted tags and sectors were previously either excluded or returned with mangled names (containing the `_is_deleted_` suffix). Consumers of the tag volume endpoint need to know whether a tag or sector has been deleted — for example, to render a visual indicator in dashboards — while still seeing the original clean name. This change surfaces the deletion state explicitly and ensures name consistency in the response.