### PR TITLE
feat: Contacts metrics on export

### DIFF
--- a/insights/metrics/conversations/reports/choices.py
+++ b/insights/metrics/conversations/reports/choices.py
@@ -11,3 +11,4 @@ class ConversationsReportSections(TextChoices):
     NPS_HUMAN = "NPS_HUMAN"
     AGENT_INVOCATION = "AGENT_INVOCATION"
     TOOL_RESULT = "TOOL_RESULT"
+    CONTACTS = "CONTACTS"

--- a/insights/metrics/conversations/reports/services.py
+++ b/insights/metrics/conversations/reports/services.py
@@ -268,6 +268,18 @@ class BaseConversationsReportService(ABC):
         """
         raise NotImplementedError("Subclasses must implement this method")
 
+    @abstractmethod
+    def get_contacts_worksheet(
+        self,
+        report: Report,
+        start_date: datetime,
+        end_date: datetime,
+    ) -> ConversationsReportWorksheet:
+        """
+        Get contacts worksheet.
+        """
+        raise NotImplementedError("Subclasses must implement this method")
+
 
 class ConversationsReportService(BaseConversationsReportService):
     """
@@ -634,6 +646,10 @@ class ConversationsReportService(BaseConversationsReportService):
             ),
             "AGENT_INVOCATION": (
                 self.get_agent_invocation_worksheet,
+                {"report": report, "start_date": start_date, "end_date": end_date},
+            ),
+            "CONTACTS": (
+                self.get_contacts_worksheet,
                 {"report": report, "start_date": start_date, "end_date": end_date},
             ),
         }
@@ -1721,6 +1737,53 @@ class ConversationsReportService(BaseConversationsReportService):
             data=data,
         )
 
