### PR TITLE
feat: Agents status V2

### DIFF
--- a/insights/human_support/services.py
+++ b/insights/human_support/services.py
@@ -751,7 +751,7 @@ class HumanSupportDashboardService:
                     value = value[0]
 
                 elif param in ("start_date", "end_date"):
-                    value = value.isoformat()
+                    value = value.strftime("%Y-%m-%d")
 
                 params[param] = str(value) if param_type == str else value
 

--- a/insights/human_support/services.py
+++ b/insights/human_support/services.py
@@ -622,6 +622,42 @@ class HumanSupportDashboardService:
             "results": formatted_results,
         }
 
+    def get_detailed_monitoring_status_v2(self, filters: dict = {}) -> dict:
+        ordering_fields = {"agent", "-agent"}
+        normalized = self._normalize_filters(filters)
+
+        params: dict = {}
+
+        if filters.get("user_request") is not None:
+            params["user_request"] = filters.get("user_request")
+        if (ordering := filters.get("ordering")) and ordering in ordering_fields:
+            params["ordering"] = ordering
+
+        for pagination_filter in ("limit", "offset"):
+            if filters.get(pagination_filter):
+                params[pagination_filter] = filters.get(pagination_filter)
+
+        mapping = {
+            "sectors": ("sector", list),
+            "queues": ("queue", list),
+            "agent": ("agent", str),
+            "start_date": ("start_date", str),
+            "end_date": ("end_date", str),
+        }
+
+        for filter_key, filter_value in mapping.items():
+            param, param_type = filter_value
+            if value := normalized.get(filter_key):
+                if param_type == list and len(value) > 0:
+                    value = value[0]
+                elif param in ("start_date", "end_date"):
+                    value = value.isoformat()
+                params[param] = str(value) if param_type == str else value
+
+        return ChatsRESTClient().get_status_by_agent(
+            str(self.project.uuid), params
+        )
+
     def get_detailed_monitoring_agents_totals(self, filters: dict = {}) -> dict:
         params = self._get_detailed_monitoring_agents_filters(filters)
         return AgentsRESTClient(self.project).agents_totals(params)
@@ -736,6 +772,36 @@ class HumanSupportDashboardService:
 
         client = CustomStatusRESTClient(self.project)
         response = client.list_custom_status_by_agent(params)
+
+        formatted_results = []
+        for agent_data in response.get("results", []):
+            formatted_results.append(
+                {
+                    "agent": agent_data.get("agent"),
+                    "agent_email": agent_data.get("agent_email"),
+                    "custom_status": agent_data.get("custom_status", []),
+                    "link": agent_data.get("link"),
+                }
+            )
+
+        return {
+            "next": response.get("next"),
+            "previous": response.get("previous"),
+            "count": response.get("count"),
+            "results": formatted_results,
+        }
+
+    def get_analysis_detailed_monitoring_status_v2(
+        self, filters: dict | None = None
+    ) -> dict:
+        ordering_fields = {"agent", "-agent"}
+        params = self._get_analysis_detailed_monitoring_status_filters(
+            filters, ordering_fields
+        )
+
+        response = ChatsRESTClient().get_status_by_agent(
+            str(self.project.uuid), params
+        )
 
         formatted_results = []
         for agent_data in response.get("results", []):

--- a/insights/human_support/tests/test_services.py
+++ b/insights/human_support/tests/test_services.py
@@ -247,6 +247,20 @@ class TestHumanSupportDashboardService(TestCase):
         result = self.service.get_detailed_monitoring_status()
         self.assertEqual(result["count"], 1)
 
+    @patch("insights.human_support.services.ChatsRESTClient")
+    def test_get_detailed_monitoring_status_v2(self, mock_client_class):
+        mock_client = MagicMock()
+        mock_client.get_status_by_agent.return_value = {
+            "results": [{"agent": "a1", "custom_status": []}],
+            "next": None,
+            "previous": None,
+            "count": 1,
+        }
+        mock_client_class.return_value = mock_client
+        result = self.service.get_detailed_monitoring_status_v2()
+        self.assertEqual(result["count"], 1)
+        mock_client.get_status_by_agent.assert_called_once()
+
     def test_csat_score_by_agents_with_mock_chats_client(self):
         mock_chats = MagicMock()
         mock_chats.csat_score_by_agents.return_value = {"results": []}
@@ -279,6 +293,28 @@ class TestHumanSupportDashboardService(TestCase):
         result = self.service.get_analysis_detailed_monitoring_status(filters={})
         self.assertEqual(result["count"], 1)
         self.assertEqual(result["results"][0]["custom_status"], [{"name": "Break"}])
