### PR TITLE
feat: Add new Project consumer using Weni EDA

### DIFF
--- a/insights/projects/consumers/__init__.py
+++ b/insights/projects/consumers/__init__.py
@@ -1,3 +1,3 @@
 from .auth_consumer import ProjectAuthConsumer
-from .project_consumer import ProjectConsumer
+from .project_consumer import OldProjectConsumer, WeniEDAProjectConsumer
 from .update_project_consumer import UpdateProjectConsumer

--- a/insights/projects/consumers/project_consumer.py
+++ b/insights/projects/consumers/project_consumer.py
@@ -4,8 +4,9 @@ import logging
 
 from sentry_sdk import capture_exception
 
+from weni.eda.django.consumers import EDAConsumer as WeniEDAConsumer
 
-from insights.event_driven.consumers import EDAConsumer
+from insights.event_driven.consumers import EDAConsumer as InsightsEDAConsumer
 from insights.event_driven.parsers.json_parser import JSONParser
 from insights.projects.usecases.auth_creation import ProjectAuthCreationUseCase
 from insights.projects.usecases.create import ProjectsUseCase
@@ -14,11 +15,24 @@ from insights.projects.usecases.project_dto import ProjectCreationDTO
 logger = logging.getLogger(__name__)
 
 
-class ProjectConsumer(EDAConsumer):
+def get_inline_agent_switch(body: dict) -> bool:
+    """
+    Handle the inline agent switch for a project.
+    """
+    if "inline_agent_switch" not in body or not isinstance(
+        body.get("inline_agent_switch"), bool
+    ):
+        return True
+
+    return body.get("inline_agent_switch")
+
+
+class OldProjectConsumer(InsightsEDAConsumer):
+    # TODO: Remove this consumer once we permanently migrate to Weni EDA
     @staticmethod
     def consume(message: amqp.Message):
         channel = message.channel
-        print(f"[ProjectConsumer] - Consuming a message. Body: {message.body}")
+        print(f"[OldProjectConsumer] - Consuming a message. Body: {message.body}")
         body = JSONParser.parse(message.body)
 
         try:
@@ -27,7 +41,7 @@ class ProjectConsumer(EDAConsumer):
                     org_uuid = UUID(body.get("organization_uuid"))
                 except ValueError as e:
                     logger.error(
-                        "[ProjectConsumer] - Invalid organization uuid: %s. Saving as None",
+                        "[OldProjectConsumer] - Invalid organization uuid: %s. Saving as None",
                         body.get("organization_uuid"),
                     )
                     capture_exception(e)
@@ -43,7 +57,7 @@ class ProjectConsumer(EDAConsumer):
                 timezone=body.get("timezone"),
                 vtex_account=body.get("vtex_account"),
                 org_uuid=org_uuid,
-                inline_agent_switch=body.get("inline_agent_switch", False),
+                inline_agent_switch=get_inline_agent_switch(body),
             )
 
             authorizations = body.get("authorizations", [])
@@ -59,4 +73,58 @@ class ProjectConsumer(EDAConsumer):
             channel.basic_ack(message.delivery_tag)
         except Exception as exception:
             channel.basic_reject(message.delivery_tag, requeue=False)
-            print(f"[ProjectConsumer] - Message rejected by: {exception}")
+            print(f"[OldProjectConsumer] - Message rejected by: {exception}")
+
+
+class WeniEDAProjectConsumer(WeniEDAConsumer):
+    """
+    Consumer responsible for handling project creation events from the Weni EDA.
+    """
+
+    def consume(self, message: amqp.Message):
+        """
+        Process an incoming project creation message from the Weni EDA.
+        """
+        channel = message.channel
+        print(f"[WeniEDAProjectConsumer] - Consuming a message. Body: {message.body}")
+        body = JSONParser.parse(message.body)
+
+        try:
+            if body.get("organization_uuid"):
+                try:
+                    org_uuid = UUID(body.get("organization_uuid"))
+                except ValueError as e:
+                    logger.error(
+                        "[WeniEDAProjectConsumer] - Invalid organization uuid: %s. Saving as None",
+                        body.get("organization_uuid"),
+                    )
+                    capture_exception(e)
+                    org_uuid = None
+            else:
+                org_uuid = None
+
+            project_dto = ProjectCreationDTO(
+                uuid=body.get("uuid"),
+                name=body.get("name"),
+                is_template=body.get("is_template"),
+                date_format=body.get("date_format"),
+                timezone=body.get("timezone"),
+                vtex_account=body.get("vtex_account"),
+                org_uuid=org_uuid,
+                inline_agent_switch=get_inline_agent_switch(body),
+            )
+
+            authorizations = body.get("authorizations", [])
+
+            project_creation = ProjectsUseCase()
+            project = project_creation.create_project(project_dto)
+
+            auth_creation = ProjectAuthCreationUseCase()
+            auth_creation.bulk_create(
+                project=str(project.uuid), authorizations=authorizations
+            )
+
+            channel.basic_ack(message.delivery_tag)
+        except Exception as exception:
+            channel.basic_reject(message.delivery_tag, requeue=False)
+            print(f"[WeniEDAProjectConsumer] - Message rejected by: {exception}")

