### PR TITLE
feat: add inline agent switch functionality to project creation

### DIFF
--- a/insights/dashboards/tasks.py
+++ b/insights/dashboards/tasks.py
@@ -1,9 +1,13 @@
+import logging
 from insights.celery import app
 from insights.dashboards.models import CONVERSATIONS_DASHBOARD_NAME, Dashboard
 from insights.dashboards.usecases.conversations_dashboard_creation import (
     CreateConversationsDashboard,
 )
 from insights.projects.models import Project
+
+
+logger = logging.getLogger(__name__)
 
 
 @app.task
@@ -13,9 +17,23 @@ def create_conversation_dashboard(project_uuid: str):
     """
     project = Project.objects.get(uuid=project_uuid)
 
+    logger.info(
+        "[ create_conversation_dashboard task ] Creating conversation dashboard for project %s",
+        project.uuid,
+    )
+
     if Dashboard.objects.filter(
         project=project, name=CONVERSATIONS_DASHBOARD_NAME
     ).exists():
+        logger.info(
+            "[ create_conversation_dashboard task ] Conversation dashboard already exists for project %s",
+            project.uuid,
+        )
         return
 
     CreateConversationsDashboard().create_dashboard(project)
+
+    logger.info(
+        "[ create_conversation_dashboard task ] Conversation dashboard created for project %s",
+        project.uuid,
+    )

--- a/insights/dashboards/viewsets.py
+++ b/insights/dashboards/viewsets.py
@@ -122,7 +122,7 @@ class DashboardViewSet(
 
     def list(self, request, *args, **kwargs):
         if project_uuid := request.query_params.get("project"):
-            project = Project.objects.get(uuid=project_uuid)
+            project = get_object_or_404(Project, uuid=project_uuid)
             is_nexus_multi_agents_active = project.is_nexus_multi_agents_active
             is_allowed = (
                 project.is_allowed or str(project_uuid) in settings.PROJECT_ALLOW_LIST

--- a/insights/dashboards/viewsets.py
+++ b/insights/dashboards/viewsets.py
@@ -26,7 +26,10 @@ from insights.metrics.meta.tasks import (
     check_dashboards_marketing_messages_status_for_project,
 )
 from insights.projects.models import Project
-from insights.projects.tasks import check_nexus_multi_agents_status
+from insights.projects.tasks import (
+    check_nexus_multi_agents_status,
+    handle_project_created_with_inline_agent_switch,
+)
 from insights.projects.usecases.dashboard_dto import FlowsDashboardCreationDTO
 from insights.sources.contacts.clients import FlowsContactsRestClient
 from insights.sources.custom_status.client import CustomStatusRESTClient
@@ -119,14 +122,21 @@ class DashboardViewSet(
 
     def list(self, request, *args, **kwargs):
         if project_uuid := request.query_params.get("project"):
-            is_nexus_multi_agents_active = (
-                Project.objects.filter(uuid=project_uuid)
-                .values_list("is_nexus_multi_agents_active", flat=True)
-                .first()
+            project = Project.objects.get(uuid=project_uuid)
+            is_nexus_multi_agents_active = project.is_nexus_multi_agents_active
+            is_allowed = (
+                project.is_allowed or str(project_uuid) in settings.PROJECT_ALLOW_LIST
             )
 
             if not is_nexus_multi_agents_active:
                 check_nexus_multi_agents_status.delay(project_uuid)
+
+            if (
+                settings.CONVERSATIONS_DASHBOARD_REQUIRES_INDEXER_ACTIVATION
+                and is_nexus_multi_agents_active
+                and not is_allowed
+            ):
+                handle_project_created_with_inline_agent_switch.delay(project_uuid)
 
             self._check_marketing_messages_status(project_uuid)
 

--- a/insights/projects/consumers/project_consumer.py
+++ b/insights/projects/consumers/project_consumer.py
@@ -43,7 +43,7 @@ class ProjectConsumer(EDAConsumer):
                 timezone=body.get("timezone"),
                 vtex_account=body.get("vtex_account"),
                 org_uuid=org_uuid,
-                inline_agent_switch=body.get("inline_agent_switch"),
+                inline_agent_switch=body.get("inline_agent_switch", False),
             )
 
             authorizations = body.get("authorizations", [])

--- a/insights/projects/consumers/project_consumer.py
+++ b/insights/projects/consumers/project_consumer.py
@@ -43,6 +43,7 @@ class ProjectConsumer(EDAConsumer):
                 timezone=body.get("timezone"),
                 vtex_account=body.get("vtex_account"),
                 org_uuid=org_uuid,
+                inline_agent_switch=body.get("inline_agent_switch"),
             )
 
             authorizations = body.get("authorizations", [])

--- a/insights/projects/services/update_nexus_multi_agents_status.py
+++ b/insights/projects/services/update_nexus_multi_agents_status.py
@@ -83,5 +83,3 @@ class UpdateNexusMultiAgentsStatusService:
             and not self.indexer_activation_service.is_project_queued(project)
         ):
             self.indexer_activation_service.add_project_to_queue(project)
-
-        return True

--- a/insights/projects/services/update_nexus_multi_agents_status.py
+++ b/insights/projects/services/update_nexus_multi_agents_status.py
@@ -4,6 +4,7 @@ from django.conf import settings
 from rest_framework import status
 from sentry_sdk import capture_exception
 
+from insights.dashboards.models import CONVERSATIONS_DASHBOARD_NAME, Dashboard
 from insights.dashboards.tasks import create_conversation_dashboard
 from insights.projects.services.indexer_activation import (
     BaseProjectIndexerActivationService,
@@ -68,11 +69,10 @@ class UpdateNexusMultiAgentsStatusService:
 
         self.add_project_to_indexer_queue(project)
 
-        # The dashboard is created but should NOT be shown in the dashboard list
-        # before the indexer is activated
-        # because of widgets that needs data from elasticsearch (flowruns)
-        # such as the human support widgets for CSAT and NPS
-        create_conversation_dashboard.delay(project.uuid)
+        if not Dashboard.objects.filter(
+            project__uuid=project.uuid, name=CONVERSATIONS_DASHBOARD_NAME
+        ).exists():
+            create_conversation_dashboard.delay(project.uuid)
 
     def add_project_to_indexer_queue(self, project: Project) -> None:
         if (

--- a/insights/projects/services/update_nexus_multi_agents_status.py
+++ b/insights/projects/services/update_nexus_multi_agents_status.py
@@ -55,23 +55,33 @@ class UpdateNexusMultiAgentsStatusService:
 
         self.cache_client.set(cache_key, str(is_active), cache_ttl)
 
-        if is_active and not project.is_nexus_multi_agents_active:
-            project.is_nexus_multi_agents_active = True
-            project.save(update_fields=["is_nexus_multi_agents_active"])
-
-            if (
-                settings.CONVERSATIONS_DASHBOARD_REQUIRES_INDEXER_ACTIVATION
-                and not self.indexer_activation_service.is_project_active_on_indexer(
-                    project
-                )
-                and not self.indexer_activation_service.is_project_queued(project)
-            ):
-                self.indexer_activation_service.add_project_to_queue(project)
-
-            # The dashboard is created but should NOT be shown in the dashboard list
-            # before the indexer is activated
-            # because of widgets that needs data from elasticsearch (flowruns)
-            # such as the human support widgets for CSAT and NPS
-            create_conversation_dashboard.delay(project.uuid)
+        self.activate_multi_agents(project, is_active)
 
         return is_active
+
+    def activate_multi_agents(self, project: Project, is_active: bool) -> None:
+        if not is_active or project.is_nexus_multi_agents_active:
+            return
+
+        project.is_nexus_multi_agents_active = True
+        project.save(update_fields=["is_nexus_multi_agents_active"])
+
+        self.add_project_to_indexer_queue(project)
+
+        # The dashboard is created but should NOT be shown in the dashboard list
+        # before the indexer is activated
+        # because of widgets that needs data from elasticsearch (flowruns)
+        # such as the human support widgets for CSAT and NPS
+        create_conversation_dashboard.delay(project.uuid)
+
+    def add_project_to_indexer_queue(self, project: Project) -> None:
+        if (
+            settings.CONVERSATIONS_DASHBOARD_REQUIRES_INDEXER_ACTIVATION
+            and not self.indexer_activation_service.is_project_active_on_indexer(
+                project
+            )
+            and not self.indexer_activation_service.is_project_queued(project)
+        ):
+            self.indexer_activation_service.add_project_to_queue(project)
+
+        return True

--- a/insights/projects/tasks.py
+++ b/insights/projects/tasks.py
@@ -113,7 +113,7 @@ def handle_project_created_with_inline_agent_switch(project_uuid: UUID):
 
     if not project.is_nexus_multi_agents_active:
         logger.info(
-            "[ handle_project_created_with_inline_agent_switch task ] Project %s does not have inline agent switch enabled",
+            "[ handle_project_created_with_inline_agent_switch task ] Project %s does not have multi-agents active",
             project.uuid,
         )
         return

--- a/insights/projects/tasks.py
+++ b/insights/projects/tasks.py
@@ -35,8 +35,11 @@ def activate_indexer():
         return
 
     pending_activations = ProjectIndexerActivation.objects.filter(
-        status=ProjectIndexerActivationStatus.PENDING
-    )
+        status__in=[
+            ProjectIndexerActivationStatus.PENDING,
+            ProjectIndexerActivationStatus.FAILED,
+        ],
+    ).order_by("created_on")
 
     if not pending_activations.exists():
         logger.info("[ activate_indexer task ] No pending activations found")

--- a/insights/projects/tasks.py
+++ b/insights/projects/tasks.py
@@ -4,6 +4,7 @@ from uuid import UUID
 from django.conf import settings
 
 from insights.celery import app
+from insights.dashboards.tasks import create_conversation_dashboard
 from insights.projects.choices import ProjectIndexerActivationStatus
 from insights.projects.models import Project, ProjectIndexerActivation
 from insights.projects.services.indexer_activation import (
@@ -97,3 +98,45 @@ def check_nexus_multi_agents_status(project_uuid: UUID):
     )
 
     service.update(project)
+
+
+@app.task
+def handle_project_created_with_inline_agent_switch(project_uuid: UUID):
+    """
+    Task to handle the creation of a project with inline agent switch enabled.
+    """
+    logger.info(
+        "[ handle_project_created_with_inline_agent_switch task ] Starting task"
+    )
+
+    project = Project.objects.get(uuid=project_uuid)
+
+    if not project.is_nexus_multi_agents_active:
+        logger.info(
+            "[ handle_project_created_with_inline_agent_switch task ] Project %s does not have inline agent switch enabled",
+            project.uuid,
+        )
+        return
+
+    service = UpdateNexusMultiAgentsStatusService(
+        nexus_client=NexusClient(),
+        cache_client=CacheClient(),
+        indexer_activation_service=ProjectIndexerActivationService(),
+    )
+
+    logger.info(
+        "[ handle_project_created_with_inline_agent_switch task ] Adding project %s to indexer queue",
+        project.uuid,
+    )
+
+    service.add_project_to_indexer_queue(project)
+
+    logger.info(
+        "[ handle_project_created_with_inline_agent_switch task ] Creating conversation dashboard for project %s",
+        project.uuid,
+    )
+    create_conversation_dashboard.delay(project.uuid)
+
+    logger.info(
+        "[ handle_project_created_with_inline_agent_switch task ] Finished task"
+    )

--- a/insights/projects/tasks.py
+++ b/insights/projects/tasks.py
@@ -132,11 +132,5 @@ def handle_project_created_with_inline_agent_switch(project_uuid: UUID):
     service.add_project_to_indexer_queue(project)
 
     logger.info(
-        "[ handle_project_created_with_inline_agent_switch task ] Creating conversation dashboard for project %s",
-        project.uuid,
-    )
-    create_conversation_dashboard.delay(project.uuid)
-
-    logger.info(
         "[ handle_project_created_with_inline_agent_switch task ] Finished task"
     )

--- a/insights/projects/tasks.py
+++ b/insights/projects/tasks.py
@@ -4,6 +4,8 @@ from uuid import UUID
 from django.conf import settings
 
 from insights.celery import app
+from insights.dashboards.models import CONVERSATIONS_DASHBOARD_NAME, Dashboard
+from insights.dashboards.tasks import create_conversation_dashboard
 from insights.projects.choices import ProjectIndexerActivationStatus
 from insights.projects.models import Project, ProjectIndexerActivation
 from insights.projects.services.indexer_activation import (
@@ -132,6 +134,11 @@ def handle_project_created_with_inline_agent_switch(project_uuid: UUID):
     )
 
     service.add_project_to_indexer_queue(project)
+
+    if not Dashboard.objects.filter(
+        project__uuid=project.uuid, name=CONVERSATIONS_DASHBOARD_NAME
+    ).exists():
+        create_conversation_dashboard.delay(project.uuid)
 
     logger.info(
         "[ handle_project_created_with_inline_agent_switch task ] Finished task"

--- a/insights/projects/tasks.py
+++ b/insights/projects/tasks.py
@@ -4,7 +4,6 @@ from uuid import UUID
 from django.conf import settings
 
 from insights.celery import app
-from insights.dashboards.tasks import create_conversation_dashboard
 from insights.projects.choices import ProjectIndexerActivationStatus
 from insights.projects.models import Project, ProjectIndexerActivation
 from insights.projects.services.indexer_activation import (

--- a/insights/projects/tests/test_services/test_update_nexus_multi_agents_service.py
+++ b/insights/projects/tests/test_services/test_update_nexus_multi_agents_service.py
@@ -157,9 +157,7 @@ class TestUpdateNexusMultiAgentsService(TestCase):
     @patch(
         "insights.projects.services.update_nexus_multi_agents_status.create_conversation_dashboard"
     )
-    def test_activate_multi_agents_when_not_active(
-        self, mock_create_dashboard
-    ):
+    def test_activate_multi_agents_when_not_active(self, mock_create_dashboard):
         self.service.activate_multi_agents(self.project, is_active=False)
         self.project.refresh_from_db(fields=["is_nexus_multi_agents_active"])
         self.assertFalse(self.project.is_nexus_multi_agents_active)
@@ -168,9 +166,7 @@ class TestUpdateNexusMultiAgentsService(TestCase):
     @patch(
         "insights.projects.services.update_nexus_multi_agents_status.create_conversation_dashboard"
     )
-    def test_activate_multi_agents_when_already_active(
-        self, mock_create_dashboard
-    ):
+    def test_activate_multi_agents_when_already_active(self, mock_create_dashboard):
         self.project.is_nexus_multi_agents_active = True
         self.project.save(update_fields=["is_nexus_multi_agents_active"])
 

--- a/insights/projects/tests/test_services/test_update_nexus_multi_agents_service.py
+++ b/insights/projects/tests/test_services/test_update_nexus_multi_agents_service.py
@@ -153,3 +153,91 @@ class TestUpdateNexusMultiAgentsService(TestCase):
         mock_cache_get.assert_called_once_with(
             f"nexus_multi_agents_status:{self.project.uuid}"
         )
+
+    @patch(
+        "insights.projects.services.update_nexus_multi_agents_status.create_conversation_dashboard"
+    )
+    def test_activate_multi_agents_when_not_active(
+        self, mock_create_dashboard
+    ):
+        self.service.activate_multi_agents(self.project, is_active=False)
+        self.project.refresh_from_db(fields=["is_nexus_multi_agents_active"])
+        self.assertFalse(self.project.is_nexus_multi_agents_active)
+        mock_create_dashboard.delay.assert_not_called()
+
+    @patch(
+        "insights.projects.services.update_nexus_multi_agents_status.create_conversation_dashboard"
+    )
+    def test_activate_multi_agents_when_already_active(
+        self, mock_create_dashboard
+    ):
+        self.project.is_nexus_multi_agents_active = True
+        self.project.save(update_fields=["is_nexus_multi_agents_active"])
+
+        self.service.activate_multi_agents(self.project, is_active=True)
+        mock_create_dashboard.delay.assert_not_called()
+        self.service.indexer_activation_service.add_project_to_queue.assert_not_called()
+
+    @override_settings(CONVERSATIONS_DASHBOARD_REQUIRES_INDEXER_ACTIVATION=True)
+    @patch(
+        "insights.projects.services.update_nexus_multi_agents_status.create_conversation_dashboard"
+    )
+    def test_activate_multi_agents_when_active_and_not_yet_activated(
+        self, mock_create_dashboard
+    ):
+        self.service.indexer_activation_service.is_project_active_on_indexer = (
+            MagicMock(return_value=False)
+        )
+        self.service.indexer_activation_service.is_project_queued = MagicMock(
+            return_value=False
+        )
+
+        self.service.activate_multi_agents(self.project, is_active=True)
+        self.project.refresh_from_db(fields=["is_nexus_multi_agents_active"])
+        self.assertTrue(self.project.is_nexus_multi_agents_active)
+        self.service.indexer_activation_service.add_project_to_queue.assert_called_once_with(
+            self.project
+        )
+        mock_create_dashboard.delay.assert_called_once_with(self.project.uuid)
+
+    @override_settings(CONVERSATIONS_DASHBOARD_REQUIRES_INDEXER_ACTIVATION=True)
+    def test_add_project_to_indexer_queue_when_not_active_and_not_queued(self):
+        self.service.indexer_activation_service.is_project_active_on_indexer = (
+            MagicMock(return_value=False)
+        )
+        self.service.indexer_activation_service.is_project_queued = MagicMock(
+            return_value=False
+        )
+
+        self.service.add_project_to_indexer_queue(self.project)
+        self.service.indexer_activation_service.add_project_to_queue.assert_called_once_with(
+            self.project
+        )
+
+    @override_settings(CONVERSATIONS_DASHBOARD_REQUIRES_INDEXER_ACTIVATION=True)
+    def test_add_project_to_indexer_queue_when_active_on_indexer(self):
+        self.service.indexer_activation_service.is_project_active_on_indexer = (
+            MagicMock(return_value=True)
+        )
+
+        self.service.add_project_to_indexer_queue(self.project)
+        self.service.indexer_activation_service.is_project_queued.assert_not_called()
+        self.service.indexer_activation_service.add_project_to_queue.assert_not_called()
+
+    @override_settings(CONVERSATIONS_DASHBOARD_REQUIRES_INDEXER_ACTIVATION=True)
+    def test_add_project_to_indexer_queue_when_already_queued(self):
+        self.service.indexer_activation_service.is_project_active_on_indexer = (
+            MagicMock(return_value=False)
+        )
+        self.service.indexer_activation_service.is_project_queued = MagicMock(
+            return_value=True
+        )
+
+        self.service.add_project_to_indexer_queue(self.project)
+        self.service.indexer_activation_service.add_project_to_queue.assert_not_called()
+
+    @override_settings(CONVERSATIONS_DASHBOARD_REQUIRES_INDEXER_ACTIVATION=False)
+    def test_add_project_to_indexer_queue_when_activation_not_required(self):
+        self.service.add_project_to_indexer_queue(self.project)
+        self.service.indexer_activation_service.is_project_active_on_indexer.assert_not_called()
+        self.service.indexer_activation_service.add_project_to_queue.assert_not_called()

--- a/insights/projects/tests/test_tasks/test_activate_indexer.py
+++ b/insights/projects/tests/test_tasks/test_activate_indexer.py
@@ -1,0 +1,175 @@
+import uuid
+from unittest.mock import patch, MagicMock
+
+from django.test import TestCase, override_settings
+
+from insights.projects.choices import ProjectIndexerActivationStatus
+from insights.projects.models import Project, ProjectIndexerActivation
+from insights.projects.tasks import activate_indexer
+
+
+@override_settings(INDEXER_AUTOMATIC_ACTIVATION=True, INDEXER_AUTOMATIC_ACTIVATION_LIMIT=5)
+class TestActivateIndexerTask(TestCase):
+    def setUp(self):
+        self.project = Project.objects.create(
+            uuid=uuid.uuid4(),
+            is_allowed=False,
+        )
+
+    @override_settings(INDEXER_AUTOMATIC_ACTIVATION=False)
+    def test_does_nothing_when_automatic_activation_is_disabled(self):
+        ProjectIndexerActivation.objects.create(
+            project=self.project,
+            status=ProjectIndexerActivationStatus.PENDING,
+        )
+        with patch(
+            "insights.projects.tasks.ProjectIndexerActivationService"
+        ) as mock_service_cls:
+            activate_indexer()
+            mock_service_cls.assert_not_called()
+
+    def test_does_nothing_when_no_pending_activations(self):
+        with patch(
+            "insights.projects.tasks.ProjectIndexerActivationService"
+        ) as mock_service_cls:
+            activate_indexer()
+            mock_service_cls.assert_not_called()
+
+    def test_picks_up_pending_activations(self):
+        activation = ProjectIndexerActivation.objects.create(
+            project=self.project,
+            status=ProjectIndexerActivationStatus.PENDING,
+        )
+        with patch(
+            "insights.projects.tasks.ProjectIndexerActivationService"
+        ) as mock_service_cls:
+            mock_service = MagicMock()
+            mock_service_cls.return_value = mock_service
+
+            activate_indexer()
+
+            mock_service.activate_project_on_indexer.assert_called_once()
+            called_activation = mock_service.activate_project_on_indexer.call_args[0][0]
+            self.assertEqual(called_activation.pk, activation.pk)
+
+    def test_picks_up_failed_activations(self):
+        activation = ProjectIndexerActivation.objects.create(
+            project=self.project,
+            status=ProjectIndexerActivationStatus.FAILED,
+        )
+        with patch(
+            "insights.projects.tasks.ProjectIndexerActivationService"
+        ) as mock_service_cls:
+            mock_service = MagicMock()
+            mock_service_cls.return_value = mock_service
+
+            activate_indexer()
+
+            mock_service.activate_project_on_indexer.assert_called_once()
+            called_activation = mock_service.activate_project_on_indexer.call_args[0][0]
+            self.assertEqual(called_activation.pk, activation.pk)
+
+    def test_ignores_success_activations(self):
+        ProjectIndexerActivation.objects.create(
+            project=self.project,
+            status=ProjectIndexerActivationStatus.SUCCESS,
+        )
+        with patch(
+            "insights.projects.tasks.ProjectIndexerActivationService"
+        ) as mock_service_cls:
+            activate_indexer()
+            mock_service_cls.assert_not_called()
+
+    def test_processes_both_pending_and_failed_activations(self):
+        project_2 = Project.objects.create(uuid=uuid.uuid4(), is_allowed=False)
+
+        pending = ProjectIndexerActivation.objects.create(
+            project=self.project,
+            status=ProjectIndexerActivationStatus.PENDING,
+        )
+        failed = ProjectIndexerActivation.objects.create(
+            project=project_2,
+            status=ProjectIndexerActivationStatus.FAILED,
+        )
+
+        with patch(
+            "insights.projects.tasks.ProjectIndexerActivationService"
+        ) as mock_service_cls:
+            mock_service = MagicMock()
+            mock_service_cls.return_value = mock_service
+
+            activate_indexer()
+
+            self.assertEqual(mock_service.activate_project_on_indexer.call_count, 2)
+
+            called_pks = [
+                call[0][0].pk
+                for call in mock_service.activate_project_on_indexer.call_args_list
+            ]
+            self.assertIn(pending.pk, called_pks)
+            self.assertIn(failed.pk, called_pks)
+
+    def test_processes_activations_ordered_by_created_on(self):
+        project_2 = Project.objects.create(uuid=uuid.uuid4(), is_allowed=False)
+
+        older = ProjectIndexerActivation.objects.create(
+            project=self.project,
+            status=ProjectIndexerActivationStatus.FAILED,
+        )
+        newer = ProjectIndexerActivation.objects.create(
+            project=project_2,
+            status=ProjectIndexerActivationStatus.PENDING,
+        )
+
+        with patch(
+            "insights.projects.tasks.ProjectIndexerActivationService"
+        ) as mock_service_cls:
+            mock_service = MagicMock()
+            mock_service_cls.return_value = mock_service
+
+            activate_indexer()
+
+            calls = mock_service.activate_project_on_indexer.call_args_list
+            self.assertEqual(calls[0][0][0].pk, older.pk)
+            self.assertEqual(calls[1][0][0].pk, newer.pk)
+
+    @patch("insights.projects.tasks.LIMIT", 1)
+    def test_respects_activation_limit(self):
+        project_2 = Project.objects.create(uuid=uuid.uuid4(), is_allowed=False)
+
+        ProjectIndexerActivation.objects.create(
+            project=self.project,
+            status=ProjectIndexerActivationStatus.PENDING,
+        )
+        ProjectIndexerActivation.objects.create(
+            project=project_2,
+            status=ProjectIndexerActivationStatus.FAILED,
+        )
+
+        with patch(
+            "insights.projects.tasks.ProjectIndexerActivationService"
+        ) as mock_service_cls:
+            mock_service = MagicMock()
+            mock_service_cls.return_value = mock_service
+
+            activate_indexer()
+
+            self.assertEqual(mock_service.activate_project_on_indexer.call_count, 1)
+
+    def test_marks_activation_as_failed_on_exception(self):
+        activation = ProjectIndexerActivation.objects.create(
+            project=self.project,
+            status=ProjectIndexerActivationStatus.PENDING,
+        )
+
+        with patch(
+            "insights.projects.tasks.ProjectIndexerActivationService"
+        ) as mock_service_cls:
+            mock_service = MagicMock()
+            mock_service.activate_project_on_indexer.side_effect = Exception("boom")
+            mock_service_cls.return_value = mock_service
+
+            activate_indexer()
+
+            activation.refresh_from_db()
+            self.assertEqual(activation.status, ProjectIndexerActivationStatus.FAILED)

--- a/insights/projects/tests/test_usecases/test_create_project.py
+++ b/insights/projects/tests/test_usecases/test_create_project.py
@@ -1,3 +1,4 @@
+from unittest.mock import patch
 from uuid import uuid4
 
 from django.test import TestCase
@@ -66,3 +67,65 @@ class TestCreateProjectUseCase(TestCase):
 
         self.assertEqual(project.uuid, project_dto.uuid)
         self.assertFalse(project.is_nexus_multi_agents_active)
+
+    @patch(
+        "insights.projects.usecases.create.handle_project_created_with_inline_agent_switch"
+    )
+    @patch("insights.projects.usecases.create.create_conversation_dashboard")
+    def test_create_project_dispatches_conversation_dashboard_task(
+        self, mock_create_dashboard, mock_handle_inline
+    ):
+        project_dto = ProjectCreationDTO(
+            uuid=uuid4().hex,
+            name="test_name",
+            timezone="America/Bahia",
+            date_format="DD/MM/YYYY",
+            is_template=False,
+        )
+
+        project = ProjectsUseCase().create_project(project_dto=project_dto)
+
+        mock_create_dashboard.delay.assert_called_once_with(project.uuid)
+        mock_handle_inline.delay.assert_not_called()
+
+    @patch(
+        "insights.projects.usecases.create.handle_project_created_with_inline_agent_switch"
+    )
+    @patch("insights.projects.usecases.create.create_conversation_dashboard")
+    def test_create_project_dispatches_inline_agent_switch_task_when_enabled(
+        self, mock_create_dashboard, mock_handle_inline
+    ):
+        project_dto = ProjectCreationDTO(
+            uuid=uuid4().hex,
+            name="test_name",
+            timezone="America/Bahia",
+            date_format="DD/MM/YYYY",
+            is_template=False,
+            inline_agent_switch=True,
+        )
+
+        project = ProjectsUseCase().create_project(project_dto=project_dto)
+
+        mock_create_dashboard.delay.assert_called_once_with(project.uuid)
+        mock_handle_inline.delay.assert_called_once_with(project.uuid)
+
+    @patch(
+        "insights.projects.usecases.create.handle_project_created_with_inline_agent_switch"
+    )
+    @patch("insights.projects.usecases.create.create_conversation_dashboard")
+    def test_create_project_does_not_dispatch_inline_agent_switch_task_when_disabled(
+        self, mock_create_dashboard, mock_handle_inline
+    ):
+        project_dto = ProjectCreationDTO(
+            uuid=uuid4().hex,
+            name="test_name",
+            timezone="America/Bahia",
+            date_format="DD/MM/YYYY",
+            is_template=False,
+            inline_agent_switch=False,
+        )
+
+        project = ProjectsUseCase().create_project(project_dto=project_dto)
+
+        mock_create_dashboard.delay.assert_called_once_with(project.uuid)
+        mock_handle_inline.delay.assert_not_called()

--- a/insights/projects/tests/test_usecases/test_create_project.py
+++ b/insights/projects/tests/test_usecases/test_create_project.py
@@ -20,6 +20,7 @@ class TestCreateProjectUseCase(TestCase):
 
         self.assertEqual(project.uuid, project_dto.uuid)
         self.assertIsNone(project.vtex_account)
+        self.assertFalse(project.is_nexus_multi_agents_active)
 
     def test_create_project_with_vtex_account(self):
         project_dto = ProjectCreationDTO(
@@ -35,3 +36,33 @@ class TestCreateProjectUseCase(TestCase):
 
         self.assertEqual(project.uuid, project_dto.uuid)
         self.assertEqual(project.vtex_account, project_dto.vtex_account)
+
+    def test_create_project_with_inline_agent_switch_enabled(self):
+        project_dto = ProjectCreationDTO(
+            uuid=uuid4().hex,
+            name="test_name",
+            timezone="America/Bahia",
+            date_format="DD/MM/YYYY",
+            is_template=False,
+            inline_agent_switch=True,
+        )
+
+        project = ProjectsUseCase().create_project(project_dto=project_dto)
+
+        self.assertEqual(project.uuid, project_dto.uuid)
+        self.assertTrue(project.is_nexus_multi_agents_active)
+
+    def test_create_project_with_inline_agent_switch_disabled(self):
+        project_dto = ProjectCreationDTO(
+            uuid=uuid4().hex,
+            name="test_name",
+            timezone="America/Bahia",
+            date_format="DD/MM/YYYY",
+            is_template=False,
+            inline_agent_switch=False,
+        )
+
+        project = ProjectsUseCase().create_project(project_dto=project_dto)
+
+        self.assertEqual(project.uuid, project_dto.uuid)
+        self.assertFalse(project.is_nexus_multi_agents_active)

--- a/insights/projects/usecases/create.py
+++ b/insights/projects/usecases/create.py
@@ -45,7 +45,7 @@ class ProjectsUseCase:
             date_format=project_dto.date_format,
             vtex_account=project_dto.vtex_account,
             org_uuid=project_dto.org_uuid,
-            is_nexus_multi_agents_active=project_dto.inline_agent_switch,
+            is_nexus_multi_agents_active=project_dto.inline_agent_switch or False,
             config=config,
         )
         CreateHumanService().create_dashboard(project)

--- a/insights/projects/usecases/create.py
+++ b/insights/projects/usecases/create.py
@@ -43,6 +43,7 @@ class ProjectsUseCase:
             date_format=project_dto.date_format,
             vtex_account=project_dto.vtex_account,
             org_uuid=project_dto.org_uuid,
+            is_nexus_multi_agents_active=project_dto.inline_agent_switch,
             config=config,
         )
         CreateHumanService().create_dashboard(project)

--- a/insights/projects/usecases/create.py
+++ b/insights/projects/usecases/create.py
@@ -1,4 +1,5 @@
 from insights.projects.models import Project
+from insights.projects.tasks import handle_project_created_with_inline_agent_switch
 
 from .project_dto import ProjectCreationDTO
 
@@ -47,4 +48,8 @@ class ProjectsUseCase:
             config=config,
         )
         CreateHumanService().create_dashboard(project)
+
+        if project.is_nexus_multi_agents_active:
+            handle_project_created_with_inline_agent_switch.delay(project.uuid)
+
         return project

--- a/insights/projects/usecases/create.py
+++ b/insights/projects/usecases/create.py
@@ -1,3 +1,4 @@
+from insights.dashboards.tasks import create_conversation_dashboard
 from insights.projects.models import Project
 from insights.projects.tasks import handle_project_created_with_inline_agent_switch
 
@@ -48,6 +49,7 @@ class ProjectsUseCase:
             config=config,
         )
         CreateHumanService().create_dashboard(project)
+        create_conversation_dashboard.delay(project.uuid)
 
         if project.is_nexus_multi_agents_active:
             handle_project_created_with_inline_agent_switch.delay(project.uuid)

--- a/insights/projects/usecases/project_dto.py
+++ b/insights/projects/usecases/project_dto.py
@@ -10,6 +10,7 @@ class ProjectCreationDTO:
     date_format: str = ""
     vtex_account: str | None = None
     org_uuid: str | None = None
+    inline_agent_switch: bool = False  # Equivalent to is_nexus_multi_agents_active
 
 
 @dataclass


### PR DESCRIPTION
### What

- Added support for the `inline_agent_switch` flag during project creation, allowing multi-agents to be activated at project creation time (not only post-creation).
- Extended `ProjectCreationDTO` with the `inline_agent_switch` field and the `ProjectConsumer` to forward it from the EDA message body.
- On project creation, the conversation dashboard task is now always dispatched, and a new `handle_project_created_with_inline_agent_switch` Celery task is dispatched when the flag is enabled to add the project to the indexer queue.
- Refactored `UpdateNexusMultiAgentsStatusService` by extracting `activate_multi_agents` and `add_project_to_indexer_queue` into dedicated methods, and added a dashboard existence check before scheduling dashboard creation.
- Added logging to the `create_conversation_dashboard` task for better observability.
- Added comprehensive unit tests for the new creation flow, multi-agents activation, and indexer queue management.

### Why

Previously, enabling Nexus multi-agents and triggering conversation dashboard creation could only happen after a project already existed, via a separate status-check flow. Connect didn't send `inline_agent_switch`, so this needed to be handled after. By handling the `inline_agent_switch` flag at creation time, the system now ensures that projects with multi-agents enabled are fully provisioned (dashboard created, indexer queued) immediately upon creation, reducing latency and eliminating the dependency on the post-creation polling cycle.

### Sequence diagram

```mermaid
sequenceDiagram
    participant EDA as EDA Message
    participant Consumer as ProjectConsumer
    participant UseCase as ProjectsUseCase
    participant DB as Database
    participant CeleryDashboard as create_conversation_dashboard (Task)
    participant CeleryInline as handle_project_created_with_inline_agent_switch (Task)
    participant Service as UpdateNexusMultiAgentsStatusService
    participant Indexer as ProjectIndexerActivationService
    participant Dashboard as Dashboard Model

    EDA->>Consumer: Project creation event (with inline_agent_switch)
    Consumer->>UseCase: create_project(ProjectCreationDTO)
    UseCase->>DB: Create Project (is_nexus_multi_agents_active = inline_agent_switch)
    UseCase->>UseCase: CreateHumanService().create_dashboard(project)
    UseCase->>CeleryDashboard: delay(project.uuid)

    alt inline_agent_switch is True
        UseCase->>CeleryInline: delay(project.uuid)
        CeleryInline->>DB: Fetch Project
        CeleryInline->>Service: add_project_to_indexer_queue(project)
        Service->>Indexer: is_project_active_on_indexer(project)
        alt Not active and not queued
            Service->>Indexer: add_project_to_queue(project)
        end
    end

    CeleryDashboard->>DB: Fetch Project
    CeleryDashboard->>Dashboard: Check if dashboard exists
    alt Dashboard does not exist
        CeleryDashboard->>Dashboard: Create conversation dashboard
    end
```