+
+    @patch("insights.human_support.services.ChatsRESTClient")
+    def test_get_analysis_detailed_monitoring_status_v2(self, mock_client_class):
+        mock_client = MagicMock()
+        mock_client.get_status_by_agent.return_value = {
+            "results": [
+                {
+                    "agent": "a1",
+                    "agent_email": "a1@x.com",
+                    "custom_status": [{"name": "Break"}],
+                    "link": "https://link",
+                },
+            ],
+            "next": None,
+            "previous": None,
+            "count": 1,
+        }
+        mock_client_class.return_value = mock_client
+        result = self.service.get_analysis_detailed_monitoring_status_v2(filters={})
+        self.assertEqual(result["count"], 1)
+        self.assertEqual(result["results"][0]["custom_status"], [{"name": "Break"}])
+        mock_client.get_status_by_agent.assert_called_once()
 
     @patch("insights.human_support.services.RoomsQueryExecutor")
     def test_get_finished_rooms(self, mock_rooms):
@@ -413,6 +449,23 @@ class TestHumanSupportDashboardService(TestCase):
         self.assertEqual(call_args.get("ordering"), "agent")
         self.assertEqual(call_args.get("limit"), 5)
         self.assertEqual(call_args.get("offset"), 10)
+
+    @patch("insights.human_support.services.ChatsRESTClient")
+    def test_get_detailed_monitoring_status_v2_with_ordering(self, mock_client_class):
+        mock_client_class.return_value.get_status_by_agent.return_value = {
+            "results": [],
+            "next": None,
+            "previous": None,
+            "count": 0,
+        }
+        self.service.get_detailed_monitoring_status_v2(
+            filters={"ordering": "agent", "limit": 5, "offset": 10}
+        )
+        call_args = mock_client_class.return_value.get_status_by_agent.call_args
+        params = call_args[0][1]
+        self.assertEqual(params.get("ordering"), "agent")
+        self.assertEqual(params.get("limit"), 5)
+        self.assertEqual(params.get("offset"), 10)
 
     @patch("insights.human_support.services.RoomsQueryExecutor")
     def test_get_finished_rooms_with_ordering_and_dates(self, mock_rooms):

--- a/insights/metrics/human_support/api/v2/urls.py
+++ b/insights/metrics/human_support/api/v2/urls.py
@@ -2,11 +2,21 @@ from django.urls import path
 
 from insights.metrics.human_support.api.v2.views import (
     DetailedMonitoringAgentsViewV2,
+    DetailedMonitoringStatusViewV2,
+    AnalysisDetailedMonitoringStatusViewV2,
 )
 
 urlpatterns = [
     path(
         "detailed-monitoring/agents/",
         DetailedMonitoringAgentsViewV2.as_view(),
+    ),
+    path(
+        "detailed-monitoring/status/",
+        DetailedMonitoringStatusViewV2.as_view(),
+    ),
+    path(
+        "analysis/detailed-monitoring/status/",
+        AnalysisDetailedMonitoringStatusViewV2.as_view(),
     ),
 ]

--- a/insights/metrics/human_support/api/v2/views.py
+++ b/insights/metrics/human_support/api/v2/views.py
@@ -28,3 +28,41 @@ class DetailedMonitoringAgentsViewV2(APIView):
         data = service.get_detailed_monitoring_agents_v2(filters=filters)
 
         return Response(data, status=200)
+
+
+class DetailedMonitoringStatusViewV2(APIView):
+    permission_classes = [IsAuthenticated, ProjectAuthQueryParamPermission]
+    feature_flag_key = "human-support-detailed-monitoring"
+
+    def get(self, request, *args, **kwargs):
+        project_uuid = request.query_params.get("project_uuid")
+        if not project_uuid:
+            return Response({"detail": "project_uuid is required"}, status=400)
+
+        project = get_object_or_404(Project, uuid=project_uuid)
+        service = HumanSupportDashboardService(project=project)
+
+        filters = get_filters_from_query_params(request.query_params)
+        filters["user_request"] = request.user.email
+        data = service.get_detailed_monitoring_status_v2(filters=filters)
+
+        return Response(data, status=200)
+
+
+class AnalysisDetailedMonitoringStatusViewV2(APIView):
+    permission_classes = [IsAuthenticated, ProjectAuthQueryParamPermission]
+    feature_flag_key = "human-support-detailed-monitoring"
+
+    def get(self, request, *args, **kwargs):
+        project_uuid = request.query_params.get("project_uuid")
+        if not project_uuid:
+            return Response({"detail": "project_uuid is required"}, status=400)
+
+        project = get_object_or_404(Project, uuid=project_uuid)
+        service = HumanSupportDashboardService(project=project)
+
+        filters = get_filters_from_query_params(request.query_params)
+        filters["user_request"] = request.user.email
+        data = service.get_analysis_detailed_monitoring_status_v2(filters=filters)
+
+        return Response(data, status=200)