--- a/insights/projects/consumers/project_consumer.py
+++ b/insights/projects/consumers/project_consumer.py
@@ -83,48 +83,43 @@ class WeniEDAProjectConsumer(WeniEDAConsumer):
 
     def consume(self, message: amqp.Message):
         """
-        Process an incoming project creation message from the Weni EDA.
+        Process an incoming project creation message.
         """
-        channel = message.channel
         print(f"[WeniEDAProjectConsumer] - Consuming a message. Body: {message.body}")
         body = JSONParser.parse(message.body)
 
-        try:
-            if body.get("organization_uuid"):
-                try:
-                    org_uuid = UUID(body.get("organization_uuid"))
-                except ValueError as e:
-                    logger.error(
-                        "[WeniEDAProjectConsumer] - Invalid organization uuid: %s. Saving as None",
-                        body.get("organization_uuid"),
-                    )
-                    capture_exception(e)
-                    org_uuid = None
-            else:
+        if body.get("organization_uuid"):
+            try:
+                org_uuid = UUID(body.get("organization_uuid"))
+            except ValueError as e:
+                logger.error(
+                    "[WeniEDAProjectConsumer] - Invalid organization uuid: %s. Saving as None",
+                    body.get("organization_uuid"),
+                )
+                capture_exception(e)
                 org_uuid = None
+        else:
+            org_uuid = None
 
-            project_dto = ProjectCreationDTO(
-                uuid=body.get("uuid"),
-                name=body.get("name"),
-                is_template=body.get("is_template"),
-                date_format=body.get("date_format"),
-                timezone=body.get("timezone"),
-                vtex_account=body.get("vtex_account"),
-                org_uuid=org_uuid,
-                inline_agent_switch=get_inline_agent_switch(body),
-            )
+        project_dto = ProjectCreationDTO(
+            uuid=body.get("uuid"),
+            name=body.get("name"),
+            is_template=body.get("is_template"),
+            date_format=body.get("date_format"),
+            timezone=body.get("timezone"),
+            vtex_account=body.get("vtex_account"),
+            org_uuid=org_uuid,
+            inline_agent_switch=get_inline_agent_switch(body),
+        )
 
-            authorizations = body.get("authorizations", [])
+        authorizations = body.get("authorizations", [])
 
-            project_creation = ProjectsUseCase()
-            project = project_creation.create_project(project_dto)
+        project_creation = ProjectsUseCase()
+        project = project_creation.create_project(project_dto)
 
-            auth_creation = ProjectAuthCreationUseCase()
-            auth_creation.bulk_create(
-                project=str(project.uuid), authorizations=authorizations
-            )
+        auth_creation = ProjectAuthCreationUseCase()
+        auth_creation.bulk_create(
+            project=str(project.uuid), authorizations=authorizations
+        )
 
-            channel.basic_ack(message.delivery_tag)
-        except Exception as exception:
-            channel.basic_reject(message.delivery_tag, requeue=False)
-            print(f"[WeniEDAProjectConsumer] - Message rejected by: {exception}")
+        self.ack()

--- a/insights/projects/handle.py
+++ b/insights/projects/handle.py
@@ -1,10 +1,22 @@
 from amqp.channel import Channel
 
-from .consumers import ProjectAuthConsumer, ProjectConsumer, UpdateProjectConsumer
+from insights.settings import USE_WENI_EDA_FOR_PROJECTS
+
+from .consumers import (
+    ProjectAuthConsumer,
+    OldProjectConsumer,
+    UpdateProjectConsumer,
+    WeniEDAProjectConsumer,
+)
 
 
 def handle_consumers(channel: Channel) -> None:
-    channel.basic_consume("insights.projects", callback=ProjectConsumer().handle)
+    if USE_WENI_EDA_FOR_PROJECTS:
+        channel.basic_consume(
+            "insights.projects", callback=WeniEDAProjectConsumer().handle
+        )
+    else:
+        channel.basic_consume("insights.projects", callback=OldProjectConsumer().handle)
     channel.basic_consume("insights.permissions", callback=ProjectAuthConsumer().handle)
     channel.basic_consume(
         "insights.update-project", callback=UpdateProjectConsumer().handle

--- a/insights/projects/handle.py
+++ b/insights/projects/handle.py
@@ -12,6 +12,7 @@ from .consumers import (
 
 def handle_consumers(channel: Channel) -> None:
     if USE_WENI_EDA_FOR_PROJECTS:
+        # TODO: Remove this checking once we permanently migrate to Weni EDA
         channel.basic_consume(
             "insights.projects", callback=WeniEDAProjectConsumer().handle
         )

--- a/insights/settings.py
+++ b/insights/settings.py
@@ -73,6 +73,7 @@ INSTALLED_APPS = [
     "rest_framework.authtoken",
     "drf_spectacular",
     "weni.feature_flags",
+    "weni.eda.django.eda_app",
 ]
 
 if ADMIN_ENABLED is True:
@@ -303,6 +304,9 @@ if USE_SENTRY:
 
 USE_EDA = env.bool("USE_EDA", default=False)
 
+# TODO: Remove this once we permanently migrate to Weni EDA
+USE_WENI_EDA_FOR_PROJECTS = env.bool("USE_WENI_EDA_FOR_PROJECTS", default=False)
+
 if USE_EDA:
     EDA_CONNECTION_BACKEND = "insights.event_driven.backends.PyAMQPConnectionBackend"
     EDA_CONSUMERS_HANDLE = "insights.event_driven.handle.handle_consumers"
@@ -316,6 +320,7 @@ if USE_EDA:
 
     FLOWS_TICKETER_EXCHANGE = env("FLOWS_TICKETER_EXCHANGE", default="sectors.topic")
     FLOWS_QUEUE_EXCHANGE = env("FLOWS_QUEUE_EXCHANGE", default="queues.topic")
+
 
 CHATS_URL = env("CHATS_URL", default="")
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -3252,6 +3252,20 @@ protobuf = ">=6.30.0,<7.0.0"
 pytest = ">=8.4.0,<9.0.0"
 
 [[package]]
+name = "weni-eda"
+version = "0.1.1"
+description = ""
+optional = false
+python-versions = "<4.0,>=3.10"
+files = [
+    {file = "weni_eda-0.1.1-py3-none-any.whl", hash = "sha256:24953f43b01976cd90345931c1552307d27d1f709ebd1792fa840126c7699cb8"},
+    {file = "weni_eda-0.1.1.tar.gz", hash = "sha256:f95934fcf27f3dd2aaadb96e16826a73fb5d0ef0e7cca24a4b0ccce026449f82"},
+]
+
+[package.dependencies]
+amqp = ">=5.2.0,<6.0.0"
+
+[[package]]
 name = "weni-feature-flags"
 version = "2.1.0"
 description = "Weni's feature flags SDK for Python backends"
@@ -3605,4 +3619,4 @@ testing = ["coverage (>=5.0.3)", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "788bb5bb70af88784e413251664ef5f531292ec1a1eb6a5e68bd1b35575beef4"
+content-hash = "fcbd53fd5aa8bd2a7a5fc28fe830a913190d04bdeb247731cd65264f8a123812"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ standardwebhooks = "^1.0.0"
 django-model-utils = "^5.0.0"
 weni-commons = "^1.1.0"
 pyjwt = "^2.11.0"
+weni-eda = "^0.1.1"
 
 [tool.poetry.group.dev.dependencies]
 ipython = "^8.22.2"


### PR DESCRIPTION
### What
- Added the `weni-eda` package (`^0.1.1`) as a new dependency and registered its Django app (`weni.eda.django.eda_app`).
- Introduced `WeniEDAProjectConsumer`, a new project consumer built on top of the Weni EDA `EDAConsumer` base class, to handle project creation events.
- Renamed the existing `ProjectConsumer` to `OldProjectConsumer` and marked it for future removal once the migration to Weni EDA is complete.
- Added a `USE_WENI_EDA_FOR_PROJECTS` feature flag (env var, defaults to `False`) that toggles between the new `WeniEDAProjectConsumer` and the legacy `OldProjectConsumer` at runtime.
- Extracted `get_inline_agent_switch` helper to safely parse the `inline_agent_switch` field from the message body, defaulting to `True` when the field is missing or not a boolean.

### Why
- The project is migrating its event-driven architecture from the internal EDA consumer implementation to the shared `weni-eda` library, which provides a standardized consumer interface across Weni services.
- A feature flag (`USE_WENI_EDA_FOR_PROJECTS`) enables a gradual rollout strategy, allowing the team to switch between the old and new consumers without code changes, reducing deployment risk.
- The `inline_agent_switch` parsing was hardened to handle missing or malformed values, preventing unexpected behavior during message consumption.