### PR TITLE
feat: data source service

### DIFF
--- a/insights/dashboards/tests/test_viewsets/test_dashboard_viewset.py
+++ b/insights/dashboards/tests/test_viewsets/test_dashboard_viewset.py
@@ -374,7 +374,8 @@ class TestDashboardViewSetAsAuthenticatedUser(BaseTestDashboardViewSet):
 
     @with_project_auth
     @patch("insights.dashboards.viewsets.get_source_data_from_widget")
-    def test_get_widget_data(self, mock_get_source_data):
+    @patch("insights.dashboards.viewsets.is_feature_active_for_attributes", return_value=False)
+    def test_get_widget_data(self, mock_feature_flag, mock_get_source_data):
         dashboard = Dashboard.objects.create(
             name="Test Dashboard", project=self.project
         )

--- a/insights/dashboards/tests/test_viewsets/test_dashboard_viewset.py
+++ b/insights/dashboards/tests/test_viewsets/test_dashboard_viewset.py
@@ -402,6 +402,97 @@ class TestDashboardViewSetAsAuthenticatedUser(BaseTestDashboardViewSet):
         )
 
     @with_project_auth
+    @patch("insights.dashboards.viewsets.DataSourceService")
+    @patch("insights.dashboards.viewsets.is_feature_active_for_attributes", return_value=True)
+    def test_get_widget_data_with_feature_flag_enabled(
+        self, mock_feature_flag, MockDataSourceService
+    ):
+        dashboard = Dashboard.objects.create(
+            name="Test Dashboard", project=self.project
+        )
+        widget = Widget.objects.create(
+            dashboard=dashboard,
+            name="Widget 1",
+            source="TestSource",
+            type="TestType",
+            config={},
+            position={},
+        )
+        mock_service = MockDataSourceService.return_value
+        mock_service.get_source_data_from_widget.return_value = {
+            "data": "service_data",
+        }
+
+        response = self.get_widget_data(str(dashboard.uuid), str(widget.uuid))
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data, {"data": "service_data"})
+        mock_service.get_source_data_from_widget.assert_called_once_with(
+            widget=widget,
+            is_report=False,
+            is_live=False,
+            filters={},
+            user_email=self.user.email,
+        )
+
+    @with_project_auth
+    @patch("insights.dashboards.viewsets.get_source_data_from_widget")
+    @patch("insights.dashboards.viewsets.is_feature_active_for_attributes", return_value=False)
+    def test_get_widget_data_feature_flag_disabled_uses_legacy(
+        self, mock_feature_flag, mock_get_source_data
+    ):
+        dashboard = Dashboard.objects.create(
+            name="Test Dashboard", project=self.project
+        )
+        widget = Widget.objects.create(
+            dashboard=dashboard,
+            name="Widget 1",
+            source="TestSource",
+            type="TestType",
+            config={},
+            position={},
+        )
+        mock_get_source_data.return_value = {"data": "legacy_data"}
+
+        response = self.get_widget_data(str(dashboard.uuid), str(widget.uuid))
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data, {"data": "legacy_data"})
+        mock_feature_flag.assert_called_once()
+        mock_get_source_data.assert_called_once()
+
+    @with_project_auth
+    @patch("insights.dashboards.viewsets.is_feature_active_for_attributes", return_value=True)
+    def test_get_widget_data_feature_flag_passes_correct_attributes(
+        self, mock_feature_flag
+    ):
+        dashboard = Dashboard.objects.create(
+            name="Test Dashboard", project=self.project
+        )
+        widget = Widget.objects.create(
+            dashboard=dashboard,
+            name="Widget 1",
+            source="TestSource",
+            type="TestType",
+            config={},
+            position={},
+        )
+
+        with patch(
+            "insights.dashboards.viewsets.DataSourceService"
+        ) as MockService:
+            mock_service = MockService.return_value
+            mock_service.get_source_data_from_widget.return_value = {}
+
+            self.get_widget_data(str(dashboard.uuid), str(widget.uuid))
+
+        mock_feature_flag.assert_called_once()
+        call_kwargs = mock_feature_flag.call_args
+        attributes = call_kwargs[1]["attributes"]
+        self.assertEqual(attributes["projectUUID"], str(self.project.uuid))
+        self.assertEqual(attributes["userEmail"], self.user.email)
+
+    @with_project_auth
     def test_get_widget_report(self):
         dashboard = Dashboard.objects.create(
             name="Test Dashboard", project=self.project
@@ -455,7 +546,8 @@ class TestDashboardViewSetAsAuthenticatedUser(BaseTestDashboardViewSet):
 
     @with_project_auth
     @patch("insights.dashboards.viewsets.get_source_data_from_widget")
-    def test_get_report_data(self, mock_get_source_data):
+    @patch("insights.dashboards.viewsets.is_feature_active_for_attributes", return_value=False)
+    def test_get_report_data(self, mock_feature_flag, mock_get_source_data):
         dashboard = Dashboard.objects.create(
             name="Test Dashboard", project=self.project
         )

--- a/insights/dashboards/viewsets.py
+++ b/insights/dashboards/viewsets.py
@@ -244,6 +244,7 @@ class DashboardViewSet(
                     )
                 )
             else:
