### PR TITLE
fix: update agent invocations and tool results total counts in metrics calculations

### DIFF
--- a/insights/metrics/conversations/api/v1/tests/test_serializers.py
+++ b/insights/metrics/conversations/api/v1/tests/test_serializers.py
@@ -1010,11 +1010,11 @@ class TestAgentInvocationMetricsSerializer(TestCase):
                     full_value=5,
                 ),
             ],
-            total=15,
+            total=2,
         )
         serializer = AgentInvocationMetricsSerializer(metrics)
 
-        self.assertEqual(serializer.data["total"], 15)
+        self.assertEqual(serializer.data["total"], 2)
         self.assertEqual(len(serializer.data["results"]), 2)
         self.assertEqual(serializer.data["results"][0]["label"], "invocation_1")
         self.assertEqual(serializer.data["results"][0]["agent"]["uuid"], agent_uuid)
@@ -1221,12 +1221,12 @@ class TestToolResultMetricsSerializer(TestCase):
                     full_value=5,
                 ),
             ],
-            total=15,
+            total=2,
         )
 
         serializer = ToolResultMetricsSerializer(metrics)
 
-        self.assertEqual(serializer.data["total"], 15)
+        self.assertEqual(serializer.data["total"], 2)
         self.assertEqual(len(serializer.data["results"]), 2)
         self.assertEqual(serializer.data["results"][0]["label"], "tool_result_1")
         self.assertEqual(serializer.data["results"][0]["agent"]["uuid"], agent_uuid)

--- a/insights/metrics/conversations/api/v1/tests/test_views.py
+++ b/insights/metrics/conversations/api/v1/tests/test_views.py
@@ -1086,7 +1086,7 @@ class TestConversationsMetricsViewSetAsAuthenticatedUser(
                     full_value=10,
                 ),
             ],
-            total=10,
+            total=1,
         )
 
         response = self.get_agent_invocation(
@@ -1098,7 +1098,7 @@ class TestConversationsMetricsViewSetAsAuthenticatedUser(
         )
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.data["total"], 10)
+        self.assertEqual(response.data["total"], 1)
         self.assertEqual(len(response.data["results"]), 1)
         self.assertEqual(response.data["results"][0]["label"], "invocation_1")
         self.assertEqual(response.data["results"][0]["agent"]["uuid"], agent_uuid)
@@ -1119,7 +1119,7 @@ class TestConversationsMetricsViewSetAsAuthenticatedUser(
                     full_value=10,
                 ),
             ],
-            total=10,
+            total=1,
         )
 
         response = self.get_agent_invocation(
@@ -1131,7 +1131,7 @@ class TestConversationsMetricsViewSetAsAuthenticatedUser(
         )
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.data["total"], 10)
+        self.assertEqual(response.data["total"], 1)
         self.assertEqual(len(response.data["results"]), 1)
         self.assertEqual(response.data["results"][0]["label"], "invocation_1")
         self.assertIsNone(response.data["results"][0]["agent"])
@@ -1220,7 +1220,7 @@ class TestConversationsMetricsViewSetAsAuthenticatedUser(
                     full_value=10,
                 ),
             ],
-            total=10,
+            total=1,
         )
         response = self.get_tool_result(
             {
@@ -1231,7 +1231,7 @@ class TestConversationsMetricsViewSetAsAuthenticatedUser(
         )
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.data["total"], 10)
+        self.assertEqual(response.data["total"], 1)
         self.assertEqual(len(response.data["results"]), 1)
 
         self.assertEqual(response.data["results"][0]["label"], "tool_result_1")
@@ -1254,7 +1254,7 @@ class TestConversationsMetricsViewSetAsAuthenticatedUser(
                     full_value=10,
                 ),
             ],
-            total=10,
+            total=1,
         )
 
         response = self.get_tool_result(
@@ -1266,7 +1266,7 @@ class TestConversationsMetricsViewSetAsAuthenticatedUser(
         )
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.data["total"], 10)
+        self.assertEqual(response.data["total"], 1)
         self.assertEqual(len(response.data["results"]), 1)
         self.assertEqual(response.data["results"][0]["label"], "tool_result_1")
 

--- a/insights/metrics/conversations/mock/services.py
+++ b/insights/metrics/conversations/mock/services.py
@@ -239,7 +239,7 @@ class MockConversationsMetricsService(BaseConversationsMetricsService):
         ]
         return AgentInvocationMetrics(
             invocations=invocations,
-            total=200,
+            total=10,
         )
 
     def get_tool_results(
@@ -265,7 +265,7 @@ class MockConversationsMetricsService(BaseConversationsMetricsService):
         ]
         return ToolResultMetrics(
             tool_results=tool_results,
-            total=30,
+            total=2,
         )
 
     def get_sales_funnel_data(

--- a/insights/metrics/conversations/services.py
+++ b/insights/metrics/conversations/services.py
@@ -1128,7 +1128,7 @@ class ConversationsMetricsService(
                 )
                 for label, item in invocations.items()
             ],
-            total=total_count,
+            total=len(invocations),
         )
 
     def get_tool_results(
@@ -1164,7 +1164,7 @@ class ConversationsMetricsService(
                 )
                 for label, item in tool_results.items()
             ],
