### PR TITLE
feat: get wabas from dashboard in abandoned cart skill

### DIFF
--- a/insights/metrics/skills/services/abandoned_cart.py
+++ b/insights/metrics/skills/services/abandoned_cart.py
@@ -1,4 +1,3 @@
-from functools import cached_property
 import json
 import logging
 

--- a/insights/metrics/skills/services/abandoned_cart.py
+++ b/insights/metrics/skills/services/abandoned_cart.py
@@ -24,8 +24,8 @@ from insights.settings import (
     ABANDONED_CART_META_TEMPLATE_IDS_PER_REQUEST,
     ABANDONED_CART_METRICS_START_DATE_MAX_DAYS,
 )
+from insights.dashboards.models import Dashboard
 from insights.sources.cache import CacheClient
-from insights.sources.integrations.clients import WeniIntegrationsClient
 
 logger = logging.getLogger(__name__)
 
@@ -66,23 +66,24 @@ class AbandonedCartSkillService(BaseSkillMetricsService):
 
         return valid_fields
 
-    @cached_property
+    @property
     def _project_wabas(self) -> list[dict]:
-        client = WeniIntegrationsClient()
-        try:
-            wabas = client.get_wabas_for_project(self.project.uuid)
-        except ValueError as e:
-            logger.error(
-                "Error fetching wabas in AbandonedCartSkillService for project %s: %s",
-                self.project.uuid,
-                e,
-            )
+        configs = Dashboard.objects.filter(
+            project=self.project,
+            config__is_whatsapp_integration=True,
+        ).values_list("config", flat=True)
 
-            raise e
+        seen = set()
+        wabas = []
+        for config in configs:
+            waba_id = config.get("waba_id")
+            if waba_id and waba_id not in seen:
+                seen.add(waba_id)
+                wabas.append({"waba_id": waba_id})
 
-        return [waba for waba in wabas if waba["waba_id"]]
+        return wabas
 
-    @cached_property
+    @property
     def _whatsapp_template_ids_and_waba(self):
         name = "weni_abandoned_cart"
 
@@ -138,7 +139,9 @@ class AbandonedCartSkillService(BaseSkillMetricsService):
         self, waba_id, template_ids, start_date, end_date, product_type
     ) -> list[dict]:
         data_points = []
