### PR TITLE
feat: contacts card endpoint

### DIFF
--- a/insights/metrics/conversations/api/v1/serializers.py
+++ b/insights/metrics/conversations/api/v1/serializers.py
@@ -610,3 +610,28 @@ class AbsoluteNumbersSerializer(serializers.Serializer):
     """
 
     value = serializers.FloatField()
+
+
+class ContactsMetricsQueryParamsSerializer(ConversationBaseQueryParamsSerializer):
+    """
+    Serializer for contacts metrics query params
+    """
+
+
+class UniqueContactsMetricsSerializer(serializers.Serializer):
+    value = serializers.IntegerField()
+
+
+class ReturningContactsMetricsSerializer(serializers.Serializer):
+    value = serializers.IntegerField()
+    percentage = serializers.FloatField()
+
+
+class AvgConversationsPerContactMetricsSerializer(serializers.Serializer):
+    value = serializers.FloatField()
+
+
+class ContactsMetricsSerializer(serializers.Serializer):
+    unique = UniqueContactsMetricsSerializer()
+    returning = ReturningContactsMetricsSerializer()
+    avg_conversations_per_contact = AvgConversationsPerContactMetricsSerializer()

--- a/insights/metrics/conversations/api/v1/tests/test_serializers.py
+++ b/insights/metrics/conversations/api/v1/tests/test_serializers.py
@@ -7,10 +7,13 @@ from insights.metrics.conversations.dataclass import (
     AgentInvocationAgent,
     AgentInvocationItem,
     AgentInvocationMetrics,
+    AvgConversationsPerContactMetricsData,
+    ContactMetricsData,
     ConversationsTotalsMetric,
     ConversationsTotalsMetrics,
     CrosstabItemData,
     CrosstabSubItemData,
+    ReturningContactsMetricsData,
     SalesFunnelMetrics,
     SubtopicMetrics,
     ToolResultAgent,
@@ -18,6 +21,7 @@ from insights.metrics.conversations.dataclass import (
     ToolResultMetrics,
     TopicMetrics,
     TopicsDistributionMetrics,
+    UniqueContactsMetricsData,
 )
 from insights.metrics.conversations.enums import (
     ConversationType,
@@ -29,6 +33,8 @@ from insights.metrics.conversations.api.v1.serializers import (
     AgentInvocationItemSerializer,
     AgentInvocationMetricsSerializer,
     AgentInvocationQueryParamsSerializer,
+    ContactsMetricsQueryParamsSerializer,
+    ContactsMetricsSerializer,
     ConversationBaseQueryParamsSerializer,
     ConversationTotalsMetricsQueryParamsSerializer,
     ConversationTotalsMetricsSerializer,
@@ -1246,3 +1252,116 @@ class TestToolResultMetricsSerializer(TestCase):
 
         self.assertEqual(serializer.data["total"], 0)
         self.assertEqual(len(serializer.data["results"]), 0)
+
+
+class TestContactsMetricsQueryParamsSerializer(TestCase):
+    def setUp(self):
+        self.project = Project.objects.create(
+            name="Test Project",
+        )
+
+    def test_serializer_valid(self):
+        serializer = ContactsMetricsQueryParamsSerializer(
+            data={
+                "start_date": "2021-01-01",
+                "end_date": "2021-01-02",
+                "project_uuid": self.project.uuid,
+            }
+        )
+        self.assertTrue(serializer.is_valid())
+        self.assertIn("project", serializer.validated_data)
+        self.assertEqual(
+            str(serializer.validated_data["project_uuid"]), str(self.project.uuid)
+        )
+        self.assertEqual(serializer.validated_data["project"], self.project)
+
+    def test_serializer_missing_project_uuid(self):
+        serializer = ContactsMetricsQueryParamsSerializer(
+            data={
+                "start_date": "2021-01-01",
+                "end_date": "2021-01-02",
+            }
+        )
+        self.assertFalse(serializer.is_valid())
+        self.assertIn("project_uuid", serializer.errors)
+        self.assertEqual(serializer.errors["project_uuid"][0].code, "required")
+
+    def test_serializer_missing_start_date(self):
+        serializer = ContactsMetricsQueryParamsSerializer(
+            data={
+                "end_date": "2021-01-02",
+                "project_uuid": self.project.uuid,
+            }
+        )
+        self.assertFalse(serializer.is_valid())
+        self.assertIn("start_date", serializer.errors)
+
+    def test_serializer_missing_end_date(self):
+        serializer = ContactsMetricsQueryParamsSerializer(
+            data={
+                "start_date": "2021-01-01",
+                "project_uuid": self.project.uuid,
+            }
+        )
+        self.assertFalse(serializer.is_valid())
+        self.assertIn("end_date", serializer.errors)
+
+    def test_serializer_invalid_project_uuid(self):
+        serializer = ContactsMetricsQueryParamsSerializer(
+            data={
+                "start_date": "2021-01-01",
+                "end_date": "2021-01-02",
+                "project_uuid": "123e4567-e89b-12d3-a456-426614174000",
+            }
+        )
+        self.assertFalse(serializer.is_valid())
+        self.assertIn("project_uuid", serializer.errors)
+        self.assertEqual(serializer.errors["project_uuid"][0].code, "project_not_found")
+
+    def test_serializer_invalid_date_range(self):
+        serializer = ContactsMetricsQueryParamsSerializer(
+            data={
+                "start_date": "2021-01-02",
+                "end_date": "2021-01-01",
+                "project_uuid": self.project.uuid,
+            }
+        )
+        self.assertFalse(serializer.is_valid())
+        self.assertIn("start_date", serializer.errors)
+        self.assertEqual(
+            serializer.errors["start_date"][0].code, "start_date_after_end_date"
+        )
+
+
+class TestContactsMetricsSerializer(TestCase):
+    def test_serializer(self):
+        metrics = ContactMetricsData(
+            unique=UniqueContactsMetricsData(value=80),
+            returning=ReturningContactsMetricsData(value=28, percentage=35.0),
+            avg_conversations_per_contact=AvgConversationsPerContactMetricsData(
+                value=1.25
+            ),
+        )
+        serializer = ContactsMetricsSerializer(metrics)
+        data = serializer.data
+
+        self.assertEqual(data["unique"]["value"], 80)
+        self.assertEqual(data["returning"]["value"], 28)
+        self.assertEqual(data["returning"]["percentage"], 35.0)
+        self.assertEqual(data["avg_conversations_per_contact"]["value"], 1.25)
+
+    def test_serializer_with_zero_values(self):
+        metrics = ContactMetricsData(
+            unique=UniqueContactsMetricsData(value=0),
+            returning=ReturningContactsMetricsData(value=0, percentage=0.0),
+            avg_conversations_per_contact=AvgConversationsPerContactMetricsData(
+                value=0.0
+            ),
+        )
+        serializer = ContactsMetricsSerializer(metrics)
+        data = serializer.data
+
+        self.assertEqual(data["unique"]["value"], 0)
+        self.assertEqual(data["returning"]["value"], 0)
+        self.assertEqual(data["returning"]["percentage"], 0.0)
+        self.assertEqual(data["avg_conversations_per_contact"]["value"], 0.0)

--- a/insights/metrics/conversations/api/v1/tests/test_views.py
+++ b/insights/metrics/conversations/api/v1/tests/test_views.py
@@ -23,14 +23,18 @@ from insights.metrics.conversations.dataclass import (
     AgentInvocationItem,
     AgentInvocationMetrics,
     AvailableWidgetsList,
+    AvgConversationsPerContactMetricsData,
+    ContactMetricsData,
     ConversationsTotalsMetric,
     ConversationsTotalsMetrics,
     CrosstabItemData,
     CrosstabSubItemData,
+    ReturningContactsMetricsData,
     SalesFunnelMetrics,
     ToolResultAgent,
     ToolResultItem,
     ToolResultMetrics,
+    UniqueContactsMetricsData,
 )
 from insights.metrics.conversations.enums import (
     AvailableWidgets,
@@ -187,6 +191,11 @@ class BaseTestConversationsMetricsViewSet(APITestCase):
 
         return self.client.get(url, query_params, format="json")
 
+    def get_contacts_metrics(self, query_params: dict) -> Response:
+        url = reverse("conversations-contacts")
+
+        return self.client.get(url, query_params, format="json")
+
 
 class TestConversationsMetricsViewSetAsAnonymousUser(
     BaseTestConversationsMetricsViewSet
@@ -273,6 +282,11 @@ class TestConversationsMetricsViewSetAsAnonymousUser(
 
     def test_cannot_get_agent_invocation_when_unauthenticated(self):
         response = self.get_agent_invocation({})
+
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    def test_cannot_get_contacts_metrics_when_unauthenticated(self):
+        response = self.get_contacts_metrics({})
 
         self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
 
@@ -1297,6 +1311,75 @@ class TestConversationsMetricsViewSetAsAuthenticatedUser(
         mock_get_tool_results.side_effect = RuntimeError("Service error")
 
         response = self.get_tool_result(
+            {
+                "project_uuid": self.project.uuid,
+                "start_date": "2024-01-01",
+                "end_date": "2024-01-31",
+            }
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_500_INTERNAL_SERVER_ERROR)
+        data = json.loads(response.content)
+        self.assertIn("code", data)
+        self.assertEqual(data["code"], "INTERNAL_ERROR")
+        self.assertIn("event_id", data)
+
+    def test_cannot_get_contacts_metrics_without_project_uuid(self):
+        response = self.get_contacts_metrics({})
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.data["project_uuid"][0].code, "required")
+
+    def test_cannot_get_contacts_metrics_without_permission(self):
+        response = self.get_contacts_metrics({"project_uuid": self.project.uuid})
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    @with_project_auth
+    def test_cannot_get_contacts_metrics_without_required_params(self):
+        response = self.get_contacts_metrics({"project_uuid": self.project.uuid})
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.data["start_date"][0].code, "required")
+        self.assertEqual(response.data["end_date"][0].code, "required")
+
+    @with_project_auth
+    @patch(
+        "insights.metrics.conversations.services.ConversationsMetricsService.get_contacts_metrics"
+    )
+    def test_get_contacts_metrics(self, mock_get_contacts_metrics):
+        mock_get_contacts_metrics.return_value = ContactMetricsData(
+            unique=UniqueContactsMetricsData(value=80),
+            returning=ReturningContactsMetricsData(value=28, percentage=35.0),
+            avg_conversations_per_contact=AvgConversationsPerContactMetricsData(
+                value=1.25
+            ),
+        )
+
+        response = self.get_contacts_metrics(
+            {
+                "project_uuid": self.project.uuid,
+                "start_date": "2024-01-01",
+                "end_date": "2024-01-31",
+            }
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["unique"]["value"], 80)
+        self.assertEqual(response.data["returning"]["value"], 28)
+        self.assertEqual(response.data["returning"]["percentage"], 35.0)
+        self.assertEqual(response.data["avg_conversations_per_contact"]["value"], 1.25)
+
+    @with_project_auth
+    @patch(
+        "insights.metrics.conversations.services.ConversationsMetricsService.get_contacts_metrics"
+    )
+    def test_get_contacts_metrics_returns_500_on_service_error(
+        self, mock_get_contacts_metrics
+    ):
+        mock_get_contacts_metrics.side_effect = RuntimeError("Service error")
+
+        response = self.get_contacts_metrics(
             {
                 "project_uuid": self.project.uuid,
                 "start_date": "2024-01-01",

--- a/insights/metrics/conversations/api/v1/views.py
+++ b/insights/metrics/conversations/api/v1/views.py
@@ -30,6 +30,8 @@ from insights.metrics.conversations.api.v1.serializers import (
     AgentInvocationQueryParamsSerializer,
     AvailableWidgetsQueryParamsSerializer,
     AvailableWidgetsSerializer,
+    ContactsMetricsQueryParamsSerializer,
+    ContactsMetricsSerializer,
     ConversationTotalsMetricsQueryParamsSerializer,
     ConversationTotalsMetricsSerializer,
     CreateTopicSerializer,
@@ -533,6 +535,30 @@ class ConversationsMetricsViewSet(
         response_data = ToolResultMetricsSerializer(metrics).data
 
         return Response(response_data, status=status.HTTP_200_OK)
+
+    @action(
+        detail=False,
+        methods=["get"],
+        url_path="contacts",
+        url_name="contacts",
+    )
+    def get_contacts_metrics(self, request: "Request", *args, **kwargs) -> Response:
+        """
+        Get contacts metrics
+        """
+        query_params = ContactsMetricsQueryParamsSerializer(data=request.query_params)
+        query_params.is_valid(raise_exception=True)
+
+        metrics = self.service.get_contacts_metrics(
+            project_uuid=query_params.validated_data["project_uuid"],
+            start_date=query_params.validated_data["start_date"],
+            end_date=query_params.validated_data["end_date"],
+        )
+
+        return Response(
+            ContactsMetricsSerializer(metrics).data,
+            status=status.HTTP_200_OK,
+        )
 
 
 class InternalConversationsMetricsViewSet(GenericViewSet):


### PR DESCRIPTION
### What
- Added a new `GET /contacts` endpoint to the `ConversationsMetricsViewSet` that returns contact-related metrics: **unique contacts**, **returning contacts** (with percentage), and **average conversations per contact**.
- Introduced new serializers (`ContactsMetricsQueryParamsSerializer`, `ContactsMetricsSerializer`, `UniqueContactsMetricsSerializer`, `ReturningContactsMetricsSerializer`, `AvgConversationsPerContactMetricsSerializer`) for request validation and response formatting.
- Added comprehensive tests covering query parameter validation (missing fields, invalid project UUID, invalid date range), authentication/authorization checks, successful response serialization (including zero-value edge cases), and 500 error handling when the service layer raises an exception.

### Why
The contacts card feature requires an API layer to expose the contacts metrics data already computed in the service layer (added in the base branch `feature/contacts-card-in-metrics-service`). This endpoint allows the frontend to display unique contacts, returning contacts with their percentage, and the average number of conversations per contact within a given date range.

### Sequence diagram
```mermaid
sequenceDiagram
    actor Client
    participant View as ConversationsMetricsViewSet
    participant QPS as ContactsMetricsQueryParamsSerializer
    participant Auth as ProjectAuthPermission
    participant Service as ConversationsMetricsService
    participant DL as DatalakeService
    participant RS as ContactsMetricsSerializer

    Client->>View: GET /conversations/contacts/?project_uuid&start_date&end_date
    View->>QPS: Validate query params
    alt Invalid params
        QPS-->>Client: 400 Bad Request
    end
    View->>Auth: Check project permission
    alt Unauthorized
        Auth-->>Client: 403 Forbidden
    end
    View->>Service: get_contacts_metrics(project_uuid, start_date, end_date)
    par Parallel queries
        Service->>DL: get_unique_contacts_count()
        Service->>DL: get_returning_contacts_count()
        Service->>DL: get_conversations_totals()
    end
    DL-->>Service: unique, returning, totals
    Service-->>View: ContactMetricsData
    View->>RS: Serialize response
    RS-->>View: JSON data
    View-->>Client: 200 OK { unique, returning, avg_conversations_per_contact }
```