### PR TITLE
feat: Add contacts metrics to the conversations metrics service

### DIFF
--- a/insights/metrics/conversations/dataclass.py
+++ b/insights/metrics/conversations/dataclass.py
@@ -191,3 +191,26 @@ class AbsoluteNumbersMetrics:
     """
 
     value: float
+
+
+@dataclass(frozen=True)
+class UniqueContactsMetricsData:
+    value: int
+
+
+@dataclass(frozen=True)
+class ReturningContactsMetricsData:
+    value: int
+    percentage: float
+
+
+@dataclass(frozen=True)
+class AvgConversationsPerContactMetricsData:
+    value: float
+
+
+@dataclass(frozen=True)
+class ContactMetricsData:
+    unique: UniqueContactsMetricsData
+    returning: ReturningContactsMetricsData
+    avg_conversations_per_contact: AvgConversationsPerContactMetricsData

--- a/insights/metrics/conversations/mock/services.py
+++ b/insights/metrics/conversations/mock/services.py
@@ -5,10 +5,13 @@ from insights.metrics.conversations.dataclass import (
     AgentInvocationAgent,
     AgentInvocationItem,
     AgentInvocationMetrics,
+    AvgConversationsPerContactMetricsData,
+    ContactMetricsData,
     ConversationsTotalsMetric,
     ConversationsTotalsMetrics,
     NPSMetrics,
     NPSMetricsField,
+    ReturningContactsMetricsData,
     SubtopicMetrics,
     ToolResultAgent,
     ToolResultItem,
@@ -17,6 +20,7 @@ from insights.metrics.conversations.dataclass import (
     TopicsDistributionMetrics,
     SalesFunnelMetrics,
     AvailableWidgetsList,
+    UniqueContactsMetricsData,
 )
 from insights.metrics.conversations.enums import (
     AvailableWidgetsListType,
@@ -285,6 +289,20 @@ class MockConversationsMetricsService(BaseConversationsMetricsService):
         self, project_uuid: UUID, widget_type: AvailableWidgetsListType | None = None
     ) -> AvailableWidgetsList:
         return []
+
+    def get_contacts_metrics(
+        self,
+        project_uuid: UUID,
+        start_date: datetime,
+        end_date: datetime,
+    ) -> ContactMetricsData:
+        return ContactMetricsData(
+            unique=UniqueContactsMetricsData(value=50),
+            returning=ReturningContactsMetricsData(value=10, percentage=20.0),
+            avg_conversations_per_contact=AvgConversationsPerContactMetricsData(
+                value=4.0
+            ),
+        )
 
     def get_crosstab_data(
         self,

--- a/insights/metrics/conversations/services.py
+++ b/insights/metrics/conversations/services.py
@@ -1,4 +1,5 @@
 from abc import ABC, abstractmethod
+from concurrent.futures import ThreadPoolExecutor
 import logging
 from typing import Callable, Optional
 from uuid import UUID
@@ -14,11 +15,14 @@ from insights.metrics.conversations.dataclass import (
     AgentInvocationItem,
     AgentInvocationMetrics,
     AvailableWidgetsList,
+    AvgConversationsPerContactMetricsData,
+    ContactMetricsData,
     ConversationsTotalsMetrics,
     CrosstabItemData,
     CrosstabSubItemData,
     NPSMetrics,
     NPSMetricsField,
+    ReturningContactsMetricsData,
     SalesFunnelMetrics,
     SubtopicMetrics,
     ToolResultAgent,
@@ -26,6 +30,7 @@ from insights.metrics.conversations.dataclass import (
     ToolResultMetrics,
     TopicMetrics,
     TopicsDistributionMetrics,
+    UniqueContactsMetricsData,
 )
 from insights.metrics.conversations.integrations.datalake.dataclass import (
     CrosstabSource,
@@ -233,6 +238,18 @@ class BaseConversationsMetricsService(ABC):
     ) -> dict:
         """
         Get crosstab data
