### PR TITLE
fix: agents metrics pagination

### DIFF
--- a/insights/core/urls/proxy_pagination.py
+++ b/insights/core/urls/proxy_pagination.py
@@ -61,3 +61,61 @@ def get_cursor_based_pagination_urls(
         next_url=next_url,
         previous_url=previous_url,
     )
+
+
+def get_limit_offset_pagination_urls(
+    request: Request,
+    response_body: dict,
+    limit_param: str = "limit",
+    offset_param: str = "offset",
+) -> PaginationURLs:
+    """
+    Rewrite upstream limit/offset pagination URLs to point back through the proxy.
+    """
+    insights_uri = request.build_absolute_uri()
+    insights_url = urlparse(insights_uri)
+    insights_endpoint = f"https://{insights_url.netloc}{insights_url.path}"
+    query_params_raw = parse_qs(insights_url.query)
+    query_params = {k: v[0] if v else None for k, v in query_params_raw.items()}
+    query_params.pop(limit_param, None)
+    query_params.pop(offset_param, None)
+
+    response_next = response_body.get("next")
+    response_previous = response_body.get("previous")
+
+    next_url = None
+    previous_url = None
+
+    if response_next:
+        next_parsed = urlparse(response_next)
+        next_qs = parse_qs(next_parsed.query)
+        next_limit = next_qs.get(limit_param, [None])[0]
+        next_offset = next_qs.get(offset_param, [None])[0]
+
+        next_query_params = query_params.copy()
+        if next_limit:
+            next_query_params[limit_param] = next_limit
+        if next_offset:
+            next_query_params[offset_param] = next_offset
+
+        next_url = f"{insights_endpoint}?{urlencode(next_query_params)}"
+
+    if response_previous:
+        prev_parsed = urlparse(response_previous)
+        prev_qs = parse_qs(prev_parsed.query)
+        prev_limit = prev_qs.get(limit_param, [None])[0]
+        prev_offset = prev_qs.get(offset_param, [None])[0]
+
+        previous_query_params = query_params.copy()
+        if prev_limit:
+            previous_query_params[limit_param] = prev_limit
+        if prev_offset:
+            previous_query_params[offset_param] = prev_offset
+
+        previous_url = f"{insights_endpoint}?{urlencode(previous_query_params)}"
+
+    return PaginationURLs(
+        next_url=next_url,
+        previous_url=previous_url,
+    )
+

--- a/insights/core/urls/proxy_pagination.py
+++ b/insights/core/urls/proxy_pagination.py
@@ -118,4 +118,3 @@ def get_limit_offset_pagination_urls(
         next_url=next_url,
         previous_url=previous_url,
     )
-

--- a/insights/metrics/human_support/api/v2/views.py
+++ b/insights/metrics/human_support/api/v2/views.py
@@ -6,7 +6,7 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 
 from insights.authentication.permissions import ProjectAuthQueryParamPermission
-from insights.core.urls.proxy_pagination import get_cursor_based_pagination_urls
+from insights.core.urls.proxy_pagination import get_limit_offset_pagination_urls
 from insights.human_support.services import HumanSupportDashboardService
 from insights.projects.models import Project
 from insights.core.filters import get_filters_from_query_params
@@ -28,9 +28,10 @@ class DetailedMonitoringAgentsViewV2(APIView):
         filters["user_request"] = request.user.email
         data = service.get_detailed_monitoring_agents_v2(filters=filters)
 
-        pagination_urls = get_cursor_based_pagination_urls(request, data)
+        pagination_urls = get_limit_offset_pagination_urls(request, data)
 
         response_data = {
+            "count": data.get("count"),
             "results": data.get("results", []),
             "next": pagination_urls.next_url,
             "previous": pagination_urls.previous_url,

--- a/insights/metrics/human_support/api/v2/views.py
+++ b/insights/metrics/human_support/api/v2/views.py
@@ -6,6 +6,7 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 
 from insights.authentication.permissions import ProjectAuthQueryParamPermission
+from insights.core.urls.proxy_pagination import get_cursor_based_pagination_urls
 from insights.human_support.services import HumanSupportDashboardService
 from insights.projects.models import Project
 from insights.core.filters import get_filters_from_query_params
@@ -27,7 +28,15 @@ class DetailedMonitoringAgentsViewV2(APIView):
         filters["user_request"] = request.user.email
         data = service.get_detailed_monitoring_agents_v2(filters=filters)
 
-        return Response(data, status=200)
+        pagination_urls = get_cursor_based_pagination_urls(request, data)
+
+        response_data = {
+            "results": data.get("results", []),
+            "next": pagination_urls.next_url,
+            "previous": pagination_urls.previous_url,
+        }
+
+        return Response(response_data, status=200)
 
 
 class DetailedMonitoringStatusViewV2(APIView):


### PR DESCRIPTION
### What

- Added a new `get_limit_offset_pagination_urls` function in `insights/core/urls/proxy_pagination.py` that rewrites upstream limit/offset pagination URLs to point back through the Insights proxy, complementing the existing cursor-based pagination utility.
- Updated `DetailedMonitoringAgentsViewV2` in `insights/metrics/human_support/api/v2/views.py` to use the new limit/offset pagination function, replacing the previous behavior of forwarding the raw upstream response directly. The response now returns a structured payload with `count`, `results`, `next`, and `previous` fields, where `next` and `previous` URLs point to the Insights API instead of the upstream service.

### Why

The `DetailedMonitoringAgentsViewV2` endpoint acts as a proxy to an upstream service that uses limit/offset pagination. Previously, the upstream pagination URLs were passed through to the client as-is, meaning they pointed directly to the upstream service instead of the Insights API. This broke pagination for clients, since they couldn't follow the `next`/`previous` links through the proxy. The new `get_limit_offset_pagination_urls` function rewrites those URLs so they route back through the Insights proxy, preserving all existing query parameters while replacing the pagination-specific ones (`limit` and `offset`) with the correct values for the next/previous page.