-        for i in range(0, len(template_ids), ABANDONED_CART_META_TEMPLATE_IDS_PER_REQUEST):
+        for i in range(
+            0, len(template_ids), ABANDONED_CART_META_TEMPLATE_IDS_PER_REQUEST
+        ):
             chunk = template_ids[i : i + ABANDONED_CART_META_TEMPLATE_IDS_PER_REQUEST]
             metrics = self.meta_api_client.get_messages_analytics(
                 waba_id=waba_id,

--- a/insights/metrics/skills/services/tests/test_abandoned_cart_metrics_service.py
+++ b/insights/metrics/skills/services/tests/test_abandoned_cart_metrics_service.py
@@ -17,6 +17,7 @@ from insights.metrics.skills.services.abandoned_cart import (
     AbandonedCartSkillService,
 )
 from insights.metrics.skills.services.dataclass import AbandonedCartWhatsAppTemplate
+from insights.dashboards.models import Dashboard
 from insights.projects.models import Project
 from insights.sources.cache import CacheClient
 from insights.metrics.meta.utils import (
@@ -80,17 +81,15 @@ class TestAbandonedCartSkillService(TestCase):
             service.validate_filters(filters)
 
     @patch("insights.metrics.meta.clients.MetaGraphAPIClient.get_templates_list")
-    @patch(
-        "insights.sources.integrations.clients.WeniIntegrationsClient.get_wabas_for_project"
-    )
     def test_cannot_whatsapp_template_id_and_waba_when_template_is_not_found(
-        self, mock_wabas, mock_templates_list
+        self, mock_templates_list
     ):
-        mock_wabas.return_value = [
-            {
-                "waba_id": "123456789098765",
-            },
-        ]
+        Dashboard.objects.create(
+            project=self.project,
+            name="dash",
+            description="",
+            config={"is_whatsapp_integration": True, "waba_id": "123456789098765"},
+        )
         mock_templates_list.return_value = {"data": []}
 
         with self.assertRaises(TemplateNotFound):
@@ -100,22 +99,19 @@ class TestAbandonedCartSkillService(TestCase):
     @patch("insights.sources.vtexcredentials.clients.AuthRestClient.get_vtex_auth")
     @patch("insights.metrics.meta.clients.MetaGraphAPIClient.get_messages_analytics")
     @patch("insights.metrics.meta.clients.MetaGraphAPIClient.get_templates_list")
-    @patch(
-        "insights.sources.integrations.clients.WeniIntegrationsClient.get_wabas_for_project"
-    )
     def test_get_metrics(
         self,
-        mock_wabas,
         mock_templates_list,
         mock_messages_analytics,
         mock_get_vtex_auth,
         mock_vtex_orders_list,
     ):
-        mock_wabas.return_value = [
-            {
-                "waba_id": "123456789098765",
-            },
-        ]
+        Dashboard.objects.create(
+            project=self.project,
+            name="dash",
+            description="",
+            config={"is_whatsapp_integration": True, "waba_id": "123456789098765"},
+        )
         mock_templates_list.return_value = {
             "data": [
                 {
@@ -213,13 +209,15 @@ class TestAbandonedCartSkillService(TestCase):
         self.assertEqual(json.loads(self.cache_client.get(cache_key)), expected_metrics)
 
     @patch("insights.metrics.meta.clients.MetaGraphAPIClient.get_templates_list")
-    @patch(
-        "insights.sources.integrations.clients.WeniIntegrationsClient.get_wabas_for_project"
-    )
     def test_whatsapp_template_ids_returns_all_templates_sorted_desc(
-        self, mock_wabas, mock_templates_list
+        self, mock_templates_list
     ):
-        mock_wabas.return_value = [{"waba_id": "waba_123"}]
+        Dashboard.objects.create(
+            project=self.project,
+            name="dash",
+            description="",
+            config={"is_whatsapp_integration": True, "waba_id": "waba_123"},
+        )
         mock_templates_list.return_value = {
             "data": [
                 {"name": "weni_abandoned_cart_1700000000", "id": "t1"},
@@ -241,13 +239,15 @@ class TestAbandonedCartSkillService(TestCase):
         self.assertEqual(templates[2].ids, ["t1"])
 
     @patch("insights.metrics.meta.clients.MetaGraphAPIClient.get_templates_list")
-    @patch(
-        "insights.sources.integrations.clients.WeniIntegrationsClient.get_wabas_for_project"
-    )
     def test_whatsapp_template_ids_groups_ids_by_name(
-        self, mock_wabas, mock_templates_list
+        self, mock_templates_list
     ):
-        mock_wabas.return_value = [{"waba_id": "waba_123"}]
+        Dashboard.objects.create(
+            project=self.project,
+            name="dash",
+            description="",
+            config={"is_whatsapp_integration": True, "waba_id": "waba_123"},
+        )
         mock_templates_list.return_value = {
             "data": [
                 {"name": "weni_abandoned_cart_1700000000", "id": "t1"},
@@ -324,13 +324,15 @@ class TestAbandonedCartSkillService(TestCase):
 
     @patch("insights.metrics.meta.clients.MetaGraphAPIClient.get_messages_analytics")
     @patch("insights.metrics.meta.clients.MetaGraphAPIClient.get_templates_list")
-    @patch(
-        "insights.sources.integrations.clients.WeniIntegrationsClient.get_wabas_for_project"
-    )
     def test_get_message_templates_metrics_combines_chunked_results(
-        self, mock_wabas, mock_templates_list, mock_analytics
+        self, mock_templates_list, mock_analytics
     ):
-        mock_wabas.return_value = [{"waba_id": "waba_123"}]
+        Dashboard.objects.create(
+            project=self.project,
+            name="dash",
+            description="",
+            config={"is_whatsapp_integration": True, "waba_id": "waba_123"},
+        )
         mock_templates_list.return_value = {
             "data": [
                 {"name": f"weni_abandoned_cart_{1700000000 + i}", "id": str(i)}


### PR DESCRIPTION
### What

Replaced the external `WeniIntegrationsClient` API call with a local database query using the `Dashboard` model to retrieve WABA (WhatsApp Business Account) information in the `AbandonedCartSkillService`.

Key changes:
- The `_project_wabas` property now queries `Dashboard` objects filtered by `project` and `config__is_whatsapp_integration=True`, extracting unique `waba_id` values from the config JSON field.
- Removed the `WeniIntegrationsClient` import and the `cached_property` import (replaced with `@property`).
- Added `Dashboard` model import.
- Updated all related tests to create `Dashboard` objects directly instead of mocking `WeniIntegrationsClient.get_wabas_for_project`, reducing mock complexity.
- Minor formatting fix in `_get_message_templates_metrics` for line length compliance.

### Why

The previous implementation relied on an external HTTP call to the Weni Integrations service to fetch WABA data for a project. Since this information is already available locally in the `Dashboard` model's config, querying the database directly eliminates an unnecessary network dependency, improving reliability, reducing latency, and simplifying error handling. The `cached_property` decorator was also replaced with a plain `@property` since the data now comes from a fast local query rather than an external API call.

### Sequence diagram

```mermaid
sequenceDiagram
    participant Client
    participant AbandonedCartSkillService
    participant Dashboard DB
    participant MetaGraphAPI

    Client->>AbandonedCartSkillService: get_metrics(filters)
    AbandonedCartSkillService->>AbandonedCartSkillService: validate_filters(filters)

    AbandonedCartSkillService->>Dashboard DB: Query dashboards where<br/>project=project &<br/>config__is_whatsapp_integration=True
    Dashboard DB-->>AbandonedCartSkillService: Dashboard configs with waba_id

    AbandonedCartSkillService->>AbandonedCartSkillService: Deduplicate waba_ids

    loop For each WABA
        AbandonedCartSkillService->>MetaGraphAPI: get_templates_list(waba_id)
        MetaGraphAPI-->>AbandonedCartSkillService: Templates matching "weni_abandoned_cart"

        loop For each template chunk
            AbandonedCartSkillService->>MetaGraphAPI: get_messages_analytics(waba_id, template_ids)
            MetaGraphAPI-->>AbandonedCartSkillService: Message analytics data points
        end
    end

    AbandonedCartSkillService-->>Client: Aggregated abandoned cart metrics
```