### PR TITLE
fix: Only show expected ratings on conversation CSAT

### DIFF
--- a/insights/metrics/conversations/integrations/elasticsearch/services.py
+++ b/insights/metrics/conversations/integrations/elasticsearch/services.py
@@ -26,9 +26,20 @@ class ConversationsElasticsearchService:
         op_field: str,
         page_size: int,
         search_after: list[str] | None = None,
+        include_values: list[str] | None = None,
     ) -> list[dict]:
         start_date = self._format_date(start_date)
         end_date = self._format_date(end_date)
+
+        nested_clauses = [{"term": {"values.name": op_field}}]
+        if include_values:
+            nested_clauses.append({"terms": {"values.value": include_values}})
+
+        nested_query = (
+            {"bool": {"must": nested_clauses}}
+            if len(nested_clauses) > 1
+            else nested_clauses[0]
+        )
 
         query = {
             "_source": [
@@ -49,7 +60,7 @@ class ConversationsElasticsearchService:
                         {
                             "nested": {
                                 "path": "values",
-                                "query": {"term": {"values.name": op_field}},
+                                "query": nested_query,
                             }
                         },
                         {

--- a/insights/metrics/conversations/reports/services.py
+++ b/insights/metrics/conversations/reports/services.py
@@ -209,6 +209,7 @@ class BaseConversationsReportService(ABC):
         start_date: str,
         end_date: str,
         op_field: str,
+        include_values: list[str] | None = None,
     ) -> list[dict]:
         """
         Get flowsrun results by contacts.
@@ -1162,6 +1163,7 @@ class ConversationsReportService(BaseConversationsReportService):
         start_date: str,
         end_date: str,
         op_field: str,
+        include_values: list[str] | None = None,
     ) -> list[dict]:
         """
         Get flowsrun results by contacts.
@@ -1220,6 +1222,7 @@ class ConversationsReportService(BaseConversationsReportService):
                     op_field=op_field,
                     page_size=page_size,
                     search_after=search_after,
+                    include_values=include_values,
                 )
             )
 
@@ -1631,12 +1634,15 @@ class ConversationsReportService(BaseConversationsReportService):
                 % (report.uuid, ", ".join(missing_fields))
             )
 
+        valid_ratings = ["1", "2", "3", "4", "5"]
+
         docs = self.get_flowsrun_results_by_contacts(
             report=report,
             flow_uuid=flow_uuid,
             start_date=start_date,
             end_date=end_date,
             op_field=op_field,
+            include_values=valid_ratings,
         )
 
         with override(report.requested_by.language or "en"):

--- a/insights/metrics/conversations/services.py
+++ b/insights/metrics/conversations/services.py
@@ -601,6 +601,7 @@ class ConversationsMetricsService(
             "created_on__gte": self._convert_to_iso_string(start_date),
             "created_on__lte": self._convert_to_iso_string(end_date),
             "flow": flow_uuid,
+            "project": project_uuid,
         }
 
         return self.flowruns_query_executor.execute(

--- a/insights/metrics/conversations/services.py
+++ b/insights/metrics/conversations/services.py
@@ -587,6 +587,8 @@ class ConversationsMetricsService(
             end_date=end_date,
         )
 
+    VALID_CSAT_RATINGS = ["1", "2", "3", "4", "5"]
+
     def _get_csat_metrics_from_flowruns(
         self,
         flow_uuid: UUID,
@@ -608,6 +610,7 @@ class ConversationsMetricsService(
             query_kwargs={
                 "project": project_uuid,
                 "op_field": op_field,
+                "include_values": self.VALID_CSAT_RATINGS,
             },
         )
 

--- a/insights/sources/flowruns/query_builder.py
+++ b/insights/sources/flowruns/query_builder.py
@@ -68,15 +68,19 @@ class FlowRunElasticSearchQueryBuilder:
     def min(self, op_field, *args, **kwargs):
         return self._base_operation("min", op_field)
 
-    def recurrence(self, op_field: str, limit: int = 100, *args, **kwargs):
+    def recurrence(
+        self, op_field: str, limit: int = 100, include_values: list = None, *args, **kwargs
+    ):
+        filter_clauses = [{"term": {"values.name": op_field}}]
+        if include_values:
+            filter_clauses.append({"terms": {"values.value": include_values}})
+
         aggs = {
             "values": {
                 "nested": {"path": "values"},
                 "aggs": {
                     "agg_field": {
-                        "filter": {
-                            "bool": {"filter": [{"term": {"values.name": op_field}}]}
-                        },
+                        "filter": {"bool": {"filter": filter_clauses}},
                         "aggs": {
                             "agg_value": {
                                 "terms": {


### PR DESCRIPTION
### What

- Added an `include_values` parameter to the Elasticsearch queries in the flow runs data pipeline (`FlowRunElasticSearchQueryBuilder`, `ConversationsElasticsearchService`, and `ConversationsReportService`) to allow filtering results by specific field values at the query level.
- Applied this new filter to CSAT metrics and reports, restricting results to valid ratings only (`"1"`, `"2"`, `"3"`, `"4"`, `"5"`).
- Included the `project` UUID in the flow runs query parameters for CSAT metrics retrieval.

### Why

CSAT metrics were returning unexpected or invalid rating values (e.g., free-text responses, out-of-range numbers) from the flow run results, polluting the aggregated data. By filtering at the Elasticsearch query level, only the expected 1–5 ratings are considered, ensuring accurate CSAT calculations in both the metrics service and the conversation reports.