+        """
+        raise NotImplementedError("Subclasses must implement this method")
+
+    @abstractmethod
+    def get_contacts_metrics(
+        self,
+        project_uuid: UUID,
+        start_date: datetime,
+        end_date: datetime,
+    ) -> ContactMetricsData:
+        """
+        Get contacts metrics
         """
         raise NotImplementedError("Subclasses must implement this method")
 
@@ -1184,3 +1201,52 @@ class ConversationsMetricsService(
         )
 
         return AbsoluteNumbersMetrics(value=value)
+
+    def get_contacts_metrics(
+        self,
+        project_uuid: UUID,
+        start_date: datetime,
+        end_date: datetime,
+    ) -> ContactMetricsData:
+        common_kwargs = {
+            "project_uuid": project_uuid,
+            "start_date": start_date,
+            "end_date": end_date,
+        }
+
+        with ThreadPoolExecutor(max_workers=3) as executor:
+            unique_future = executor.submit(
+                self.datalake_service.get_unique_contacts_count, **common_kwargs
+            )
+            returning_future = executor.submit(
+                self.datalake_service.get_returning_contacts_count, **common_kwargs
+            )
+            totals_future = executor.submit(
+                self.datalake_service.get_conversations_totals, **common_kwargs
+            )
+
+        unique_contacts_count = unique_future.result()
+        returning_contacts_count = returning_future.result()
+        total_conversations = totals_future.result().total_conversations.value
+
+        returning_percentage = (
+            round((returning_contacts_count / unique_contacts_count) * 100, 2)
+            if unique_contacts_count > 0
+            else 0
+        )
+        avg_conversations_per_contact = (
+            round(total_conversations / unique_contacts_count, 2)
+            if unique_contacts_count > 0
+            else 0
+        )
+
+        return ContactMetricsData(
+            unique=UniqueContactsMetricsData(value=unique_contacts_count),
+            returning=ReturningContactsMetricsData(
+                value=returning_contacts_count,
+                percentage=returning_percentage,
+            ),
+            avg_conversations_per_contact=AvgConversationsPerContactMetricsData(
+                value=avg_conversations_per_contact,
+            ),
+        )

--- a/insights/metrics/conversations/tests/test_services.py
+++ b/insights/metrics/conversations/tests/test_services.py
@@ -14,17 +14,21 @@ from insights.metrics.conversations.dataclass import (
     AgentInvocationItem,
     AgentInvocationMetrics,
     AvailableWidgetsList,
+    AvgConversationsPerContactMetricsData,
+    ContactMetricsData,
     ConversationsTotalsMetrics,
     ConversationsTotalsMetric,
     CrosstabItemData,
     CrosstabSubItemData,
     NPSMetrics,
     NPSMetricsField,
+    ReturningContactsMetricsData,
     SalesFunnelMetrics,
     ToolResultAgent,
     ToolResultItem,
     ToolResultMetrics,
     TopicsDistributionMetrics,
+    UniqueContactsMetricsData,
 )
 from insights.metrics.conversations.enums import (
     AbsoluteNumbersMetricsType,
@@ -1959,3 +1963,99 @@ class TestConversationsMetricsService(TestCase):
                 start_date=self.start_date,
                 end_date=self.end_date,
             )
+
+    def test_get_contacts_metrics(self):
+        project_uuid = self.project.uuid
+
+        self.mock_datalake_service.get_unique_contacts_count.return_value = 50
+        self.mock_datalake_service.get_returning_contacts_count.return_value = 10
+        self.mock_datalake_service.get_conversations_totals.return_value = (
+            ConversationsTotalsMetrics(
+                total_conversations=ConversationsTotalsMetric(
+                    value=200, percentage=100
+                ),
+                resolved=ConversationsTotalsMetric(value=120, percentage=60),
+                unresolved=ConversationsTotalsMetric(value=80, percentage=40),
+                transferred_to_human=ConversationsTotalsMetric(value=0, percentage=0),
+            )
+        )
+
+        result = self.service.get_contacts_metrics(
+            project_uuid=project_uuid,
+            start_date=self.start_date,
+            end_date=self.end_date,
+        )
+
+        self.assertIsInstance(result, ContactMetricsData)
+        self.assertEqual(result.unique, UniqueContactsMetricsData(value=50))
+        self.assertEqual(
+            result.returning,
+            ReturningContactsMetricsData(value=10, percentage=20.0),
+        )
+        self.assertEqual(
+            result.avg_conversations_per_contact,
+            AvgConversationsPerContactMetricsData(value=4.0),
+        )
+
+        self.mock_datalake_service.get_unique_contacts_count.assert_called_once_with(
+            project_uuid=project_uuid,
+            start_date=self.start_date,
+            end_date=self.end_date,
+        )
+        self.mock_datalake_service.get_returning_contacts_count.assert_called_once_with(
+            project_uuid=project_uuid,
+            start_date=self.start_date,
+            end_date=self.end_date,
+        )
+        self.mock_datalake_service.get_conversations_totals.assert_called_once_with(
+            project_uuid=project_uuid,
+            start_date=self.start_date,
+            end_date=self.end_date,
+        )
+
+    def test_get_contacts_metrics_with_zero_unique_contacts(self):
+        self.mock_datalake_service.get_unique_contacts_count.return_value = 0
+        self.mock_datalake_service.get_returning_contacts_count.return_value = 0
+        self.mock_datalake_service.get_conversations_totals.return_value = (
+            ConversationsTotalsMetrics(
+                total_conversations=ConversationsTotalsMetric(value=0, percentage=100),
+                resolved=ConversationsTotalsMetric(value=0, percentage=0),
+                unresolved=ConversationsTotalsMetric(value=0, percentage=0),
+                transferred_to_human=ConversationsTotalsMetric(value=0, percentage=0),
+            )
+        )
+
+        result = self.service.get_contacts_metrics(
+            project_uuid=self.project.uuid,
+            start_date=self.start_date,
+            end_date=self.end_date,
+        )
+
+        self.assertIsInstance(result, ContactMetricsData)
+        self.assertEqual(result.unique.value, 0)
+        self.assertEqual(result.returning.value, 0)
+        self.assertEqual(result.returning.percentage, 0)
+        self.assertEqual(result.avg_conversations_per_contact.value, 0)
+
+    def test_get_contacts_metrics_returning_percentage_calculation(self):
+        self.mock_datalake_service.get_unique_contacts_count.return_value = 80
+        self.mock_datalake_service.get_returning_contacts_count.return_value = 25
+        self.mock_datalake_service.get_conversations_totals.return_value = (
+            ConversationsTotalsMetrics(
+                total_conversations=ConversationsTotalsMetric(
+                    value=150, percentage=100
+                ),
+                resolved=ConversationsTotalsMetric(value=90, percentage=60),
+                unresolved=ConversationsTotalsMetric(value=60, percentage=40),
+                transferred_to_human=ConversationsTotalsMetric(value=0, percentage=0),
+            )
+        )
+
+        result = self.service.get_contacts_metrics(
+            project_uuid=self.project.uuid,
+            start_date=self.start_date,
+            end_date=self.end_date,
+        )
+
+        self.assertEqual(result.returning.percentage, 31.25)
+        self.assertEqual(result.avg_conversations_per_contact.value, 1.88)


### PR DESCRIPTION
### What

- Added a new `get_contacts_metrics` method to the conversations metrics service layer (`ConversationsMetricsService`) that aggregates contact-related metrics: **unique contacts**, **returning contacts** (with percentage), and **average conversations per contact**.
- Introduced four new frozen dataclasses — `UniqueContactsMetricsData`, `ReturningContactsMetricsData`, `AvgConversationsPerContactMetricsData`, and `ContactMetricsData` — to structure the contact metrics response.
- Declared the abstract method in `BaseConversationsMetricsService` and implemented the mock counterpart in `MockConversationsMetricsService`.
- Added three test cases covering: the standard scenario, the zero-unique-contacts edge case (division-by-zero guard), and percentage/average calculation accuracy.

### Why

The contacts card is a new dashboard widget that gives users visibility into contact engagement — how many unique contacts interacted, how many are returning, and the average number of conversations each contact generates. This PR wires up the metrics service layer on top of the datalake queries (`get_unique_contacts_count`, `get_returning_contacts_count`, and `get_conversations_totals`) already introduced in the previous PR, performing the three queries concurrently via `ThreadPoolExecutor` to minimize latency.

### Sequence diagram

```mermaid
sequenceDiagram
    participant Client
    participant ConversationsMetricsService
    participant ThreadPoolExecutor
    participant DatalakeService

    Client->>ConversationsMetricsService: get_contacts_metrics(project_uuid, start_date, end_date)
    ConversationsMetricsService->>ThreadPoolExecutor: submit 3 parallel tasks

    par Parallel Datalake Queries
        ThreadPoolExecutor->>DatalakeService: get_unique_contacts_count(...)
        DatalakeService-->>ThreadPoolExecutor: unique_contacts_count (int)
    and
        ThreadPoolExecutor->>DatalakeService: get_returning_contacts_count(...)
        DatalakeService-->>ThreadPoolExecutor: returning_contacts_count (int)
    and
        ThreadPoolExecutor->>DatalakeService: get_conversations_totals(...)
        DatalakeService-->>ThreadPoolExecutor: ConversationsTotalsMetrics
    end

    ThreadPoolExecutor-->>ConversationsMetricsService: all futures resolved

    ConversationsMetricsService->>ConversationsMetricsService: Calculate returning_percentage<br/>(returning / unique × 100)
    ConversationsMetricsService->>ConversationsMetricsService: Calculate avg_conversations_per_contact<br/>(total_conversations / unique)

    ConversationsMetricsService-->>Client: ContactMetricsData(unique, returning, avg)
```