### PR TITLE
feat: remove parallel processing feature flags and streamline Datalake service methods

### DIFF
--- a/insights/metrics/conversations/integrations/datalake/services.py
+++ b/insights/metrics/conversations/integrations/datalake/services.py
@@ -11,7 +11,6 @@ from django.conf import settings
 from django.utils import timezone
 from django.utils.translation import override, gettext
 from sentry_sdk import capture_exception
-from weni.feature_flags.shortcuts import is_feature_active_for_attributes
 
 from insights.metrics.conversations.dataclass import (
     ConversationsTotalsMetric,
@@ -1218,55 +1217,23 @@ class DatalakeConversationsMetricsService(BaseDatalakeConversationsMetricsServic
             "date_end": end_date,
         }
 
-        try:
-            use_parallel = is_feature_active_for_attributes(
-                settings.CROSSTAB_PARALLEL_FETCHING_FEATURE_FLAG_KEY,
-                attributes={"projectUUID": str(project_uuid)},
-            )
-        except Exception as e:
-            logger.error(
-                "Failed to check if crosstab parallel fetching is active: %s", e
-            )
-            use_parallel = False
+        logger.info(
+            "[DATALAKE CONVERSATIONS METRICS SERVICE] Fetching source A and B events in parallel for project %s",
+            project_uuid,
+        )
 
-        if use_parallel:
-            logger.info(
-                "[DATALAKE CONVERSATIONS METRICS SERVICE] Fetching source A and B events in parallel for project %s",
-                project_uuid,
-            )
+        def fetch_source_a():
+            return self.get_raw_events_data(key=source_a.key, **common_kwargs)
 
-            def fetch_source_a():
-                return self.get_raw_events_data(key=source_a.key, **common_kwargs)
+        def fetch_source_b():
+            return self.get_raw_events_data(key=source_b.key, **common_kwargs)
 
-            def fetch_source_b():
-                return self.get_raw_events_data(key=source_b.key, **common_kwargs)
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            source_a_future = executor.submit(fetch_source_a)
+            source_b_future = executor.submit(fetch_source_b)
 
-            with ThreadPoolExecutor(max_workers=2) as executor:
-                source_a_future = executor.submit(fetch_source_a)
-                source_b_future = executor.submit(fetch_source_b)
-
-            source_a_events = source_a_future.result()
-            source_b_events = source_b_future.result()
-        else:
-            logger.info(
-                "[DATALAKE CONVERSATIONS METRICS SERVICE] Getting source A events for project %s with source A %s",
-                project_uuid,
-                source_a.key,
-            )
-            source_a_events = self.get_raw_events_data(
-                key=source_a.key,
-                **common_kwargs,
-            )
-
-            logger.info(
-                "[DATALAKE CONVERSATIONS METRICS SERVICE] Getting source B events for project %s with source B %s",
-                project_uuid,
-                source_b.key,
-            )
-            source_b_events = self.get_raw_events_data(
-                key=source_b.key,
-                **common_kwargs,
-            )
+        source_a_events = source_a_future.result()
+        source_b_events = source_b_future.result()
 
         labels_data = CrosstabLabelsSerializer(
             source_a_events, source_a.field, reference_field=reference_field

--- a/insights/metrics/conversations/integrations/datalake/tests/test_services.py
+++ b/insights/metrics/conversations/integrations/datalake/tests/test_services.py
@@ -1707,11 +1707,7 @@ class DatalakeConversationsMetricsServiceTestCase(TestCase):
         self.assertIsInstance(results["quoted_value"], ToolResultMetric)
         self.assertEqual(results["quoted_value"].count, 4)
 
-    @patch(
-        "insights.metrics.conversations.integrations.datalake.services.is_feature_active_for_attributes",
-        return_value=True,
-    )
-    def test_get_crosstab_data_parallel_fetching(self, mock_feature_flag):
+    def test_get_crosstab_data_parallel_fetching(self):
         project_uuid = uuid.uuid4()
         start_date = datetime.now() - timedelta(days=1)
         end_date = datetime.now()
@@ -1746,109 +1742,6 @@ class DatalakeConversationsMetricsServiceTestCase(TestCase):
                 date_start=start_date,
                 date_end=end_date,
             )
-
-        mock_feature_flag.assert_called_once_with(
-            "insightsCrosstabParallelFetching",
-            attributes={"projectUUID": str(project_uuid)},
-        )
-
-    @patch(
-        "insights.metrics.conversations.integrations.datalake.services.is_feature_active_for_attributes",
-        return_value=False,
-    )
-    def test_get_crosstab_data_sequential_fetching(self, mock_feature_flag):
-        project_uuid = uuid.uuid4()
-        start_date = datetime.now() - timedelta(days=1)
-        end_date = datetime.now()
-        source_a = CrosstabSource(key="source_a_key", field="value")
-        source_b = CrosstabSource(key="source_b_key", field="value")
-
-        self.mock_events_client.get_events.return_value = []
-
-        with patch.object(
-            self.service, "get_raw_events_data", return_value=[]
-        ) as mock_get_raw:
-            self.service.get_crosstab_data(
-                project_uuid=project_uuid,
-                source_a=source_a,
-                source_b=source_b,
-                start_date=start_date,
-                end_date=end_date,
-            )
-
-            self.assertEqual(mock_get_raw.call_count, 2)
-            mock_get_raw.assert_any_call(
-                key="source_a_key",
-                event_name=self.service.event_name,
-                project=project_uuid,
-                date_start=start_date,
-                date_end=end_date,
-            )
-            mock_get_raw.assert_any_call(
-                key="source_b_key",
-                event_name=self.service.event_name,
-                project=project_uuid,
-                date_start=start_date,
-                date_end=end_date,
-            )
-
-        mock_feature_flag.assert_called_once_with(
-            "insightsCrosstabParallelFetching",
-            attributes={"projectUUID": str(project_uuid)},
-        )
-
-    @patch(
-        "insights.metrics.conversations.integrations.datalake.services.is_feature_active_for_attributes",
-        return_value=True,
-    )
-    def test_get_crosstab_data_parallel_returns_same_result_as_sequential(
-        self, mock_feature_flag
-    ):
-        project_uuid = uuid.uuid4()
-        start_date = datetime.now() - timedelta(days=1)
-        end_date = datetime.now()
-        source_a = CrosstabSource(key="source_a_key", field="value")
-        source_b = CrosstabSource(key="source_b_key", field="value")
-
-        source_a_events = [
-            {"value": "label_1", "join_key": "jk1"},
-            {"value": "label_2", "join_key": "jk2"},
-        ]
-        source_b_events = [
-            {"value": "data_1", "join_key": "jk1"},
-            {"value": "data_2", "join_key": "jk2"},
-        ]
-
-        def get_raw_side_effect(**kwargs):
-            if kwargs.get("key") == "source_a_key":
-                return source_a_events
-            return source_b_events
-
-        with patch.object(
-            self.service, "get_raw_events_data", side_effect=get_raw_side_effect
-        ):
-            parallel_result = self.service.get_crosstab_data(
-                project_uuid=project_uuid,
-                source_a=source_a,
-                source_b=source_b,
-                start_date=start_date,
-                end_date=end_date,
-            )
-
-        mock_feature_flag.return_value = False
-
-        with patch.object(
-            self.service, "get_raw_events_data", side_effect=get_raw_side_effect
-        ):
-            sequential_result = self.service.get_crosstab_data(
-                project_uuid=project_uuid,
-                source_a=source_a,
-                source_b=source_b,
-                start_date=start_date,
-                end_date=end_date,
-            )
-
-        self.assertEqual(parallel_result, sequential_result)
 
     def test_get_unique_contacts_count(self):
         project_uuid = uuid.uuid4()

--- a/insights/metrics/conversations/reports/services.py
+++ b/insights/metrics/conversations/reports/services.py
@@ -19,7 +19,6 @@ from django.utils.translation import gettext_lazy as _
 from django.utils.translation import gettext, override
 from django.utils import translation, timezone
 from sentry_sdk import capture_exception
-from weni.feature_flags.shortcuts import is_feature_active
 
 from insights.metrics.conversations.enums import ConversationType
 from insights.metrics.conversations.reports.available_widgets import (
@@ -171,13 +170,6 @@ class BaseConversationsReportService(ABC):
     def get_datalake_events_in_parallel(self, report: Report, **kwargs) -> list[dict]:
         """
         Get datalake events in parallel.
-        """
-        raise NotImplementedError("Subclasses must implement this method")
-
-    @abstractmethod
-    def should_use_parallel_processing(self, report: Report) -> bool:
-        """
-        Check if parallel processing should be used.
         """
         raise NotImplementedError("Subclasses must implement this method")
 
@@ -1078,39 +1070,11 @@ class ConversationsReportService(BaseConversationsReportService):
 
         return events
 
-    def should_use_parallel_processing(self, report: Report) -> bool:
-        """
-        Check if parallel processing should be used.
-        """
-        feature_flag_key = (
-            settings.REPORT_GENERATION_USE_PARALLEL_PROCESSING_FEATURE_FLAG_KEY
-        )
-
-        try:
-            is_feature_flag_active = is_feature_active(
-                key=feature_flag_key,
-                user_email=report.requested_by.email,
-                project_uuid=report.project.uuid,
-            )
-            return is_feature_flag_active
-
-        except Exception as e:
-            logger.error(
-                "[CONVERSATIONS REPORT SERVICE] Failed to check if parallel processing should be used for report %s. Error: %s",
-                report.uuid,
-                e,
-            )
-            capture_exception(e)
-            return False
-
     def get_datalake_events(self, report: Report, **kwargs) -> list[dict]:
         """
         Get datalake events.
         """
-        if self.should_use_parallel_processing(report):
-            return self.get_datalake_events_in_parallel(report, **kwargs)
-        else:
-            return self.get_datalake_events_sequential(report, **kwargs)
+        return self.get_datalake_events_in_parallel(report, **kwargs)
 
     def _format_date(self, original_date: str | int, report: Report) -> str:
         """

--- a/insights/metrics/conversations/reports/tests/test_services.py
+++ b/insights/metrics/conversations/reports/tests/test_services.py
@@ -379,16 +379,12 @@ class TestConversationsReportService(TestCase):
         self.assertEqual(self.service.get_next_report_to_generate(), first_report)
 
     @patch(
-        "insights.metrics.conversations.reports.services.ConversationsReportService.should_use_parallel_processing",
-        return_value=False,
-    )
-    @patch(
         "insights.sources.dl_events.tests.mock_client.MockDataLakeEventsClient.get_events"
     )
     @patch("insights.sources.tests.mock.MockCacheClient.set")
     @patch("insights.sources.tests.mock.MockCacheClient.get")
     def test_get_datalake_events_when_no_events_exist(
-        self, mock_cache_get, mock_cache_set, mock_get_datalake_events, _mock_parallel
+        self, mock_cache_get, mock_cache_set, mock_get_datalake_events
     ):
         mock_get_datalake_events.return_value = []
         mock_cache_get.return_value = None
@@ -420,16 +416,12 @@ class TestConversationsReportService(TestCase):
         )
 
     @patch(
-        "insights.metrics.conversations.reports.services.ConversationsReportService.should_use_parallel_processing",
-        return_value=False,
-    )
-    @patch(
         "insights.sources.dl_events.tests.mock_client.MockDataLakeEventsClient.get_events"
     )
     @patch("insights.sources.tests.mock.MockCacheClient.set")
     @patch("insights.sources.tests.mock.MockCacheClient.get")
     def test_get_datalake_events_when_events_exist(
-        self, mock_cache_get, mock_cache_set, mock_get_datalake_events, _mock_parallel
+        self, mock_cache_get, mock_cache_set, mock_get_datalake_events
     ):
         mock_cache_get.return_value = None
         mock_cache_set.return_value = None
@@ -469,16 +461,12 @@ class TestConversationsReportService(TestCase):
         )
 
     @patch(
-        "insights.metrics.conversations.reports.services.ConversationsReportService.should_use_parallel_processing",
-        return_value=False,
-    )
-    @patch(
         "insights.sources.dl_events.tests.mock_client.MockDataLakeEventsClient.get_events"
     )
     @patch("insights.sources.tests.mock.MockCacheClient.set")
     @patch("insights.sources.tests.mock.MockCacheClient.get")
     def test_get_datalake_events_when_events_exist_with_multiple_pages(
-        self, mock_cache_get, mock_cache_set, mock_get_datalake_events, _mock_parallel
+        self, mock_cache_get, mock_cache_set, mock_get_datalake_events
     ):
         mock_cache_get.return_value = None
         mock_cache_set.return_value = None
@@ -517,27 +505,14 @@ class TestConversationsReportService(TestCase):
             cache_key, json.dumps(events), ex=settings.REPORT_GENERATION_TIMEOUT
         )
 
-    @patch(
-        "insights.metrics.conversations.reports.services.ConversationsReportService.should_use_parallel_processing",
-        return_value=False,
-    )
-    @patch(
-        "insights.sources.dl_events.tests.mock_client.MockDataLakeEventsClient.get_events"
-    )
+    @patch.object(ConversationsReportService, "get_events_count")
     def test_get_datalake_events_when_page_limit_is_reached(
-        self, mock_get_datalake_events, _mock_parallel
+        self, mock_get_events_count
     ):
-        mock_events = [{"id": "1"}, {"id": "2"}]
-
-        def get_datalake_events(**kwargs):
-            if (
-                kwargs.get("offset")
-                < self.service.events_limit_per_page * self.service.page_limit + 1
-            ):
-                return mock_events
-            return []
-
-        mock_get_datalake_events.side_effect = get_datalake_events
+        total_exceeding_page_limit = (
+            self.service.events_limit_per_page * self.service.page_limit
+        )
+        mock_get_events_count.return_value = total_exceeding_page_limit
 
         report = Report.objects.create(
             project=self.project,
@@ -629,14 +604,10 @@ class TestConversationsReportService(TestCase):
         self.assertEqual(worksheet.data[1]["Subtopic"], "Unclassified")
 
     @patch(
-        "insights.metrics.conversations.reports.services.ConversationsReportService.should_use_parallel_processing",
-        return_value=False,
-    )
-    @patch(
         "insights.sources.dl_events.tests.mock_client.MockDataLakeEventsClient.get_events"
     )
     def test_get_datalake_events_when_report_is_failed(
-        self, mock_get_datalake_events, _mock_parallel
+        self, mock_get_datalake_events
     ):
         mock_events = [{"id": "1"}, {"id": "2"}]
 
@@ -1217,11 +1188,7 @@ class TestConversationsReportServiceAdditional(TestCase):
                 self.assertEqual(report.status, ReportStatus.FAILED)
                 self.assertIn("send_email", report.errors)
 
-    @patch(
-        "insights.metrics.conversations.reports.services.ConversationsReportService.should_use_parallel_processing",
-        return_value=False,
-    )
-    def test_get_datalake_events_with_cached_data(self, _mock_parallel):
+    def test_get_datalake_events_with_cached_data(self):
         """Test get_datalake_events with cached data."""
         report = Report.objects.create(
             project=self.project,
@@ -1251,11 +1218,7 @@ class TestConversationsReportServiceAdditional(TestCase):
                     self.assertEqual(events, cached_events)
                     mock_cache_get.assert_called_once_with(cache_key)
 
-    @patch(
-        "insights.metrics.conversations.reports.services.ConversationsReportService.should_use_parallel_processing",
-        return_value=False,
-    )
-    def test_get_datalake_events_with_invalid_cached_data(self, _mock_parallel):
+    def test_get_datalake_events_with_invalid_cached_data(self):
         """Test get_datalake_events with invalid cached data."""
         report = Report.objects.create(
             project=self.project,
@@ -1279,11 +1242,7 @@ class TestConversationsReportServiceAdditional(TestCase):
 
                 self.assertEqual(events, [])
 
-    @patch(
-        "insights.metrics.conversations.reports.services.ConversationsReportService.should_use_parallel_processing",
-        return_value=False,
-    )
-    def test_get_datalake_events_with_empty_events(self, _mock_parallel):
+    def test_get_datalake_events_with_empty_events(self):
         """Test get_datalake_events with empty events list."""
         report = Report.objects.create(
             project=self.project,
@@ -2631,14 +2590,10 @@ class TestConversationsReportServiceAdditional(TestCase):
         mock_get_custom_widget.assert_called_once()
 
     @patch(
-        "insights.metrics.conversations.reports.services.ConversationsReportService.should_use_parallel_processing",
-        return_value=False,
-    )
-    @patch(
         "insights.sources.dl_events.tests.mock_client.MockDataLakeEventsClient.get_events"
     )
     def test_get_datalake_events_with_datetime_objects(
-        self, mock_get_events, _mock_parallel
+        self, mock_get_events
     ):
         """Test get_datalake_events with datetime objects in kwargs."""
         mock_get_events.return_value = []
@@ -3992,74 +3947,6 @@ class TestGetEventsCount(TestCase):
         self.assertIsInstance(call_kwargs["date_end"], str)
 
 
-class TestShouldUseParallelProcessing(TestCase):
-    def setUp(self):
-        self.service = ConversationsReportService(
-            elasticsearch_service=ConversationsElasticsearchService(
-                client=MockElasticsearchClient(),
-            ),
-            events_limit_per_page=5,
-            page_limit=5,
-            datalake_events_client=MockDataLakeEventsClient(),
-            metrics_service=ConversationsMetricsService(
-                datalake_service=MagicMock(spec=BaseConversationsMetricsService),
-                nexus_conversations_client=MagicMock(spec=NexusConversationsAPIClient),
-                cache_client=MockCacheClient(),
-                flowruns_query_executor=MockFlowRunsQueryExecutor(),
-            ),
-            cache_client=MockCacheClient(),
-        )
-        self.project = Project.objects.create(name="Test")
-        self.user = User.objects.create(email="test@test.com", language="en")
-
-    @patch("insights.metrics.conversations.reports.services.is_feature_active")
-    def test_returns_true_when_feature_flag_is_active(self, mock_is_feature_active):
-        mock_is_feature_active.return_value = True
-
-        report = Report.objects.create(
-            project=self.project,
-            source=self.service.source,
-            source_config={},
-            filters={},
-            format=ReportFormat.CSV,
-            requested_by=self.user,
-        )
-
-        self.assertTrue(self.service.should_use_parallel_processing(report))
-
-    @patch("insights.metrics.conversations.reports.services.is_feature_active")
-    def test_returns_false_when_feature_flag_is_inactive(self, mock_is_feature_active):
-        mock_is_feature_active.return_value = False
-
-        report = Report.objects.create(
-            project=self.project,
-            source=self.service.source,
-            source_config={},
-            filters={},
-            format=ReportFormat.CSV,
-            requested_by=self.user,
-        )
-
-        self.assertFalse(self.service.should_use_parallel_processing(report))
-
-    @patch("insights.metrics.conversations.reports.services.is_feature_active")
-    def test_returns_false_when_feature_flag_raises_exception(
-        self, mock_is_feature_active
-    ):
-        mock_is_feature_active.side_effect = Exception("Feature flag error")
-
-        report = Report.objects.create(
-            project=self.project,
-            source=self.service.source,
-            source_config={},
-            filters={},
-            format=ReportFormat.CSV,
-            requested_by=self.user,
-        )
-
-        self.assertFalse(self.service.should_use_parallel_processing(report))
-
-
 class TestGetDatalakeEventsDispatch(TestCase):
     def setUp(self):
         self.service = ConversationsReportService(
@@ -4081,14 +3968,7 @@ class TestGetDatalakeEventsDispatch(TestCase):
         self.user = User.objects.create(email="test@test.com", language="en")
 
     @patch.object(ConversationsReportService, "get_datalake_events_in_parallel")
-    @patch.object(
-        ConversationsReportService,
-        "should_use_parallel_processing",
-        return_value=True,
-    )
-    def test_dispatches_to_parallel_when_flag_is_active(
-        self, _mock_parallel, mock_parallel_method
-    ):
+    def test_dispatches_to_parallel(self, mock_parallel_method):
         mock_parallel_method.return_value = [{"id": "1"}]
 
         report = Report.objects.create(
@@ -4104,32 +3984,6 @@ class TestGetDatalakeEventsDispatch(TestCase):
         result = self.service.get_datalake_events(report, key="example")
 
         mock_parallel_method.assert_called_once_with(report, key="example")
-        self.assertEqual(result, [{"id": "1"}])
-
-    @patch.object(ConversationsReportService, "get_datalake_events_sequential")
-    @patch.object(
-        ConversationsReportService,
-        "should_use_parallel_processing",
-        return_value=False,
-    )
-    def test_dispatches_to_sequential_when_flag_is_inactive(
-        self, _mock_parallel, mock_sequential_method
-    ):
-        mock_sequential_method.return_value = [{"id": "1"}]
-
-        report = Report.objects.create(
-            project=self.project,
-            source=self.service.source,
-            source_config={},
-            filters={},
-            format=ReportFormat.CSV,
-            requested_by=self.user,
-            status=ReportStatus.IN_PROGRESS,
-        )
-
-        result = self.service.get_datalake_events(report, key="example")
-
-        mock_sequential_method.assert_called_once_with(report, key="example")
         self.assertEqual(result, [{"id": "1"}])
 
 

--- a/insights/settings.py
+++ b/insights/settings.py
@@ -403,10 +403,6 @@ REPORT_GENERATION_MAX_CONCURRENT_REPORTS = env.int(
 REPORT_GENERATION_TIMEOUT = env.int(
     "REPORT_GENERATION_TIMEOUT", default=60 * 60
 )  # 1 hour
-REPORT_GENERATION_USE_PARALLEL_PROCESSING_FEATURE_FLAG_KEY = env.str(
-    "REPORT_GENERATION_USE_PARALLEL_PROCESSING_FEATURE_FLAG_KEY",
-    default="insightsReportGenerationUseParallelProcessing",
-)
 REPORT_PARALLEL_FETCH_MAX_WORKERS = env.int(
     "REPORT_PARALLEL_FETCH_MAX_WORKERS", default=5
 )
@@ -561,10 +557,4 @@ VTEX_ORDERS_API_CACHE_TTL = env.int("VTEX_ORDERS_API_CACHE_TTL", default=60 * 60
 # Data source service
 DATA_SOURCE_SERVICE_FEATURE_FLAG_KEY = env.str(
     "DATA_SOURCE_SERVICE_FEATURE_FLAG_KEY", default="insightsDataSourceService"
-)
-
-# Crosstab parallel fetching
-CROSSTAB_PARALLEL_FETCHING_FEATURE_FLAG_KEY = env.str(
-    "CROSSTAB_PARALLEL_FETCHING_FEATURE_FLAG_KEY",
-    default="insightsCrosstabParallelFetching",
 )


### PR DESCRIPTION
### What
- Removed the `insightsCrosstabParallelFetching` and `insightsReportGenerationUseParallelProcessing` feature flags along with their corresponding settings, feature flag checks, and sequential fallback code paths.
- The crosstab data fetching in `DatalakeConversationsMetricsService.get_crosstab_data` now always uses `ThreadPoolExecutor` for parallel requests instead of conditionally falling back to sequential fetching.
- The report generation in `ConversationsReportService.get_datalake_events` now always dispatches to `get_datalake_events_in_parallel`, and the `should_use_parallel_processing` abstract method was removed from `BaseConversationsReportService`.
- Removed the `weni.feature_flags` import from both service modules.
- Cleaned up tests by removing the `TestShouldUseParallelProcessing` test class, the sequential fetching and parallel-vs-sequential comparison tests, and all feature flag mocks that were no longer needed.

### Why
The parallel processing feature flags (`insightsCrosstabParallelFetching` and `insightsReportGenerationUseParallelProcessing`) have served their purpose as a gradual rollout mechanism. Since parallel fetching has been validated in production, the flags are no longer needed. Removing them simplifies the codebase by eliminating dead code paths, unnecessary branching logic, and external feature flag dependencies, making the services easier to maintain going forward.