### PR TITLE
feat: internal errors response middleware

### DIFF
--- a/insights/core/middleware.py
+++ b/insights/core/middleware.py
@@ -1,8 +1,12 @@
 import traceback
+import logging
 
 import sentry_sdk
 from django.conf import settings
 from django.http import JsonResponse
+
+
+logger = logging.getLogger(__name__)
 
 
 class InternalErrorHandlerMiddleware:
@@ -13,6 +17,7 @@ class InternalErrorHandlerMiddleware:
         return self.get_response(request)
 
     def process_exception(self, request, exception):
+        logger.exception(f"Internal error: {exception}")
         event_id = sentry_sdk.capture_exception(exception)
 
         response_data = {

--- a/insights/core/middleware.py
+++ b/insights/core/middleware.py
@@ -21,7 +21,12 @@ class InternalErrorHandlerMiddleware:
         if not event_id:
             event_id = sentry_sdk.capture_exception(exception)
 
-        logger.exception(f"Internal error: {exception}")
+        logger.exception(
+            "Internal error on %s %s: %s",
+            request.method,
+            request.get_full_path(),
+            exception,
+        )
 
         response_data = {
             "code": "INTERNAL_ERROR",

--- a/insights/core/middleware.py
+++ b/insights/core/middleware.py
@@ -1,8 +1,9 @@
 import logging
-
+import traceback
 import sentry_sdk
-from django.http import JsonResponse
 
+from django.http import JsonResponse
+from django.conf import settings
 
 logger = logging.getLogger(__name__)
 
@@ -27,5 +28,8 @@ class InternalErrorHandlerMiddleware:
             "message": "An internal error has occurred",
             "event_id": event_id or "unknown",
         }
+
+        if settings.DEBUG:
+            response_data["detail"] = traceback.format_exc()
 
         return JsonResponse(response_data, status=500)

--- a/insights/core/middleware.py
+++ b/insights/core/middleware.py
@@ -1,0 +1,27 @@
+import traceback
+
+import sentry_sdk
+from django.conf import settings
+from django.http import JsonResponse
+
+
+class InternalErrorHandlerMiddleware:
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        return self.get_response(request)
+
+    def process_exception(self, request, exception):
+        event_id = sentry_sdk.capture_exception(exception)
+
+        response_data = {
+            "code": "INTERNAL_ERROR",
+            "message": "An internal error has occurred",
+            "event_id": event_id,
+        }
+
+        if settings.DEBUG:
+            response_data["detail"] = traceback.format_exc()
+
+        return JsonResponse(response_data, status=500)

--- a/insights/core/middleware.py
+++ b/insights/core/middleware.py
@@ -26,7 +26,6 @@ class InternalErrorHandlerMiddleware:
             request.method,
             request.get_full_path(),
             exception,
-            exc_info=True,
         )
 
         response_data = {

--- a/insights/core/middleware.py
+++ b/insights/core/middleware.py
@@ -1,4 +1,3 @@
-import traceback
 import logging
 
 import sentry_sdk

--- a/insights/core/middleware.py
+++ b/insights/core/middleware.py
@@ -2,7 +2,6 @@ import traceback
 import logging
 
 import sentry_sdk
-from django.conf import settings
 from django.http import JsonResponse
 
 

--- a/insights/core/middleware.py
+++ b/insights/core/middleware.py
@@ -17,16 +17,17 @@ class InternalErrorHandlerMiddleware:
         return self.get_response(request)
 
     def process_exception(self, request, exception):
+        event_id = sentry_sdk.last_event_id()
+
+        if not event_id:
+            event_id = sentry_sdk.capture_exception(exception)
+
         logger.exception(f"Internal error: {exception}")
-        event_id = sentry_sdk.capture_exception(exception)
 
         response_data = {
             "code": "INTERNAL_ERROR",
             "message": "An internal error has occurred",
-            "event_id": event_id,
+            "event_id": event_id or "unknown",
         }
-
-        if settings.DEBUG:
-            response_data["detail"] = traceback.format_exc()
 
         return JsonResponse(response_data, status=500)

--- a/insights/core/middleware.py
+++ b/insights/core/middleware.py
@@ -26,6 +26,7 @@ class InternalErrorHandlerMiddleware:
             request.method,
             request.get_full_path(),
             exception,
+            exc_info=True,
         )
 
         response_data = {

--- a/insights/core/tests/test_middleware.py
+++ b/insights/core/tests/test_middleware.py
@@ -1,3 +1,4 @@
+import json
 from unittest.mock import patch
 
 from django.test import TestCase, RequestFactory, override_settings
@@ -19,7 +20,7 @@ class InternalErrorHandlerMiddlewareTestCase(TestCase):
         response = self.middleware.process_exception(request, exception)
 
         self.assertEqual(response.status_code, 500)
-        data = response.json()
+        data = json.loads(response.content)
         self.assertEqual(data["code"], "INTERNAL_ERROR")
         self.assertEqual(data["message"], "An internal error has occurred")
         self.assertEqual(data["event_id"], "abc123")
@@ -34,7 +35,7 @@ class InternalErrorHandlerMiddlewareTestCase(TestCase):
 
         response = self.middleware.process_exception(request, exception)
 
-        data = response.json()
+        data = json.loads(response.content)
         self.assertIn("detail", data)
         self.assertIsInstance(data["detail"], str)
 
@@ -57,7 +58,7 @@ class InternalErrorHandlerMiddlewareTestCase(TestCase):
 
         response = self.middleware.process_exception(request, exception)
 
-        data = response.json()
+        data = json.loads(response.content)
         self.assertNotIn("detail", data)
 
     @patch("insights.core.middleware.sentry_sdk.capture_exception")

--- a/insights/core/tests/test_middleware.py
+++ b/insights/core/tests/test_middleware.py
@@ -1,0 +1,71 @@
+from unittest.mock import patch
+
+from django.test import TestCase, RequestFactory, override_settings
+
+from insights.core.middleware import InternalErrorHandlerMiddleware
+
+
+class InternalErrorHandlerMiddlewareTestCase(TestCase):
+    def setUp(self):
+        self.factory = RequestFactory()
+        self.middleware = InternalErrorHandlerMiddleware(get_response=lambda r: None)
+
+    @patch("insights.core.middleware.sentry_sdk.capture_exception")
+    def test_returns_500_with_event_id(self, mock_capture):
+        mock_capture.return_value = "abc123"
+        request = self.factory.get("/")
+        exception = ValueError("something went wrong")
+
+        response = self.middleware.process_exception(request, exception)
+
+        self.assertEqual(response.status_code, 500)
+        data = response.json()
+        self.assertEqual(data["code"], "INTERNAL_ERROR")
+        self.assertEqual(data["message"], "An internal error has occurred")
+        self.assertEqual(data["event_id"], "abc123")
+        self.assertNotIn("detail", data)
+
+    @override_settings(DEBUG=True)
+    @patch("insights.core.middleware.sentry_sdk.capture_exception")
+    def test_includes_detail_when_debug_is_true(self, mock_capture):
+        mock_capture.return_value = "abc123"
+        request = self.factory.get("/")
+        exception = ValueError("something went wrong")
+
+        response = self.middleware.process_exception(request, exception)
+
+        data = response.json()
+        self.assertIn("detail", data)
+        self.assertIsInstance(data["detail"], str)
+
+    @patch("insights.core.middleware.sentry_sdk.capture_exception")
+    def test_calls_sentry_capture_exception(self, mock_capture):
+        mock_capture.return_value = "evt-id"
+        request = self.factory.get("/")
+        exception = RuntimeError("unexpected")
+
+        self.middleware.process_exception(request, exception)
+
+        mock_capture.assert_called_once_with(exception)
+
+    @override_settings(DEBUG=False)
+    @patch("insights.core.middleware.sentry_sdk.capture_exception")
+    def test_does_not_include_detail_when_debug_is_false(self, mock_capture):
+        mock_capture.return_value = "evt-id"
+        request = self.factory.get("/")
+        exception = Exception("fail")
+
+        response = self.middleware.process_exception(request, exception)
+
+        data = response.json()
+        self.assertNotIn("detail", data)
+
+    @patch("insights.core.middleware.sentry_sdk.capture_exception")
+    def test_response_content_type_is_json(self, mock_capture):
+        mock_capture.return_value = "evt-id"
+        request = self.factory.get("/")
+        exception = Exception("fail")
+
+        response = self.middleware.process_exception(request, exception)
+
+        self.assertEqual(response["Content-Type"], "application/json")

--- a/insights/settings.py
+++ b/insights/settings.py
@@ -88,6 +88,7 @@ MIDDLEWARE = [
     "django.contrib.auth.middleware.AuthenticationMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
+    "insights.core.middleware.InternalErrorHandlerMiddleware",
 ]
 
 CSRF_TRUSTED_ORIGINS = env.list("CSRF_TRUSTED_ORIGINS", default=[])


### PR DESCRIPTION
### What
- Added a new `InternalErrorHandlerMiddleware` in `insights/core/middleware.py` that intercepts unhandled exceptions across all views and returns a standardized JSON error response with HTTP 500 status.
- The middleware captures exceptions in Sentry (using `sentry_sdk`), includes the Sentry `event_id` in the response, and logs the exception via Python's `logging` module.
- In `DEBUG` mode, the response also includes a `detail` field with the full traceback for easier local debugging.
- Registered the middleware in `MIDDLEWARE` list in `insights/settings.py`.
- Added comprehensive unit tests in `insights/core/tests/test_middleware.py` covering: 500 response structure, Sentry integration, debug/non-debug behavior, and JSON content type validation.

Response example:
```json
{
    "code": "INTERNAL_ERROR",
    "message": "An internal error has occurred",
    "event_id": "9b7f9e0b95f6429cb88ecd0472aa2feb"
}
```

### Why
Previously, unhandled exceptions in views could result in inconsistent error responses (HTML error pages, varying formats, etc.), making it harder for API consumers to programmatically handle server errors. This middleware centralizes internal error handling so that every uncaught exception produces a consistent JSON response with a structured `code`, `message`, and Sentry `event_id`, improving both the developer experience for API consumers and the observability of production errors.

### Sequence diagram
```mermaid
sequenceDiagram
    participant Client
    participant Django
    participant Middleware as InternalErrorHandlerMiddleware
    participant View
    participant Sentry
    participant Logger

    Client->>Django: HTTP Request
    Django->>Middleware: __call__(request)
    Middleware->>View: get_response(request)

    alt View raises an exception
        View-->>Middleware: Exception raised
        Middleware->>Middleware: process_exception(request, exception)
        Middleware->>Sentry: last_event_id()

        alt event_id is None
            Middleware->>Sentry: capture_exception(exception)
            Sentry-->>Middleware: event_id
        end

        Middleware->>Logger: logger.exception("Internal error: ...")

        alt DEBUG is True
            Middleware->>Middleware: Include traceback in response
        end

        Middleware-->>Client: JsonResponse 500 {code, message, event_id, [detail]}
    else View succeeds
        View-->>Middleware: HttpResponse
        Middleware-->>Django: HttpResponse
        Django-->>Client: HTTP Response
    end
```