-            total=total_count,
+            total=len(tool_results),
         )
 
     def get_event_count(

--- a/insights/metrics/conversations/services.py
+++ b/insights/metrics/conversations/services.py
@@ -1104,13 +1104,13 @@ class ConversationsMetricsService(
         """
         Get agent invocation counts grouped by agent
         """
-        invocations = self.datalake_service.get_agent_invocations(
+        invocation_counts_by_agent = self.datalake_service.get_agent_invocations(
             project_uuid=project_uuid,
             start_date=start_date,
             end_date=end_date,
         )
 
-        total_count = sum(item.count for item in invocations.values())
+        total_count = sum(item.count for item in invocation_counts_by_agent.values())
 
         return AgentInvocationMetrics(
             invocations=[
@@ -1126,9 +1126,9 @@ class ConversationsMetricsService(
                     ),
                     full_value=item.count,
                 )
-                for label, item in invocations.items()
+                for label, item in invocation_counts_by_agent.items()
             ],
-            total=len(invocations),
+            total=len(invocation_counts_by_agent),
         )
 
     def get_tool_results(
@@ -1140,13 +1140,13 @@ class ConversationsMetricsService(
         """
         Get tool result counts grouped by agent
         """
-        tool_results = self.datalake_service.get_tool_results(
+        tool_results_by_agent = self.datalake_service.get_tool_results(
             project_uuid=project_uuid,
             start_date=start_date,
             end_date=end_date,
         )
 
-        total_count = sum(item.count for item in tool_results.values())
+        total_count = sum(item.count for item in tool_results_by_agent.values())
 
         return ToolResultMetrics(
             tool_results=[
@@ -1162,9 +1162,9 @@ class ConversationsMetricsService(
                     ),
                     full_value=item.count,
                 )
-                for label, item in tool_results.items()
+                for label, item in tool_results_by_agent.items()
             ],
-            total=len(tool_results),
+            total=len(tool_results_by_agent),
         )
 
     def get_event_count(

--- a/insights/metrics/conversations/tests/test_services.py
+++ b/insights/metrics/conversations/tests/test_services.py
@@ -959,7 +959,7 @@ class TestConversationsMetricsService(TestCase):
         )
 
         self.assertIsInstance(results, AgentInvocationMetrics)
-        self.assertEqual(results.total, 10)
+        self.assertEqual(results.total, 1)
         self.assertEqual(len(results.invocations), 1)
         self.assertIsInstance(results.invocations[0], AgentInvocationItem)
         self.assertEqual(results.invocations[0].label, "invocation_1")
@@ -992,7 +992,7 @@ class TestConversationsMetricsService(TestCase):
         )
 
         self.assertIsInstance(results, AgentInvocationMetrics)
-        self.assertEqual(results.total, 10)
+        self.assertEqual(results.total, 1)
         self.assertEqual(len(results.invocations), 1)
         self.assertIsInstance(results.invocations[0], AgentInvocationItem)
         self.assertEqual(results.invocations[0].label, "invocation_1")
@@ -1040,7 +1040,7 @@ class TestConversationsMetricsService(TestCase):
             end_date=self.end_date,
         )
 
-        self.assertEqual(results.total, 30)
+        self.assertEqual(results.total, 2)
         self.assertEqual(len(results.invocations), 2)
         self.assertEqual(results.invocations[0].label, "invocation_1")
         self.assertEqual(results.invocations[0].full_value, 10)
@@ -1069,7 +1069,7 @@ class TestConversationsMetricsService(TestCase):
             end_date=self.end_date,
         )
 
-        self.assertEqual(results.total, 30)
+        self.assertEqual(results.total, 2)
         self.assertEqual(len(results.invocations), 2)
         self.assertEqual(results.invocations[0].label, "invocation_1")
         self.assertEqual(
@@ -1109,7 +1109,7 @@ class TestConversationsMetricsService(TestCase):
             end_date=self.end_date,
         )
         self.assertIsInstance(results, ToolResultMetrics)
-        self.assertEqual(results.total, 10)
+        self.assertEqual(results.total, 1)
         self.assertEqual(len(results.tool_results), 1)
         self.assertIsInstance(results.tool_results[0], ToolResultItem)
         self.assertEqual(results.tool_results[0].label, "tool_result_1")
@@ -1141,7 +1141,7 @@ class TestConversationsMetricsService(TestCase):
         )
 
         self.assertIsInstance(results, ToolResultMetrics)
-        self.assertEqual(results.total, 10)
+        self.assertEqual(results.total, 1)
         self.assertEqual(len(results.tool_results), 1)
         self.assertIsInstance(results.tool_results[0], ToolResultItem)
         self.assertEqual(results.tool_results[0].label, "tool_result_1")
@@ -1189,7 +1189,7 @@ class TestConversationsMetricsService(TestCase):
             end_date=self.end_date,
         )
 
-        self.assertEqual(results.total, 30)
+        self.assertEqual(results.total, 2)
         self.assertEqual(len(results.tool_results), 2)
         self.assertEqual(results.tool_results[0].label, "tool_result_1")
         self.assertEqual(results.tool_results[0].full_value, 10)
@@ -1218,7 +1218,7 @@ class TestConversationsMetricsService(TestCase):
             end_date=self.end_date,
         )
 
-        self.assertEqual(results.total, 30)
+        self.assertEqual(results.total, 2)
         self.assertEqual(len(results.tool_results), 2)
         self.assertEqual(results.tool_results[0].label, "tool_result_1")
         self.assertEqual(


### PR DESCRIPTION
### What
Changed the `total` field in `AgentInvocationMetrics` and `ToolResultMetrics` to represent the number of distinct agents/tools instead of the sum of all invocation or tool result counts. Previously, `total` was set to `total_count` (the aggregate of all event counts); now it is set to `len(invocations)` and `len(tool_results)`, respectively. All related tests and mock data were updated to reflect the corrected values.

### Why
The `total` field was reporting the sum of all individual event counts (e.g., 10 + 20 = 30) rather than the actual number of distinct agents or tools returned in the results (e.g., 2).