--- a/insights/sources/chats/clients.py
+++ b/insights/sources/chats/clients.py
@@ -30,3 +30,14 @@ class ChatsRESTClient(InternalAuthentication):
             max_retries=3,
         )
         return response.json()
+
+    def get_status_by_agent(self, project_uuid: str, query_filters: dict) -> dict:
+        response = request_with_retry(
+            url=f"{self.base_url}/v2/internal/dashboard/{project_uuid}/custom-status-by-agent/",
+            headers=self.headers,
+            params=query_filters,
+            method="GET",
+            timeout=60,
+            max_retries=3,
+        )
+        return response.json()


### PR DESCRIPTION
### What

- Introduced **v2 API endpoints** for human support detailed monitoring under `insights/metrics/human_support/api/v2/`, adding three new views: `DetailedMonitoringAgentsViewV2`, `DetailedMonitoringStatusViewV2`, and `AnalysisDetailedMonitoringStatusViewV2`.
- Added new methods to `ChatsRESTClient` (`get_agents` and `get_status_by_agent`) that call the Chats service's v2 internal dashboard endpoints (`/v2/internal/dashboard/{project}/agent/` and `/v2/internal/dashboard/{project}/custom-status-by-agent/`).
- Added corresponding service methods to `HumanSupportDashboardService`: `get_detailed_monitoring_agents_v2`, `get_detailed_monitoring_status_v2`, and `get_analysis_detailed_monitoring_status_v2`.
- Restructured the human support API directory from a flat layout (`metrics/human_support/urls.py`, `views.py`) into a versioned namespace (`api/v1/` and `api/v2/`).
- Removed deprecated conversations module code: agent invocation and tool result serializers, datalake services/dataclasses, mock services, and their associated tests.
- Simplified `UserProjectsView` by removing the `name` query parameter filter.
- Added unit tests for the new v2 service methods covering basic calls and ordering/pagination.

### Why

The v1 agents and status endpoints fetch raw data and handle pagination locally (in-memory with `LimitOffsetPagination`), which doesn't scale well and duplicates logic already available upstream. The v2 endpoints delegate pagination, filtering, and data aggregation to the Chats service via its v2 internal dashboard API, resulting in a cleaner architecture with server-side pagination and reduced processing in the insights engine. The deprecated conversations code (agent invocation, tool results, datalake integrations) was no longer in use and was removed to reduce maintenance surface.

### Sequence diagram

```mermaid
sequenceDiagram
    participant Client
    participant V2View as V2 API View
    participant Service as HumanSupportDashboardService
    participant ChatsClient as ChatsRESTClient
    participant ChatsAPI as Chats Service (external)

    Client->>V2View: GET /v2/human-support/detailed-monitoring/agents/<br>?project_uuid=...&filters
    V2View->>V2View: Authenticate & validate project_uuid
    V2View->>Service: get_detailed_monitoring_agents_v2(filters)
    Service->>Service: Build query params from filters
    Service->>ChatsClient: get_agents(project_uuid, params)
    ChatsClient->>ChatsAPI: GET /v2/internal/dashboard/{project}/agent/<br>?params (server-side pagination)
    ChatsAPI-->>ChatsClient: Paginated JSON response
    ChatsClient-->>Service: Raw response dict
    Service->>Service: Format results (agent, status, metrics)
    Service-->>V2View: Formatted paginated dict
    V2View-->>Client: 200 OK with paginated data

    Client->>V2View: GET /v2/human-support/detailed-monitoring/status/<br>?project_uuid=...&filters
    V2View->>Service: get_detailed_monitoring_status_v2(filters)
    Service->>Service: Normalize filters & build params
    Service->>ChatsClient: get_status_by_agent(project_uuid, params)
    ChatsClient->>ChatsAPI: GET /v2/internal/dashboard/{project}/custom-status-by-agent/
    ChatsAPI-->>ChatsClient: Paginated JSON response
    ChatsClient-->>Service: Raw response dict
    Service-->>V2View: Response dict (passthrough)
    V2View-->>Client: 200 OK with status data
```