### PR TITLE
feat: implement parallel processing for event count retrieval in DatalakeConversationsMetricsService

### DIFF
--- a/insights/metrics/conversations/integrations/datalake/services.py
+++ b/insights/metrics/conversations/integrations/datalake/services.py
@@ -657,34 +657,44 @@ class DatalakeConversationsMetricsService(BaseDatalakeConversationsMetricsServic
                 logger.warning(f"Cache retrieval failed: {e}")
 
         try:
-            resolved_events_count = self.events_client.get_events_count(
-                project=project_uuid,
-                date_start=start_date,
-                date_end=end_date,
-                event_name=self.event_name,
-                key="conversation_classification",
-                value="resolved",
-                table="conversation_classification",
-            )[0].get("count", 0)
-            unresolved_events_count = self.events_client.get_events_count(
-                project=project_uuid,
-                date_start=start_date,
-                date_end=end_date,
-                event_name=self.event_name,
-                key="conversation_classification",
-                value="unresolved",
-                table="conversation_classification",
-            )[0].get("count", 0)
-            transferred_to_human_events_count = self.events_client.get_events_count(
-                project=project_uuid,
-                date_start=start_date,
-                date_end=end_date,
-                event_name=self.event_name,
-                key="conversation_classification",
-                metadata_key="human_support",
-                metadata_value="true",
-                table="conversation_classification",
-            )[0].get("count", 0)
+            with ThreadPoolExecutor(max_workers=3) as executor:
+                resolved_future = executor.submit(
+                    self.events_client.get_events_count,
+                    project=project_uuid,
+                    date_start=start_date,
+                    date_end=end_date,
+                    event_name=self.event_name,
+                    key="conversation_classification",
+                    value="resolved",
+                    table="conversation_classification",
+                )
+                unresolved_future = executor.submit(
+                    self.events_client.get_events_count,
+                    project=project_uuid,
+                    date_start=start_date,
+                    date_end=end_date,
+                    event_name=self.event_name,
+                    key="conversation_classification",
+                    value="unresolved",
+                    table="conversation_classification",
+                )
+                transferred_future = executor.submit(
+                    self.events_client.get_events_count,
+                    project=project_uuid,
+                    date_start=start_date,
+                    date_end=end_date,
+                    event_name=self.event_name,
+                    key="conversation_classification",
+                    metadata_key="human_support",
+                    metadata_value="true",
+                    table="conversation_classification",
+                )
+
+                resolved_events_count = resolved_future.result()[0].get("count", 0)
+                unresolved_events_count = unresolved_future.result()[0].get("count", 0)
+                transferred_to_human_events_count = transferred_future.result()[0].get(
+                    "count", 0
+                )
         except Exception as e:
             capture_exception(e)
             logger.error(e)


### PR DESCRIPTION
### What
Refactored the `get_conversations_totals` method in `DatalakeConversationsMetricsService` to execute the three `get_events_count` calls (resolved, unresolved, and transferred to human) in parallel using `ThreadPoolExecutor` with 3 workers, instead of sequentially one after the other.

### Why
Each `get_events_count` call is an I/O-bound request to the datalake. Running them sequentially means the total latency is the sum of all three calls. By executing them concurrently with a thread pool, the total latency is reduced to roughly the duration of the slowest single call, improving the response time of the conversations totals endpoint.

### Sequence diagram
```mermaid
sequenceDiagram
    participant Client
    participant Service as DatalakeConversationsMetricsService
    participant Cache
    participant Executor as ThreadPoolExecutor
    participant DL as Datalake Events Client

    Client->>Service: get_conversations_totals(project, start, end)
    Service->>Cache: Check cached results
    alt Cache hit
        Cache-->>Service: Return cached data
        Service-->>Client: ConversationsTotalsMetrics
    else Cache miss
        Service->>Executor: Create ThreadPoolExecutor(max_workers=3)
        par Parallel requests
            Executor->>DL: get_events_count(resolved)
            Executor->>DL: get_events_count(unresolved)
            Executor->>DL: get_events_count(transferred_to_human)
        end
        DL-->>Executor: resolved_count
        DL-->>Executor: unresolved_count
        DL-->>Executor: transferred_count
        Executor-->>Service: All futures resolved
        Service->>Service: Calculate totals & percentages
        Service->>Cache: Save results to cache
        Service-->>Client: ConversationsTotalsMetrics
    end
```