+                # TODO: Remove this once the data source service is rolled out to all projects
                 serialized_source = get_source_data_from_widget(
                     widget=widget,
                     is_report=False,
@@ -293,13 +294,37 @@ class DashboardViewSet(
             filters = dict(request.data or request.query_params or {})
             filters.pop("project", None)
             is_live = filters.pop("is_live", False)
-            serialized_source = get_source_data_from_widget(
-                widget=widget,
-                is_report=True,
-                filters=filters,
-                user_email=request.user.email,
-                is_live=is_live,
-            )
+
+            project = dashboard.project
+
+            feature_flag_attributes = {
+                "projectUUID": str(project.uuid),
+                "userEmail": request.user.email,
+            }
+
+            if is_feature_active_for_attributes(
+                settings.DATA_SOURCE_SERVICE_FEATURE_FLAG_KEY,
+                attributes=feature_flag_attributes,
+            ):
+                serialized_source = (
+                    self.source_data_service.get_source_data_from_widget(
+                        widget=widget,
+                        is_report=True,
+                        filters=filters,
+                        user_email=request.user.email,
+                        is_live=is_live,
+                    )
+                )
+            else:
+                # TODO: Remove this once the data source service is rolled out to all projects
+                serialized_source = get_source_data_from_widget(
+                    widget=widget,
+                    is_report=True,
+                    filters=filters,
+                    user_email=request.user.email,
+                    is_live=is_live,
+                )
+
             return Response(serialized_source, status.HTTP_200_OK)
         except PermissionDenied:
             raise

--- a/insights/dashboards/viewsets.py
+++ b/insights/dashboards/viewsets.py
@@ -10,6 +10,7 @@ from rest_framework.exceptions import PermissionDenied
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from django.shortcuts import get_object_or_404
+from weni.feature_flags.shortcuts import is_feature_active_for_attributes
 
 from insights.authentication.permissions import ProjectAuthPermission
 from insights.dashboards.filters import DashboardFilter
@@ -33,6 +34,7 @@ from insights.projects.tasks import (
 from insights.projects.usecases.dashboard_dto import FlowsDashboardCreationDTO
 from insights.sources.contacts.clients import FlowsContactsRestClient
 from insights.sources.custom_status.client import CustomStatusRESTClient
+from insights.sources.services import DataSourceService
 from insights.widgets.models import Report, Widget
 from insights.widgets.usecases.get_source_data import (
     get_source_data_from_widget,
@@ -61,6 +63,10 @@ class DashboardViewSet(
 
     filter_backends = [DjangoFilterBackend]
     filterset_class = DashboardFilter
+
+    @property
+    def source_data_service(self):
+        return DataSourceService()
 
     def get_permissions(self):
         if self.action in [
@@ -216,13 +222,36 @@ class DashboardViewSet(
             filters = dict(request.data or request.query_params or {})
             filters.pop("project", None)
             is_live = filters.pop("is_live", False)
-            serialized_source = get_source_data_from_widget(
-                widget=widget,
-                is_report=False,
-                is_live=is_live,
-                filters=filters,
-                user_email=request.user.email,
-            )
+
+            project = dashboard.project
+
+            feature_flag_attributes = {
+                "projectUUID": str(project.uuid),
+                "userEmail": request.user.email,
+            }
+
+            if is_feature_active_for_attributes(
+                settings.DATA_SOURCE_SERVICE_FEATURE_FLAG_KEY,
+                attributes=feature_flag_attributes,
+            ):
+                serialized_source = (
+                    self.source_data_service.get_source_data_from_widget(
+                        widget=widget,
+                        is_report=False,
+                        is_live=is_live,
+                        filters=filters,
+                        user_email=request.user.email,
+                    )
+                )
+            else:
+                serialized_source = get_source_data_from_widget(
+                    widget=widget,
+                    is_report=False,
+                    is_live=is_live,
+                    filters=filters,
+                    user_email=request.user.email,
+                )
+
             return Response(serialized_source, status.HTTP_200_OK)
         except PermissionDenied:
             raise

--- a/insights/settings.py
+++ b/insights/settings.py
@@ -545,5 +545,5 @@ VTEX_ORDERS_API_CACHE_TTL = env.int("VTEX_ORDERS_API_CACHE_TTL", default=60 * 60
 
 # Data source service
 DATA_SOURCE_SERVICE_FEATURE_FLAG_KEY = env.str(
-    "DATA_SOURCE_SERVICE_FEATURE_FLAG_KEY", default="data_source_service"
+    "DATA_SOURCE_SERVICE_FEATURE_FLAG_KEY", default="insightsDataSourceService"
 )

--- a/insights/settings.py
+++ b/insights/settings.py
@@ -542,3 +542,8 @@ ABANDONED_CART_MAX_TEMPLATE_IDS = env.int("ABANDONED_CART_MAX_TEMPLATE_IDS", def
 
 # VTEX Orders API Cache TTL
 VTEX_ORDERS_API_CACHE_TTL = env.int("VTEX_ORDERS_API_CACHE_TTL", default=60 * 60)
+
+# Data source service
+DATA_SOURCE_SERVICE_FEATURE_FLAG_KEY = env.str(
+    "DATA_SOURCE_SERVICE_FEATURE_FLAG_KEY", default="data_source_service"
+)

--- a/insights/sources/agents/usecases/query_execute.py
+++ b/insights/sources/agents/usecases/query_execute.py
@@ -5,11 +5,14 @@ from insights.sources.agents.clients import (
 )
 from insights.sources.agents.filtersets import AgentFilterSet
 from insights.sources.agents.query_builder import AgentSQLQueryBuilder
+from insights.sources.base import BaseQueryExecutor
 from insights.sources.filter_strategies import PostgreSQLFilterStrategy
 
 
-class QueryExecutor:
+class QueryExecutor(BaseQueryExecutor):
+    @classmethod
     def execute(
+        cls,
         filters: dict,
         operation: str,
         parser: callable,

--- a/insights/sources/base.py
+++ b/insights/sources/base.py
@@ -1,0 +1,12 @@
+from abc import ABC, abstractmethod
+
+
+class BaseQueryExecutor(ABC):
+    """
+    Base class for query executors
+    """
+
+    @classmethod
+    @abstractmethod
+    def execute(cls, *args, **kwargs):
+        raise NotImplementedError("Subclasses must implement this method")

--- a/insights/sources/chat_completion/usecases/query_execute.py
+++ b/insights/sources/chat_completion/usecases/query_execute.py
@@ -1,8 +1,11 @@
+from insights.sources.base import BaseQueryExecutor
 from insights.sources.chat_completion.clients import ChatCompletionClient
 
 
-class QueryExecutor:
+class QueryExecutor(BaseQueryExecutor):
+    @classmethod
     def execute(
+        cls,
         filters: dict,
         operation: str,
         parser: callable,

--- a/insights/sources/factories.py
+++ b/insights/sources/factories.py
@@ -1,0 +1,40 @@
+from abc import ABC, abstractmethod
+from typing import Type
+from django.utils.module_loading import import_string
+
+import logging
+
+from insights.sources.base import BaseQueryExecutor
+
+logger = logging.getLogger(__name__)
+
+
+class BaseSourceQueryExecutorFactory(ABC):
+    """
+    Base class for source query executor factories
+    """
+
+    @abstractmethod
+    @classmethod
+    def get_source_query_executor(cls, source_name: str) -> Type[BaseQueryExecutor]:
+        raise NotImplementedError("Subclasses must implement this method")
+
+
+class SourceQueryExecutorFactory(BaseSourceQueryExecutorFactory):
+    """
+    Factory for source query executors
+    """
+
+    @classmethod
+    def get_source_query_executor(cls, source_name: str) -> Type[BaseQueryExecutor]:
+        try:
+            source_path = (
+                f"insights.sources.{source_name}.usecases.query_execute.QueryExecutor"
+            )
+            return import_string(source_path)
+        except (ModuleNotFoundError, ImportError, AttributeError) as e:
+            logger.warning(f"Source '{source_name}' not available: {e}")
+            return None
+        except Exception as e:
+            logger.error(f"Unexpected error loading source '{source_name}': {e}")
+            return None

--- a/insights/sources/factories.py
+++ b/insights/sources/factories.py
@@ -14,8 +14,8 @@ class BaseSourceQueryExecutorFactory(ABC):
     Base class for source query executor factories
     """
 
-    @abstractmethod
     @classmethod
+    @abstractmethod
     def get_source_query_executor(cls, source_name: str) -> Type[BaseQueryExecutor]:
         raise NotImplementedError("Subclasses must implement this method")
 

--- a/insights/sources/flowruns/usecases/query_execute.py
+++ b/insights/sources/flowruns/usecases/query_execute.py
@@ -1,4 +1,5 @@
 from insights.db.elasticsearch.connection import Connection
+from insights.sources.base import BaseQueryExecutor
 from insights.sources.filter_strategies import ElasticSearchFilterStrategy
 from insights.sources.flowruns.clients import (
     FlowRunElasticSearchQueryGenerator,
@@ -31,8 +32,10 @@ def transform_results_data(
     return transformed_results
 
 
-class QueryExecutor:
+class QueryExecutor(BaseQueryExecutor):
+    @classmethod
     def execute(
+        cls,
         filters: dict,
         operation: str,
         parser: callable,

--- a/insights/sources/flows/usecases/query_execute.py
+++ b/insights/sources/flows/usecases/query_execute.py
@@ -2,11 +2,14 @@ from insights.db.postgres.psycopg.connection import get_cursor
 from insights.sources.filter_strategies import PostgreSQLFilterStrategy
 from insights.sources.flows.clients import FlowSQLQueryGenerator
 from insights.sources.flows.filtersets import FlowFilterSet
+from insights.sources.base import BaseQueryExecutor
 from insights.sources.flows.query_builder import FlowSQLQueryBuilder
 
 
-class QueryExecutor:
+class QueryExecutor(BaseQueryExecutor):
+    @classmethod
     def execute(
+        cls,
         filters: dict,
         operation: str,
         parser: callable,

--- a/insights/sources/orders/usecases/query_execute.py
+++ b/insights/sources/orders/usecases/query_execute.py
@@ -1,9 +1,12 @@
+from insights.sources.base import BaseQueryExecutor
 from insights.sources.orders.clients import VtexOrdersRestClient
 from insights.sources.cache import CacheClient
 
 
-class QueryExecutor:
+class QueryExecutor(BaseQueryExecutor):
+    @classmethod
     def execute(
+        cls,
         filters: dict,
         operation: str,
         parser: callable,

--- a/insights/sources/queues/usecases/query_execute.py
+++ b/insights/sources/queues/usecases/query_execute.py
@@ -2,11 +2,14 @@ from insights.db.postgres.django.connection import dictfetchall, get_cursor
 from insights.sources.filter_strategies import PostgreSQLFilterStrategy
 from insights.sources.queues.clients import QueueSQLQueryGenerator
 from insights.sources.queues.filtersets import QueueFilterSet
+from insights.sources.base import BaseQueryExecutor
 from insights.sources.queues.query_builder import QueueSQLQueryBuilder
 
 
-class QueryExecutor:
+class QueryExecutor(BaseQueryExecutor):
+    @classmethod
     def execute(
+        cls,
         filters: dict,
         operation: str,
         parser: callable,

--- a/insights/sources/rooms/usecases/query_execute.py
+++ b/insights/sources/rooms/usecases/query_execute.py
@@ -9,11 +9,14 @@ from insights.sources.rooms.clients import (
     RoomSQLQueryGenerator,
 )
 from insights.sources.rooms.filtersets import RoomFilterSet
+from insights.sources.base import BaseQueryExecutor
 from insights.sources.rooms.query_builder import RoomSQLQueryBuilder
 
 
-class QueryExecutor:
+class QueryExecutor(BaseQueryExecutor):
+    @classmethod
     def execute(
+        cls,
         filters: dict,
         operation: str,
         parser: callable,

--- a/insights/sources/sectors/usecases/query_execute.py
+++ b/insights/sources/sectors/usecases/query_execute.py
@@ -2,11 +2,14 @@ from insights.db.postgres.django.connection import dictfetchall, get_cursor
 from insights.sources.filter_strategies import PostgreSQLFilterStrategy
 from insights.sources.sectors.clients import SectorSQLQueryGenerator
 from insights.sources.sectors.filtersets import SectorFilterSet
+from insights.sources.base import BaseQueryExecutor
 from insights.sources.sectors.query_builder import SectorSQLQueryBuilder
 
 
-class QueryExecutor:
+class QueryExecutor(BaseQueryExecutor):
+    @classmethod
     def execute(
+        cls,
         filters: dict,
         operation: str,
         parser: callable,

--- a/insights/sources/services.py
+++ b/insights/sources/services.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import Type
+from typing import Optional, Type
 
 from django.core.exceptions import ObjectDoesNotExist
 from rest_framework.exceptions import PermissionDenied
@@ -44,7 +44,9 @@ class DataSourceService(BaseDataSourceService):
 
     def __init__(
         self,
-        source_query_executor_factory: SourceQueryExecutorFactory = SourceQueryExecutorFactory(),
+        source_query_executor_factory: Type[
+            SourceQueryExecutorFactory
+        ] = SourceQueryExecutorFactory,
     ):
         self.source_query_executor_factory = source_query_executor_factory
 
@@ -102,9 +104,10 @@ class DataSourceService(BaseDataSourceService):
         widget: Widget,
         is_report: bool = False,
         is_live: bool = False,
-        filters: dict = {},
+        filters: Optional[dict] = None,
         user_email: str = "",
     ):
+        filters = filters or {}
         try:
             source = widget.source
             if is_report:

--- a/insights/sources/services.py
+++ b/insights/sources/services.py
@@ -113,7 +113,7 @@ class DataSourceService(BaseDataSourceService):
             if is_report:
                 widget = widget.report
 
-            source_query_executor = self.get_source_query_executor(source.slug)
+            source_query_executor = self.get_source_query_executor(source)
             if source_query_executor is None:
                 raise Exception(
                     f"could not find a source with the slug {source}, make sure that the widget is configured with a supported source"

--- a/insights/sources/services.py
+++ b/insights/sources/services.py
@@ -1,9 +1,19 @@
 from abc import ABC, abstractmethod
 from typing import Type
 
+from django.core.exceptions import ObjectDoesNotExist
+from rest_framework.exceptions import PermissionDenied
+
+from insights.authentication.services.jwt_service import JWTService
+from insights.projects.parsers import parse_dict_to_json
 from insights.sources.base import BaseQueryExecutor
 from insights.sources.factories import SourceQueryExecutorFactory
+from insights.sources.vtexcredentials.exceptions import VtexCredentialsNotFound
 from insights.widgets.models import Widget
+from insights.widgets.usecases.get_source_data import (
+    cross_source_data_operation,
+    simple_source_data_operation,
+)
 
 
 class BaseDataSourceService(ABC):
@@ -49,5 +59,72 @@ class DataSourceService(BaseDataSourceService):
         filters: dict = {},
         user_email: str = "",
     ):
-        source_query_executor = self.get_source_query_executor(widget.source.slug)
-        # TODO: Implement the logic to get the source data from the widget
+        try:
+            source = widget.source
+            if is_report:
+                widget = widget.report
+
+            source_query_executor = self.get_source_query_executor(source.slug)
+            if source_query_executor is None:
+                raise Exception(
+                    f"could not find a source with the slug {source}, make sure that the widget is configured with a supported source"
+                )
+
+            serialized_auth = {}
+            if widget.type == "vtex_order":
+                if widget.project.vtex_account:
+                    serialized_auth = {
+                        "domain": widget.project.vtex_account,
+                        "internal_token": JWTService().generate_jwt_token(
+                            vtex_account=widget.project.vtex_account
+                        ),
+                    }
+                else:
+                    auth_source = self.get_source_query_executor("vtexcredentials")
+                    try:
+                        serialized_auth: dict = auth_source.execute(
+                            filters={"project": widget.project.uuid},
+                            operation="get_vtex_auth",
+                            parser=parse_dict_to_json,
+                            return_format="",
+                            query_kwargs={},
+                        )
+                    except VtexCredentialsNotFound:
+                        raise PermissionDenied(
+                            detail="VTEX credentials not configured for this project. Please configure the VTEX integration first."
+                        )
+
+            operation_function = (
+                cross_source_data_operation
+                if widget.is_crossing_data
+                else simple_source_data_operation
+            )
+
+            extra_query_kwargs = {}
+
+            if (
+                widget.name == "human_service_dashboard.peaks_in_human_service"
+                and is_report is False
+            ):
+                extra_query_kwargs["timeseries_hour_kwargs"] = {
+                    "start_hour": 7,
+                    "end_hour": 18,
+                }
+
+            return operation_function(
+                widget=widget,
+                source_query=source_query_executor,
+                is_live=is_live,
+                filters=filters,
+                user_email=user_email,
+                auth_params=serialized_auth,
+                extra_query_kwargs=extra_query_kwargs,
+            )
+
+        except ObjectDoesNotExist:
+            raise Exception("Widget not found.")
+
+        except KeyError:
+            raise Exception(
+                "The subwidgets operation needs to be one that returns only one object value."
+            )

--- a/insights/sources/services.py
+++ b/insights/sources/services.py
@@ -1,0 +1,53 @@
+from abc import ABC, abstractmethod
+from typing import Type
+
+from insights.sources.base import BaseQueryExecutor
+from insights.sources.factories import SourceQueryExecutorFactory
+from insights.widgets.models import Widget
+
+
+class BaseDataSourceService(ABC):
+    """
+    Base class for data source services
+    """
+
+    @abstractmethod
+    def get_source_query_executor(self, source_name: str):
+        raise NotImplementedError("Subclasses must implement this method")
+
+    @abstractmethod
+    def get_source_data_from_widget(
+        self,
+        widget: Widget,
+        is_report: bool = False,
+        is_live: bool = False,
+        filters: dict = {},
+        user_email: str = "",
+    ):
+        raise NotImplementedError("Subclasses must implement this method")
+
+
+class DataSourceService(BaseDataSourceService):
+    """
+    Data source service
+    """
+
+    def __init__(
+        self,
+        source_query_executor_factory: SourceQueryExecutorFactory = SourceQueryExecutorFactory(),
+    ):
+        self.source_query_executor_factory = source_query_executor_factory
+
+    def get_source_query_executor(self, source_name: str) -> Type[BaseQueryExecutor]:
+        return self.source_query_executor_factory.get_source_query_executor(source_name)
+
+    def get_source_data_from_widget(
+        self,
+        widget: Widget,
+        is_report: bool = False,
+        is_live: bool = False,
+        filters: dict = {},
+        user_email: str = "",
+    ):
+        source_query_executor = self.get_source_query_executor(widget.source.slug)
+        # TODO: Implement the logic to get the source data from the widget

--- a/insights/sources/services.py
+++ b/insights/sources/services.py
@@ -51,6 +51,52 @@ class DataSourceService(BaseDataSourceService):
     def get_source_query_executor(self, source_name: str) -> Type[BaseQueryExecutor]:
         return self.source_query_executor_factory.get_source_query_executor(source_name)
 
+    def _handle_serialized_auth(self, widget: Widget) -> dict:
+        """
+        Handle the serialized authentication for the widget
+        """
+        if widget.type != "vtex_order":
+            return {}
+
+        if widget.project.vtex_account:
+            return {
+                "domain": widget.project.vtex_account,
+                "internal_token": JWTService().generate_jwt_token(
+                    vtex_account=widget.project.vtex_account
+                ),
+            }
+
+        auth_source = self.get_source_query_executor("vtexcredentials")
+        try:
+            return auth_source.execute(
+                filters={"project": widget.project.uuid},
+                operation="get_vtex_auth",
+                parser=parse_dict_to_json,
+                return_format="",
+                query_kwargs={},
+            )
+        except VtexCredentialsNotFound:
+            raise PermissionDenied(
+                detail="VTEX credentials not configured for this project. Please configure the VTEX integration first."
+            )
+
+    def _get_extra_query_kwargs(self, widget: Widget, is_report: bool) -> dict:
+        """
+        Handle extra query keyword arguments based on the widget configuration
+        """
+        extra_query_kwargs = {}
+
+        if (
+            widget.name == "human_service_dashboard.peaks_in_human_service"
+            and is_report is False
+        ):
+            extra_query_kwargs["timeseries_hour_kwargs"] = {
+                "start_hour": 7,
+                "end_hour": 18,
+            }
+
+        return extra_query_kwargs
+
     def get_source_data_from_widget(
         self,
         widget: Widget,
@@ -70,29 +116,7 @@ class DataSourceService(BaseDataSourceService):
                     f"could not find a source with the slug {source}, make sure that the widget is configured with a supported source"
                 )
 
-            serialized_auth = {}
-            if widget.type == "vtex_order":
-                if widget.project.vtex_account:
-                    serialized_auth = {
-                        "domain": widget.project.vtex_account,
-                        "internal_token": JWTService().generate_jwt_token(
-                            vtex_account=widget.project.vtex_account
-                        ),
-                    }
-                else:
-                    auth_source = self.get_source_query_executor("vtexcredentials")
-                    try:
-                        serialized_auth: dict = auth_source.execute(
-                            filters={"project": widget.project.uuid},
-                            operation="get_vtex_auth",
-                            parser=parse_dict_to_json,
-                            return_format="",
-                            query_kwargs={},
-                        )
-                    except VtexCredentialsNotFound:
-                        raise PermissionDenied(
-                            detail="VTEX credentials not configured for this project. Please configure the VTEX integration first."
-                        )
+            serialized_auth = self._handle_serialized_auth(widget)
 
             operation_function = (
                 cross_source_data_operation
@@ -100,16 +124,7 @@ class DataSourceService(BaseDataSourceService):
                 else simple_source_data_operation
             )
 
-            extra_query_kwargs = {}
-
-            if (
-                widget.name == "human_service_dashboard.peaks_in_human_service"
-                and is_report is False
-            ):
-                extra_query_kwargs["timeseries_hour_kwargs"] = {
-                    "start_hour": 7,
-                    "end_hour": 18,
-                }
+            extra_query_kwargs = self._get_extra_query_kwargs(widget, is_report)
 
             return operation_function(
                 widget=widget,

--- a/insights/sources/tags/usecases/query_execute.py
+++ b/insights/sources/tags/usecases/query_execute.py
@@ -2,11 +2,14 @@ from insights.db.postgres.django.connection import dictfetchall, get_cursor
 from insights.sources.filter_strategies import PostgreSQLFilterStrategy
 from insights.sources.tags.clients import TagSQLQueryGenerator
 from insights.sources.tags.filtersets import TagFilterSet
+from insights.sources.base import BaseQueryExecutor
 from insights.sources.tags.query_builder import TagSQLQueryBuilder
 
 
-class QueryExecutor:
+class QueryExecutor(BaseQueryExecutor):
+    @classmethod
     def execute(
+        cls,
         filters: dict,
         operation: str,
         parser: callable,

--- a/insights/sources/tests/test_base.py
+++ b/insights/sources/tests/test_base.py
@@ -1,0 +1,31 @@
+from django.test import TestCase
+
+from insights.sources.base import BaseQueryExecutor
+
+
+class ConcreteQueryExecutor(BaseQueryExecutor):
+    @classmethod
+    def execute(cls, *args, **kwargs):
+        return {"executed": True}
+
+
+class TestBaseQueryExecutor(TestCase):
+    def test_cannot_instantiate_abstract_class(self):
+        with self.assertRaises(TypeError):
+            BaseQueryExecutor()
+
+    def test_concrete_subclass_can_be_instantiated(self):
+        executor = ConcreteQueryExecutor()
+        self.assertIsInstance(executor, BaseQueryExecutor)
+
+    def test_concrete_subclass_execute_returns_expected(self):
+        result = ConcreteQueryExecutor.execute()
+        self.assertEqual(result, {"executed": True})
+
+    def test_incomplete_subclass_raises_type_error(self):
+        with self.assertRaises(TypeError):
+
+            class IncompleteExecutor(BaseQueryExecutor):
+                pass
+
+            IncompleteExecutor()

--- a/insights/sources/tests/test_factories.py
+++ b/insights/sources/tests/test_factories.py
@@ -1,0 +1,66 @@
+from unittest.mock import patch
+
+from django.test import TestCase
+
+from insights.sources.base import BaseQueryExecutor
+from insights.sources.factories import SourceQueryExecutorFactory
+
+
+class TestSourceQueryExecutorFactory(TestCase):
+    @patch("insights.sources.factories.import_string")
+    def test_returns_executor_for_valid_source(self, mock_import_string):
+        mock_executor = type("MockExecutor", (BaseQueryExecutor,), {
+            "execute": classmethod(lambda cls, *a, **kw: None),
+        })
+        mock_import_string.return_value = mock_executor
+
+        result = SourceQueryExecutorFactory.get_source_query_executor("rooms")
+
+        self.assertEqual(result, mock_executor)
+        mock_import_string.assert_called_once_with(
+            "insights.sources.rooms.usecases.query_execute.QueryExecutor"
+        )
+
+    @patch("insights.sources.factories.import_string")
+    def test_returns_none_for_nonexistent_source(self, mock_import_string):
+        mock_import_string.side_effect = ModuleNotFoundError("No module")
+
+        result = SourceQueryExecutorFactory.get_source_query_executor(
+            "nonexistent_source"
+        )
+
+        self.assertIsNone(result)
+
+    @patch("insights.sources.factories.import_string")
+    def test_returns_none_on_import_error(self, mock_import_string):
+        mock_import_string.side_effect = ImportError("Cannot import")
+
+        result = SourceQueryExecutorFactory.get_source_query_executor("bad_source")
+
+        self.assertIsNone(result)
+
+    @patch("insights.sources.factories.import_string")
+    def test_returns_none_on_attribute_error(self, mock_import_string):
+        mock_import_string.side_effect = AttributeError("No attribute")
+
+        result = SourceQueryExecutorFactory.get_source_query_executor("bad_source")
+
+        self.assertIsNone(result)
+
+    @patch("insights.sources.factories.import_string")
+    def test_returns_none_on_unexpected_error(self, mock_import_string):
+        mock_import_string.side_effect = RuntimeError("Something went wrong")
+
+        result = SourceQueryExecutorFactory.get_source_query_executor("broken_source")
+
+        self.assertIsNone(result)
+
+    @patch("insights.sources.factories.import_string")
+    def test_constructs_correct_import_path(self, mock_import_string):
+        mock_import_string.return_value = object()
+
+        SourceQueryExecutorFactory.get_source_query_executor("vtex_conversions")
+
+        mock_import_string.assert_called_once_with(
+            "insights.sources.vtex_conversions.usecases.query_execute.QueryExecutor"
+        )

--- a/insights/sources/tests/test_services.py
+++ b/insights/sources/tests/test_services.py
@@ -1,0 +1,278 @@
+import uuid
+from unittest.mock import MagicMock, patch
+
+from django.test import TestCase
+from rest_framework.exceptions import PermissionDenied
+
+from insights.sources.base import BaseQueryExecutor
+from insights.sources.services import DataSourceService
+from insights.sources.vtexcredentials.exceptions import VtexCredentialsNotFound
+
+
+class FakeQueryExecutor(BaseQueryExecutor):
+    @classmethod
+    def execute(cls, *args, **kwargs):
+        return {"result": "data"}
+
+
+def _make_widget(
+    widget_type="default",
+    source_slug="rooms",
+    widget_name="test_widget",
+    vtex_account=None,
+    is_crossing_data=False,
+):
+    project = MagicMock()
+    project.uuid = uuid.uuid4()
+    project.vtex_account = vtex_account
+    project.timezone = "America/Sao_Paulo"
+
+    source = MagicMock()
+    source.slug = source_slug
+
+    widget = MagicMock()
+    widget.type = widget_type
+    widget.name = widget_name
+    widget.source = source
+    widget.project = project
+    widget.is_crossing_data = is_crossing_data
+    widget.config = {}
+
+    return widget
+
+
+class TestDataSourceServiceGetSourceQueryExecutor(TestCase):
+    def test_delegates_to_factory(self):
+        mock_factory = MagicMock()
+        mock_factory.get_source_query_executor.return_value = FakeQueryExecutor
+
+        service = DataSourceService(source_query_executor_factory=mock_factory)
+        result = service.get_source_query_executor("rooms")
+
+        self.assertEqual(result, FakeQueryExecutor)
+        mock_factory.get_source_query_executor.assert_called_once_with("rooms")
+
+
+class TestDataSourceServiceHandleSerializedAuth(TestCase):
+    def test_returns_empty_dict_for_non_vtex_widget(self):
+        service = DataSourceService()
+        widget = _make_widget(widget_type="default")
+
+        result = service._handle_serialized_auth(widget)
+
+        self.assertEqual(result, {})
+
+    @patch("insights.sources.services.JWTService")
+    def test_returns_auth_with_vtex_account(self, MockJWTService):
+        mock_jwt = MockJWTService.return_value
+        mock_jwt.generate_jwt_token.return_value = "test-jwt-token"
+
+        service = DataSourceService()
+        widget = _make_widget(
+            widget_type="vtex_order",
+            vtex_account="my-vtex-store",
+        )
+
+        result = service._handle_serialized_auth(widget)
+
+        self.assertEqual(result["domain"], "my-vtex-store")
+        self.assertEqual(result["internal_token"], "test-jwt-token")
+        mock_jwt.generate_jwt_token.assert_called_once_with(
+            vtex_account="my-vtex-store"
+        )
+
+    def test_falls_back_to_vtexcredentials_executor(self):
+        mock_auth_executor = MagicMock()
+        mock_auth_executor.execute.return_value = {
+            "domain": "store-from-creds",
+            "internal_token": "creds-token",
+        }
+
+        mock_factory = MagicMock()
+        mock_factory.get_source_query_executor.return_value = mock_auth_executor
+
+        service = DataSourceService(source_query_executor_factory=mock_factory)
+        widget = _make_widget(widget_type="vtex_order", vtex_account=None)
+
+        result = service._handle_serialized_auth(widget)
+
+        self.assertEqual(result["domain"], "store-from-creds")
+        mock_factory.get_source_query_executor.assert_called_with("vtexcredentials")
+
+    def test_raises_permission_denied_when_credentials_not_found(self):
+        mock_auth_executor = MagicMock()
+        mock_auth_executor.execute.side_effect = VtexCredentialsNotFound()
+
+        mock_factory = MagicMock()
+        mock_factory.get_source_query_executor.return_value = mock_auth_executor
+
+        service = DataSourceService(source_query_executor_factory=mock_factory)
+        widget = _make_widget(widget_type="vtex_order", vtex_account=None)
+
+        with self.assertRaises(PermissionDenied):
+            service._handle_serialized_auth(widget)
+
+
+class TestDataSourceServiceGetExtraQueryKwargs(TestCase):
+    def test_returns_timeseries_kwargs_for_peaks_widget(self):
+        service = DataSourceService()
+        widget = _make_widget(
+            widget_name="human_service_dashboard.peaks_in_human_service"
+        )
+
+        result = service._get_extra_query_kwargs(widget, is_report=False)
+
+        self.assertEqual(
+            result["timeseries_hour_kwargs"],
+            {"start_hour": 7, "end_hour": 18},
+        )
+
+    def test_returns_empty_dict_for_peaks_widget_as_report(self):
+        service = DataSourceService()
+        widget = _make_widget(
+            widget_name="human_service_dashboard.peaks_in_human_service"
+        )
+
+        result = service._get_extra_query_kwargs(widget, is_report=True)
+
+        self.assertEqual(result, {})
+
+    def test_returns_empty_dict_for_other_widgets(self):
+        service = DataSourceService()
+        widget = _make_widget(widget_name="some_other_widget")
+
+        result = service._get_extra_query_kwargs(widget, is_report=False)
+
+        self.assertEqual(result, {})
+
+
+class TestDataSourceServiceGetSourceDataFromWidget(TestCase):
+    @patch("insights.sources.services.simple_source_data_operation")
+    def test_calls_simple_operation_for_non_crossing_widget(self, mock_simple_op):
+        mock_simple_op.return_value = {"value": 42}
+
+        mock_factory = MagicMock()
+        mock_factory.get_source_query_executor.return_value = FakeQueryExecutor
+
+        service = DataSourceService(source_query_executor_factory=mock_factory)
+        widget = _make_widget(is_crossing_data=False)
+
+        result = service.get_source_data_from_widget(
+            widget=widget,
+            filters={"date__gte": "2025-01-01"},
+            user_email="test@test.com",
+        )
+
+        self.assertEqual(result, {"value": 42})
+        mock_simple_op.assert_called_once()
+        call_kwargs = mock_simple_op.call_args[1]
+        self.assertEqual(call_kwargs["source_query"], FakeQueryExecutor)
+        self.assertFalse(call_kwargs["is_live"])
+        self.assertEqual(call_kwargs["user_email"], "test@test.com")
+
+    @patch("insights.sources.services.cross_source_data_operation")
+    def test_calls_cross_operation_for_crossing_widget(self, mock_cross_op):
+        mock_cross_op.return_value = {"value": 50}
+
+        mock_factory = MagicMock()
+        mock_factory.get_source_query_executor.return_value = FakeQueryExecutor
+
+        service = DataSourceService(source_query_executor_factory=mock_factory)
+        widget = _make_widget(is_crossing_data=True)
+
+        result = service.get_source_data_from_widget(widget=widget)
+
+        self.assertEqual(result, {"value": 50})
+        mock_cross_op.assert_called_once()
+
+    @patch("insights.sources.services.simple_source_data_operation")
+    def test_uses_report_when_is_report_is_true(self, mock_simple_op):
+        mock_simple_op.return_value = {"value": 10}
+
+        mock_factory = MagicMock()
+        mock_factory.get_source_query_executor.return_value = FakeQueryExecutor
+
+        service = DataSourceService(source_query_executor_factory=mock_factory)
+        widget = _make_widget()
+        report_widget = MagicMock()
+        report_widget.type = "default"
+        report_widget.name = "report"
+        report_widget.is_crossing_data = False
+        report_widget.project = widget.project
+        widget.report = report_widget
+
+        result = service.get_source_data_from_widget(widget=widget, is_report=True)
+
+        self.assertEqual(result, {"value": 10})
+        call_kwargs = mock_simple_op.call_args[1]
+        self.assertEqual(call_kwargs["widget"], report_widget)
+
+    def test_raises_exception_when_source_not_found(self):
+        mock_factory = MagicMock()
+        mock_factory.get_source_query_executor.return_value = None
+
+        service = DataSourceService(source_query_executor_factory=mock_factory)
+        widget = _make_widget()
+
+        with self.assertRaises(Exception) as ctx:
+            service.get_source_data_from_widget(widget=widget)
+
+        self.assertIn("could not find a source", str(ctx.exception))
+
+    @patch("insights.sources.services.simple_source_data_operation")
+    def test_passes_vtex_auth_params(self, mock_simple_op):
+        mock_simple_op.return_value = {"orders": []}
+
+        mock_auth_executor = MagicMock()
+        mock_auth_executor.execute.return_value = {
+            "domain": "vtex-store",
+            "internal_token": "jwt-token",
+        }
+
+        mock_factory = MagicMock()
+        mock_factory.get_source_query_executor.side_effect = lambda name: (
+            mock_auth_executor if name == "vtexcredentials" else FakeQueryExecutor
+        )
+
+        service = DataSourceService(source_query_executor_factory=mock_factory)
+        widget = _make_widget(widget_type="vtex_order", vtex_account=None)
+
+        service.get_source_data_from_widget(widget=widget)
+
+        call_kwargs = mock_simple_op.call_args[1]
+        self.assertEqual(call_kwargs["auth_params"]["domain"], "vtex-store")
+
+    @patch("insights.sources.services.simple_source_data_operation")
+    def test_passes_extra_query_kwargs_for_peaks_widget(self, mock_simple_op):
+        mock_simple_op.return_value = {"results": []}
+
+        mock_factory = MagicMock()
+        mock_factory.get_source_query_executor.return_value = FakeQueryExecutor
+
+        service = DataSourceService(source_query_executor_factory=mock_factory)
+        widget = _make_widget(
+            widget_name="human_service_dashboard.peaks_in_human_service"
+        )
+
+        service.get_source_data_from_widget(widget=widget, is_report=False)
+
+        call_kwargs = mock_simple_op.call_args[1]
+        self.assertEqual(
+            call_kwargs["extra_query_kwargs"]["timeseries_hour_kwargs"],
+            {"start_hour": 7, "end_hour": 18},
+        )
+
+    @patch("insights.sources.services.simple_source_data_operation")
+    def test_defaults_filters_to_empty_dict_when_none(self, mock_simple_op):
+        mock_simple_op.return_value = {}
+
+        mock_factory = MagicMock()
+        mock_factory.get_source_query_executor.return_value = FakeQueryExecutor
+
+        service = DataSourceService(source_query_executor_factory=mock_factory)
+        widget = _make_widget()
+
+        service.get_source_data_from_widget(widget=widget, filters=None)
+
+        call_kwargs = mock_simple_op.call_args[1]
+        self.assertEqual(call_kwargs["filters"], {})

--- a/insights/sources/tests/test_services.py
+++ b/insights/sources/tests/test_services.py
@@ -27,13 +27,10 @@ def _make_widget(
     project.vtex_account = vtex_account
     project.timezone = "America/Sao_Paulo"
 
-    source = MagicMock()
-    source.slug = source_slug
-
     widget = MagicMock()
     widget.type = widget_type
     widget.name = widget_name
-    widget.source = source
+    widget.source = source_slug
     widget.project = project
     widget.is_crossing_data = is_crossing_data
     widget.config = {}

--- a/insights/sources/vtex_conversions/usecases/query_execute.py
+++ b/insights/sources/vtex_conversions/usecases/query_execute.py
@@ -13,11 +13,12 @@ from insights.sources.orders.clients import VtexOrdersRestClient
 from insights.sources.vtex_conversions.services import VTEXOrdersConversionsService
 from insights.sources.vtexcredentials.clients import AuthRestClient
 from insights.sources.vtexcredentials.exceptions import VtexCredentialsNotFound
+from insights.sources.base import BaseQueryExecutor
 
 logger = logging.getLogger(__name__)
 
 
-class QueryExecutor:
+class QueryExecutor(BaseQueryExecutor):
     @classmethod
     def get_vtex_credentials(cls, project: Project):
         vtex_credentials_client = AuthRestClient(project=project.uuid)

--- a/insights/sources/vtexcredentials/usecases/query_execute.py
+++ b/insights/sources/vtexcredentials/usecases/query_execute.py
@@ -1,8 +1,11 @@
+from insights.sources.base import BaseQueryExecutor
 from insights.sources.vtexcredentials.clients import AuthRestClient
 
 
-class QueryExecutor:
+class QueryExecutor(BaseQueryExecutor):
+    @classmethod
     def execute(
+        cls,
         filters: dict,
         operation: str,
         parser: callable,

--- a/insights/widgets/usecases/get_source_data.py
+++ b/insights/widgets/usecases/get_source_data.py
@@ -199,6 +199,7 @@ def get_source_data_from_widget(
     filters: dict = {},
     user_email: str = "",
 ):
+    # TODO: Remove this function once the data source service is rolled out to all projects
     try:
         source = widget.source
         if is_report:


### PR DESCRIPTION
### What

- Introduced a `BaseQueryExecutor` abstract base class (`insights/sources/base.py`) that all source-specific `QueryExecutor` classes now inherit from, standardizing their interface with `execute` as a `@classmethod`.
- Created a `SourceQueryExecutorFactory` (`insights/sources/factories.py`) that dynamically resolves and loads the correct `QueryExecutor` for a given source slug using Django's `import_string`.
- Implemented a new `DataSourceService` (`insights/sources/services.py`) that encapsulates the full data-fetching pipeline: resolving the executor via the factory, handling VTEX authentication (via `vtex_account` or `vtexcredentials` fallback), computing extra query kwargs, and dispatching to the appropriate operation function (`simple_source_data_operation` or `cross_source_data_operation`).
- Integrated the `DataSourceService` into `DashboardViewSet` behind a feature flag (`DATA_SOURCE_SERVICE_FEATURE_FLAG_KEY`), controlled per project/user via `is_feature_active_for_attributes`. When the flag is disabled, the legacy `get_source_data_from_widget` function is used.
- Refactored all 10 source-specific `QueryExecutor` classes (agents, chat_completion, flowruns, flows, orders, queues, rooms, sectors, tags, vtexcredentials) to extend `BaseQueryExecutor` and use `@classmethod`.
- Added comprehensive test suites for `BaseQueryExecutor`, `SourceQueryExecutorFactory`, `DataSourceService`, and the feature flag integration in `DashboardViewSet`.

### Why

The previous architecture had the data-fetching logic tightly coupled inside `get_source_data_from_widget`, a monolithic function that handled source resolution, authentication, and query dispatching all at once. Each `QueryExecutor` was an unrelated standalone class with no shared contract, making it impossible to enforce consistency or swap implementations. This refactoring introduces proper separation of concerns through a service layer with dependency injection (factory pattern), enabling easier testing, safer rollout via feature flags, and a clear path toward deprecating the legacy function once the new service is fully validated in production.

### Sequence diagram

This is a simplified view of the changes, focusing only on the feature flag switch to use the new or old logic.

```mermaid
sequenceDiagram
    participant Client
    participant ViewSet as DashboardViewSet
    participant FF as FeatureFlag
    participant Service as DataSourceService
    participant Legacy as get_source_data_from_widget
    Client->>ViewSet: GET /widget-data
    ViewSet->>FF: is_feature_active_for_attributes(key, {projectUUID, userEmail})
    alt Flag enabled
        ViewSet->>Service: get_source_data_from_widget(widget, filters, ...)
        Service-->>ViewSet: serialized data
    else Flag disabled
        ViewSet->>Legacy: get_source_data_from_widget(widget, filters, ...)
        Legacy-->>ViewSet: serialized data
    end
    ViewSet-->>Client: HTTP 200 {data}
```