+    def get_contacts_worksheet(
+        self,
+        report: Report,
+        start_date: datetime,
+        end_date: datetime,
+    ) -> ConversationsReportWorksheet:
+        contacts_metrics = self.metrics_service.get_contacts_metrics(
+            project_uuid=report.project.uuid,
+            start_date=start_date,
+            end_date=end_date,
+        )
+
+        with override(report.requested_by.language or "en"):
+            worksheet_name = gettext("Contacts")
+            metric_label = gettext("Metric")
+            value_label = gettext("Value")
+            percentage_label = gettext("Percentage")
+
+            unique_contacts_label = gettext("Unique contacts")
+            returning_contacts_label = gettext("Returning contacts")
+            avg_conversations_per_contact_label = gettext(
+                "Avg conversations per contact"
+            )
+
+        data = [
+            {
+                metric_label: unique_contacts_label,
+                value_label: contacts_metrics.unique.value,
+                percentage_label: "",
+            },
+            {
+                metric_label: returning_contacts_label,
+                value_label: contacts_metrics.returning.value,
+                percentage_label: contacts_metrics.returning.percentage,
+            },
+            {
+                metric_label: avg_conversations_per_contact_label,
+                value_label: contacts_metrics.avg_conversations_per_contact.value,
+                percentage_label: "",
+            },
+        ]
+
+        return ConversationsReportWorksheet(
+            name=worksheet_name,
+            data=data,
+        )
+
     def get_available_widgets(self, project: Project) -> AvailableReportWidgets:
         """
         Get available widgets.
@@ -1732,6 +1795,7 @@ class ConversationsReportService(BaseConversationsReportService):
             "TOPICS_HUMAN",
             "AGENT_INVOCATION",
             "TOOL_RESULT",
+            "CONTACTS",
         ]
 
         special_widgets_get_functions = [

--- a/insights/metrics/conversations/reports/tests/mock.py
+++ b/insights/metrics/conversations/reports/tests/mock.py
@@ -49,6 +49,14 @@ class MockConversationsReportService(BaseConversationsReportService):
     ) -> ConversationsReportWorksheet:
         pass
 
+    def get_contacts_worksheet(
+        self,
+        report: Report,
+        start_date: datetime,
+        end_date: datetime,
+    ) -> ConversationsReportWorksheet:
+        pass
+
     def get_flowsrun_results_by_contacts(
         self,
         report: Report,
@@ -70,4 +78,5 @@ class MockConversationsReportService(BaseConversationsReportService):
         self.project_can_receive_new_reports_generation = MagicMock()
         self.get_datalake_events = MagicMock()
         self.get_resolutions_worksheet = MagicMock()
+        self.get_contacts_worksheet = MagicMock()
         self.get_flowsrun_results_by_contacts = MagicMock()

--- a/insights/metrics/conversations/reports/tests/test_serializers.py
+++ b/insights/metrics/conversations/reports/tests/test_serializers.py
@@ -718,6 +718,23 @@ class TestRequestConversationsReportGenerationSerializer(TestCase):
             [ConversationsReportSections.AGENT_INVOCATION],
         )
 
+    def test_serializer_with_contacts_section(self):
+        serializer = RequestConversationsReportGenerationSerializer(
+            data={
+                "project_uuid": self.project.uuid,
+                "type": ReportFormat.CSV,
+                "start_date": "2025-01-24",
+                "end_date": "2025-01-25",
+                "sections": [ConversationsReportSections.CONTACTS],
+            }
+        )
+        self.assertTrue(serializer.is_valid())
+        self.assertEqual(serializer.validated_data["project"], self.project)
+        self.assertEqual(
+            serializer.validated_data["sections"],
+            [ConversationsReportSections.CONTACTS],
+        )
+
     def test_serializer_without_sections_custom_widgets_and_crosstab_widgets(self):
         serializer = RequestConversationsReportGenerationSerializer(
             data={

--- a/insights/metrics/conversations/reports/tests/test_services.py
+++ b/insights/metrics/conversations/reports/tests/test_services.py
@@ -2070,6 +2070,7 @@ class TestConversationsReportServiceAdditional(TestCase):
             "TOPICS_HUMAN",
             "AGENT_INVOCATION",
             "TOOL_RESULT",
+            "CONTACTS",
         ]
         self.assertEqual(result.sections, expected_sections)
         self.assertEqual(result.custom_widgets, [])
@@ -2155,6 +2156,7 @@ class TestConversationsReportServiceAdditional(TestCase):
             "TOPICS_HUMAN",
             "AGENT_INVOCATION",
             "TOOL_RESULT",
+            "CONTACTS",
             "CSAT_AI",
             "CSAT_HUMAN",
             "NPS_AI",
@@ -2217,6 +2219,7 @@ class TestConversationsReportServiceAdditional(TestCase):
             "TOPICS_HUMAN",
             "AGENT_INVOCATION",
             "TOOL_RESULT",
+            "CONTACTS",
         ]
         self.assertEqual(result.sections, expected_sections)
         self.assertEqual(
@@ -2283,6 +2286,7 @@ class TestConversationsReportServiceAdditional(TestCase):
             "TOPICS_HUMAN",
             "AGENT_INVOCATION",
             "TOOL_RESULT",
+            "CONTACTS",
             "CSAT_AI",
             "NPS_AI",
         ]
@@ -2331,6 +2335,7 @@ class TestConversationsReportServiceAdditional(TestCase):
             "TOPICS_HUMAN",
             "AGENT_INVOCATION",
             "TOOL_RESULT",
+            "CONTACTS",
             "CSAT_AI",
         ]
         self.assertEqual(result.sections, expected_sections)
@@ -2396,6 +2401,7 @@ class TestConversationsReportServiceAdditional(TestCase):
             "TOPICS_HUMAN",
             "AGENT_INVOCATION",
             "TOOL_RESULT",
+            "CONTACTS",
         ]
         self.assertEqual(result.sections, expected_sections)
         self.assertEqual(result.custom_widgets, [])
@@ -3880,3 +3886,128 @@ class TestConversationsReportServiceAdditional(TestCase):
         self.assertEqual(worksheet.data[0]["Agent"], "unknown_agent")
         self.assertEqual(worksheet.data[0]["Invocations"], 5)
         self.assertEqual(worksheet.data[0]["Percentage"], 100.0)
+
+    @patch(
+        "insights.metrics.conversations.services.ConversationsMetricsService.get_contacts_metrics"
+    )
+    def test_get_contacts_worksheet(self, mock_get_contacts_metrics):
+        from insights.metrics.conversations.dataclass import (
+            ContactMetricsData,
+            UniqueContactsMetricsData,
+            ReturningContactsMetricsData,
+            AvgConversationsPerContactMetricsData,
+        )
+
+        mock_get_contacts_metrics.return_value = ContactMetricsData(
+            unique=UniqueContactsMetricsData(value=80),
+            returning=ReturningContactsMetricsData(value=28, percentage=35.0),
+            avg_conversations_per_contact=AvgConversationsPerContactMetricsData(
+                value=1.25
+            ),
+        )
+
+        report = Report.objects.create(
+            project=self.project,
+            source=self.service.source,
+            source_config={"sections": ["CONTACTS"]},
+            filters={"start": "2025-01-01", "end": "2025-01-02"},
+            format=ReportFormat.CSV,
+            requested_by=self.user,
+            status=ReportStatus.IN_PROGRESS,
+        )
+
+        worksheet = self.service.get_contacts_worksheet(
+            report=report,
+            start_date=datetime.fromisoformat("2025-01-01"),
+            end_date=datetime.fromisoformat("2025-01-02"),
+        )
+
+        self.assertEqual(worksheet.name, "Contacts")
+        self.assertEqual(len(worksheet.data), 3)
+
+        self.assertEqual(worksheet.data[0]["Metric"], "Unique contacts")
+        self.assertEqual(worksheet.data[0]["Value"], 80)
+        self.assertEqual(worksheet.data[0]["Percentage"], "")
+
+        self.assertEqual(worksheet.data[1]["Metric"], "Returning contacts")
+        self.assertEqual(worksheet.data[1]["Value"], 28)
+        self.assertEqual(worksheet.data[1]["Percentage"], 35.0)
+
+        self.assertEqual(
+            worksheet.data[2]["Metric"], "Avg conversations per contact"
+        )
+        self.assertEqual(worksheet.data[2]["Value"], 1.25)
+        self.assertEqual(worksheet.data[2]["Percentage"], "")
+
+        mock_get_contacts_metrics.assert_called_once_with(
+            project_uuid=self.project.uuid,
+            start_date=datetime.fromisoformat("2025-01-01"),
+            end_date=datetime.fromisoformat("2025-01-02"),
+        )
+
+    @patch(
+        "insights.metrics.conversations.services.ConversationsMetricsService.get_contacts_metrics"
+    )
+    def test_get_contacts_worksheet_with_zero_values(self, mock_get_contacts_metrics):
+        from insights.metrics.conversations.dataclass import (
+            ContactMetricsData,
+            UniqueContactsMetricsData,
+            ReturningContactsMetricsData,
+            AvgConversationsPerContactMetricsData,
+        )
+
+        mock_get_contacts_metrics.return_value = ContactMetricsData(
+            unique=UniqueContactsMetricsData(value=0),
+            returning=ReturningContactsMetricsData(value=0, percentage=0.0),
+            avg_conversations_per_contact=AvgConversationsPerContactMetricsData(
+                value=0.0
+            ),
+        )
+
+        report = Report.objects.create(
+            project=self.project,
+            source=self.service.source,
+            source_config={"sections": ["CONTACTS"]},
+            filters={"start": "2025-01-01", "end": "2025-01-02"},
+            format=ReportFormat.CSV,
+            requested_by=self.user,
+            status=ReportStatus.IN_PROGRESS,
+        )
+
+        worksheet = self.service.get_contacts_worksheet(
+            report=report,
+            start_date=datetime.fromisoformat("2025-01-01"),
+            end_date=datetime.fromisoformat("2025-01-02"),
+        )
+
+        self.assertEqual(worksheet.name, "Contacts")
+        self.assertEqual(len(worksheet.data), 3)
+        self.assertEqual(worksheet.data[0]["Value"], 0)
+        self.assertEqual(worksheet.data[1]["Value"], 0)
+        self.assertEqual(worksheet.data[1]["Percentage"], 0.0)
+        self.assertEqual(worksheet.data[2]["Value"], 0.0)
+
+    @patch(
+        "insights.metrics.conversations.reports.services.ConversationsReportService.get_contacts_worksheet"
+    )
+    def test_get_worksheets_with_contacts_section(self, mock_get_contacts_worksheet):
+        mock_get_contacts_worksheet.return_value = ConversationsReportWorksheet(
+            name="Contacts",
+            data=[{"Metric": "Unique contacts", "Value": 80, "Percentage": ""}],
+        )
+
+        report = Report.objects.create(
+            project=self.project,
+            source=self.service.source,
+            source_config={"sections": ["CONTACTS"]},
+            filters={"start": "2025-01-01", "end": "2025-01-02"},
+            format=ReportFormat.CSV,
+            requested_by=self.user,
+        )
+
+        worksheets = self.service._get_worksheets(
+            report, datetime(2025, 1, 1), datetime(2025, 1, 2)
+        )
+
+        self.assertEqual(len(worksheets), 1)
+        mock_get_contacts_worksheet.assert_called_once()

--- a/insights/metrics/conversations/reports/tests/test_views.py
+++ b/insights/metrics/conversations/reports/tests/test_views.py
@@ -263,6 +263,43 @@ class TestConversationsReportsViewSetAsAuthenticatedUser(
             call_kwargs["source_config"]["crosstab_widgets"],
         )
 
+    @with_project_auth
+    @patch(
+        "insights.metrics.conversations.reports.services.ConversationsReportService.get_current_report_for_project"
+    )
+    @patch(
+        "insights.metrics.conversations.reports.services.ConversationsReportService.request_generation"
+    )
+    def test_request_generation_with_contacts_section(
+        self,
+        mock_request_generation,
+        mock_get_current_report_for_project,
+    ):
+        report = Report(
+            project=self.project,
+            source=ReportSource.CONVERSATIONS_DASHBOARD,
+            status=ReportStatus.PENDING,
+            requested_by=self.user,
+        )
+        mock_request_generation.return_value = report
+        mock_get_current_report_for_project.return_value = None
+
+        response = self.request_generation(
+            {
+                "project_uuid": self.project.uuid,
+                "type": ReportFormat.CSV,
+                "start_date": "2025-01-01",
+                "end_date": "2025-01-02",
+                "sections": ["CONTACTS"],
+            }
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_202_ACCEPTED)
+        self.assertEqual(response.data["status"], ReportStatus.PENDING)
+
+        call_kwargs = mock_request_generation.call_args[1]
+        self.assertEqual(call_kwargs["source_config"]["sections"], ["CONTACTS"])
+
 
 class BaseTestAvailableWidgetsViewSet(APITestCase):
     def get_available_widgets(self, query_params: dict) -> Response:


### PR DESCRIPTION
### What
- Added `CONTACTS` as a new section in `ConversationsReportSections`, enabling contacts data to be included in conversations reports.
- Implemented `get_contacts_worksheet` in `ConversationsReportService`, which fetches contact metrics (unique contacts, returning contacts, and average conversations per contact) and formats them into a report worksheet with metric, value, and percentage columns.
- Registered the `CONTACTS` section in the worksheets mapping and the available widgets list so it is automatically picked up during report generation.
- Added the corresponding abstract method to `BaseConversationsReportService` and updated the mock service.
- Added tests covering the serializer validation, view request generation, worksheet output (including zero-value edge cases), and worksheet integration via `_get_worksheets`.

### Why
Users need visibility into contact-level metrics within the conversations report. By exposing unique contacts, returning contacts, and average conversations per contact as a dedicated report section, stakeholders can analyze engagement patterns and contact retention directly from the exported report without relying on separate dashboards or queries.

### Sequence diagram
```mermaid
sequenceDiagram
    participant Client
    participant View as ConversationsReportsViewSet
    participant Serializer as RequestConversationsReportGenerationSerializer
    participant ReportService as ConversationsReportService
    participant MetricsService as ConversationsMetricsService
    participant Datalake

    Client->>View: POST /reports (sections: ["CONTACTS"])
    View->>Serializer: Validate request data
    Serializer-->>View: Validated data (project, sections, dates)
    View->>ReportService: request_generation(sections=["CONTACTS"], ...)
    ReportService->>ReportService: _get_worksheets(report, start_date, end_date)
    ReportService->>ReportService: get_contacts_worksheet(report, start_date, end_date)
    ReportService->>MetricsService: get_contacts_metrics(project_uuid, start_date, end_date)
    MetricsService->>Datalake: Query unique contacts count
    Datalake-->>MetricsService: Unique contacts result
    MetricsService->>Datalake: Query returning contacts count
    Datalake-->>MetricsService: Returning contacts result
    MetricsService->>MetricsService: Calculate avg conversations per contact
    MetricsService-->>ReportService: ContactMetricsData (unique, returning, avg)
    ReportService->>ReportService: Build worksheet rows (Metric / Value / Percentage)
    ReportService-->>ReportService: ConversationsReportWorksheet
    ReportService-->>View: Report (status: PENDING)
    View-->>Client: 202 Accepted (report status)
```