### PR TITLE
feat: Add crosstab parallel fetching

### DIFF
--- a/insights/metrics/conversations/integrations/datalake/services.py
+++ b/insights/metrics/conversations/integrations/datalake/services.py
@@ -11,6 +11,7 @@ from django.conf import settings
 from django.utils import timezone
 from django.utils.translation import override, gettext
 from sentry_sdk import capture_exception
+from weni.feature_flags.shortcuts import is_feature_active_for_attributes
 
 from insights.metrics.conversations.dataclass import (
     ConversationsTotalsMetric,
@@ -1185,25 +1186,55 @@ class DatalakeConversationsMetricsService(BaseDatalakeConversationsMetricsServic
             "date_end": end_date,
         }
 
-        logger.info(
-            "[DATALAKE CONVERSATIONS METRICS SERVICE] Getting source A events for project %s with source A %s",
-            project_uuid,
-            source_a.key,
-        )
-        source_a_events = self.get_raw_events_data(
-            key=source_a.key,
-            **common_kwargs,
-        )
+        try:
+            use_parallel = is_feature_active_for_attributes(
+                settings.CROSSTAB_PARALLEL_FETCHING_FEATURE_FLAG_KEY,
+                attributes={"projectUUID": str(project_uuid)},
+            )
+        except Exception as e:
+            logger.error(
+                "Failed to check if crosstab parallel fetching is active: %s", e
+            )
+            use_parallel = False
 
-        logger.info(
-            "[DATALAKE CONVERSATIONS METRICS SERVICE] Getting source B events for project %s with source B %s",
-            project_uuid,
-            source_b.key,
-        )
-        source_b_events = self.get_raw_events_data(
-            key=source_b.key,
-            **common_kwargs,
-        )
+        if use_parallel:
+            logger.info(
+                "[DATALAKE CONVERSATIONS METRICS SERVICE] Fetching source A and B events in parallel for project %s",
+                project_uuid,
+            )
+
+            def fetch_source_a():
+                return self.get_raw_events_data(key=source_a.key, **common_kwargs)
+
+            def fetch_source_b():
+                return self.get_raw_events_data(key=source_b.key, **common_kwargs)
+
+            with ThreadPoolExecutor(max_workers=2) as executor:
+                source_a_future = executor.submit(fetch_source_a)
+                source_b_future = executor.submit(fetch_source_b)
+
+            source_a_events = source_a_future.result()
+            source_b_events = source_b_future.result()
+        else:
+            logger.info(
+                "[DATALAKE CONVERSATIONS METRICS SERVICE] Getting source A events for project %s with source A %s",
+                project_uuid,
+                source_a.key,
+            )
+            source_a_events = self.get_raw_events_data(
+                key=source_a.key,
+                **common_kwargs,
+            )
+
+            logger.info(
+                "[DATALAKE CONVERSATIONS METRICS SERVICE] Getting source B events for project %s with source B %s",
+                project_uuid,
+                source_b.key,
+            )
+            source_b_events = self.get_raw_events_data(
+                key=source_b.key,
+                **common_kwargs,
+            )
 
         labels_data = CrosstabLabelsSerializer(
             source_a_events, source_a.field, reference_field=reference_field

--- a/insights/metrics/conversations/integrations/datalake/tests/test_services.py
+++ b/insights/metrics/conversations/integrations/datalake/tests/test_services.py
@@ -11,6 +11,7 @@ from insights.metrics.conversations.dataclass import (
 from insights.metrics.conversations.enums import ConversationType
 from insights.metrics.conversations.integrations.datalake.dataclass import (
     AgentInvocationMetric,
+    CrosstabSource,
     SalesFunnelData,
     ToolResultMetric,
 )
@@ -1703,3 +1704,146 @@ class DatalakeConversationsMetricsServiceTestCase(TestCase):
         self.assertIn("quoted_value", results)
         self.assertIsInstance(results["quoted_value"], ToolResultMetric)
         self.assertEqual(results["quoted_value"].count, 4)
+
+    @patch(
+        "insights.metrics.conversations.integrations.datalake.services.is_feature_active_for_attributes",
+        return_value=True,
+    )
+    def test_get_crosstab_data_parallel_fetching(self, mock_feature_flag):
+        project_uuid = uuid.uuid4()
+        start_date = datetime.now() - timedelta(days=1)
+        end_date = datetime.now()
+        source_a = CrosstabSource(key="source_a_key", field="value")
+        source_b = CrosstabSource(key="source_b_key", field="value")
+
+        self.mock_events_client.get_events.return_value = []
+
+        with patch.object(
+            self.service, "get_raw_events_data", return_value=[]
+        ) as mock_get_raw:
+            self.service.get_crosstab_data(
+                project_uuid=project_uuid,
+                source_a=source_a,
+                source_b=source_b,
+                start_date=start_date,
+                end_date=end_date,
+            )
+
+            self.assertEqual(mock_get_raw.call_count, 2)
+            mock_get_raw.assert_any_call(
+                key="source_a_key",
+                event_name=self.service.event_name,
+                project=project_uuid,
+                date_start=start_date,
+                date_end=end_date,
+            )
+            mock_get_raw.assert_any_call(
+                key="source_b_key",
+                event_name=self.service.event_name,
+                project=project_uuid,
+                date_start=start_date,
+                date_end=end_date,
+            )
+
+        mock_feature_flag.assert_called_once_with(
+            "insightsCrosstabParallelFetching",
+            attributes={"projectUUID": str(project_uuid)},
+        )
+
+    @patch(
+        "insights.metrics.conversations.integrations.datalake.services.is_feature_active_for_attributes",
+        return_value=False,
+    )
+    def test_get_crosstab_data_sequential_fetching(self, mock_feature_flag):
+        project_uuid = uuid.uuid4()
+        start_date = datetime.now() - timedelta(days=1)
+        end_date = datetime.now()
+        source_a = CrosstabSource(key="source_a_key", field="value")
+        source_b = CrosstabSource(key="source_b_key", field="value")
+
+        self.mock_events_client.get_events.return_value = []
+
+        with patch.object(
+            self.service, "get_raw_events_data", return_value=[]
+        ) as mock_get_raw:
+            self.service.get_crosstab_data(
+                project_uuid=project_uuid,
+                source_a=source_a,
+                source_b=source_b,
+                start_date=start_date,
+                end_date=end_date,
+            )
+
+            self.assertEqual(mock_get_raw.call_count, 2)
+            mock_get_raw.assert_any_call(
+                key="source_a_key",
+                event_name=self.service.event_name,
+                project=project_uuid,
+                date_start=start_date,
+                date_end=end_date,
+            )
+            mock_get_raw.assert_any_call(
+                key="source_b_key",
+                event_name=self.service.event_name,
+                project=project_uuid,
+                date_start=start_date,
+                date_end=end_date,
+            )
+
+        mock_feature_flag.assert_called_once_with(
+            "insightsCrosstabParallelFetching",
+            attributes={"projectUUID": str(project_uuid)},
+        )
+
+    @patch(
+        "insights.metrics.conversations.integrations.datalake.services.is_feature_active_for_attributes",
+        return_value=True,
+    )
+    def test_get_crosstab_data_parallel_returns_same_result_as_sequential(
+        self, mock_feature_flag
+    ):
+        project_uuid = uuid.uuid4()
+        start_date = datetime.now() - timedelta(days=1)
+        end_date = datetime.now()
+        source_a = CrosstabSource(key="source_a_key", field="value")
+        source_b = CrosstabSource(key="source_b_key", field="value")
+
+        source_a_events = [
+            {"value": "label_1", "join_key": "jk1"},
+            {"value": "label_2", "join_key": "jk2"},
+        ]
+        source_b_events = [
+            {"value": "data_1", "join_key": "jk1"},
+            {"value": "data_2", "join_key": "jk2"},
+        ]
+
+        def get_raw_side_effect(**kwargs):
+            if kwargs.get("key") == "source_a_key":
+                return source_a_events
+            return source_b_events
+
+        with patch.object(
+            self.service, "get_raw_events_data", side_effect=get_raw_side_effect
+        ):
+            parallel_result = self.service.get_crosstab_data(
+                project_uuid=project_uuid,
+                source_a=source_a,
+                source_b=source_b,
+                start_date=start_date,
+                end_date=end_date,
+            )
+
+        mock_feature_flag.return_value = False
+
+        with patch.object(
+            self.service, "get_raw_events_data", side_effect=get_raw_side_effect
+        ):
+            sequential_result = self.service.get_crosstab_data(
+                project_uuid=project_uuid,
+                source_a=source_a,
+                source_b=source_b,
+                start_date=start_date,
+                end_date=end_date,
+            )
+
+        self.assertEqual(parallel_result, sequential_result)

--- a/insights/settings.py
+++ b/insights/settings.py
@@ -547,3 +547,9 @@ VTEX_ORDERS_API_CACHE_TTL = env.int("VTEX_ORDERS_API_CACHE_TTL", default=60 * 60
 DATA_SOURCE_SERVICE_FEATURE_FLAG_KEY = env.str(
     "DATA_SOURCE_SERVICE_FEATURE_FLAG_KEY", default="insightsDataSourceService"
 )
+
+# Crosstab parallel fetching
+CROSSTAB_PARALLEL_FETCHING_FEATURE_FLAG_KEY = env.str(
+    "CROSSTAB_PARALLEL_FETCHING_FEATURE_FLAG_KEY",
+    default="insightsCrosstabParallelFetching",
+)


### PR DESCRIPTION
### What
- Added parallel data fetching for crosstab source A and source B events using `ThreadPoolExecutor`, gated behind a feature flag (`insightsCrosstabParallelFetching`).
- Introduced the `CROSSTAB_PARALLEL_FETCHING_FEATURE_FLAG_KEY` setting in `insights/settings.py`, configurable via environment variable.
- When the feature flag is active for a given project, `get_crosstab_data` fetches both sources concurrently; otherwise, it falls back to the existing sequential behavior.
- Added three new test cases covering parallel fetching, sequential fetching, and result equivalence between both strategies.

### Why
The `get_crosstab_data` method fetches events for two independent sources (A and B) sequentially, which means the total wait time is the sum of both requests. Since these two fetches are independent of each other, they can be executed in parallel to reduce latency. A feature flag controls the rollout so the change can be enabled per project and safely rolled back if needed.

### Sequence diagram

```mermaid
sequenceDiagram
    participant Client
    participant Service as DatalakeConversationsMetricsService
    participant FF as Feature Flag Service
    participant DL as Datalake

    Client->>Service: get_crosstab_data(project, source_a, source_b, dates)
    Service->>FF: is_feature_active_for_attributes("insightsCrosstabParallelFetching", projectUUID)
    FF-->>Service: active? (true / false)

    alt Parallel fetching (flag active)
        Service->>DL: get_raw_events_data(source_a) [Thread 1]
        Service->>DL: get_raw_events_data(source_b) [Thread 2]
        DL-->>Service: source_a_events [Thread 1]
        DL-->>Service: source_b_events [Thread 2]
    else Sequential fetching (flag inactive or error)
        Service->>DL: get_raw_events_data(source_a)
        DL-->>Service: source_a_events
        Service->>DL: get_raw_events_data(source_b)
        DL-->>Service: source_b_events
    end

    Service->>Service: Build crosstab from source_a_events + source_b_events
    Service-->>Client: Crosstab result
```