### PR TITLE
chore: add comprehensive tests for pagination and permissions in metrics module

### DIFF
--- a/insights/authentication/tests/test_authentication.py
+++ b/insights/authentication/tests/test_authentication.py
@@ -1,13 +1,28 @@
 import uuid
-from rest_framework.test import APITestCase
-from rest_framework.views import APIView
-from rest_framework.response import Response
-from rest_framework import status
-from insights.authentication.authentication import JWTAuthentication
-from insights.authentication.permissions import HasInternalAuthenticationPermission
-from django.test import override_settings
-from django.urls import reverse
+from unittest.mock import MagicMock, patch
 
+from django.contrib.auth import get_user_model
+from django.test import RequestFactory, TestCase, override_settings
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.exceptions import ValidationError
+from rest_framework.request import Request
+from rest_framework.response import Response
+from rest_framework.test import APIRequestFactory, APITestCase
+from rest_framework.views import APIView
+
+from insights.authentication.admin_sso import (
+    AdminOIDCAuthenticationBackend,
+    admin_oidc_logout,
+    get_oidc_logout_url,
+)
+from insights.authentication.authentication import JWTAuthentication
+from insights.authentication.permissions import (
+    FeatureFlagPermission,
+    HasInternalAuthenticationPermission,
+    ProjectAuthBodyPermission,
+    ProjectQueryParamPermission,
+)
 from insights.authentication.services.jwt_service import JWTService
 from insights.authentication.services.tests.test_jwt_service import (
     generate_private_key,
@@ -15,7 +30,10 @@ from insights.authentication.services.tests.test_jwt_service import (
     generate_public_key,
     generate_public_key_pem,
 )
-from insights.projects.models import Project
+from insights.dashboards.models import Dashboard
+from insights.projects.models import Project, ProjectAuth
+
+User = get_user_model()
 
 
 TEST_PRIVATE_KEY = generate_private_key()
@@ -70,3 +88,261 @@ class TestJWTAuthentication(APITestCase):
         url = reverse("jwt-authentication-view")
         response = self.client.get(url, HTTP_AUTHORIZATION="Bearer invalid-token")
         self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+
+class TestProjectAuthBodyPermission(TestCase):
+    def setUp(self):
+        self.factory = APIRequestFactory()
+        self.permission = ProjectAuthBodyPermission()
+        self.user = User.objects.create_user(email="body@test.com")
+        self.project = Project.objects.create(name="Body Project")
+        self.view = MagicMock()
+
+    def _make_post_request(self, data):
+        wsgi_request = self.factory.post("/", data={}, format="json")
+        request = Request(wsgi_request)
+        request.user = self.user
+        request._full_data = data
+        return request
+
+    def test_missing_project_uuid_raises_validation_error(self):
+        request = self._make_post_request({})
+        with self.assertRaises(ValidationError) as ctx:
+            self.permission.has_permission(request, self.view)
+        self.assertIn("project_uuid", ctx.exception.detail)
+
+    def test_valid_project_uuid_with_auth(self):
+        ProjectAuth.objects.create(project=self.project, user=self.user, role=1)
+        request = self._make_post_request({"project_uuid": str(self.project.uuid)})
+        self.assertTrue(self.permission.has_permission(request, self.view))
+
+    def test_valid_project_uuid_without_auth(self):
+        request = self._make_post_request({"project_uuid": str(self.project.uuid)})
+        self.assertFalse(self.permission.has_permission(request, self.view))
+
+
+class TestProjectQueryParamPermission(TestCase):
+    def setUp(self):
+        self.factory = APIRequestFactory()
+        self.permission = ProjectQueryParamPermission()
+        self.user = User.objects.create_user(email="qp@test.com")
+        self.project = Project.objects.create(name="QP Project")
+        self.view = MagicMock()
+
+    def _make_request(self, method="get", **kwargs):
+        fn = getattr(self.factory, method)
+        wsgi_request = fn(**kwargs)
+        request = Request(wsgi_request)
+        return request
+
+    def test_anonymous_user_returns_false(self):
+        from django.contrib.auth.models import AnonymousUser
+
+        request = self._make_request(path="/")
+        request.user = AnonymousUser()
+        self.assertFalse(self.permission.has_permission(request, self.view))
+
+    def test_missing_project_uuid_raises_validation_error(self):
+        request = self._make_request(path="/")
+        request.user = self.user
+        with self.assertRaises(ValidationError) as ctx:
+            self.permission.has_permission(request, self.view)
+        self.assertIn("project_uuid", ctx.exception.detail)
+
+    def test_valid_auth(self):
+        ProjectAuth.objects.create(project=self.project, user=self.user, role=1)
+        request = self._make_request(
+            path="/", data={"project_uuid": str(self.project.uuid)}
+        )
+        request.user = self.user
+        self.assertTrue(self.permission.has_permission(request, self.view))
+
+
+class TestFeatureFlagPermission(TestCase):
+    def setUp(self):
+        self.factory = APIRequestFactory()
+        self.permission = FeatureFlagPermission()
+        self.user = User.objects.create_user(email="ff@test.com")
+        self.project = Project.objects.create(name="FF Project")
+
+    def _make_request(self, method="get", **kwargs):
+        fn = getattr(self.factory, method)
+        wsgi_request = fn(**kwargs)
+        request = Request(wsgi_request)
+        return request
+
+    def test_no_feature_flag_key_on_view(self):
+        view = MagicMock(spec=[])
+        request = self._make_request(path="/")
+        request.user = self.user
+        self.assertFalse(self.permission.has_permission(request, view))
+
+    def test_missing_project_returns_false(self):
+        view = MagicMock()
+        view.feature_flag_key = "test_flag"
+        view.kwargs = {}
+        request = self._make_request(path="/")
+        request.user = self.user
+        self.assertFalse(self.permission.has_permission(request, view))
+
+    @patch("insights.authentication.permissions.is_feature_active", return_value=True)
+    def test_feature_active(self, mock_ff):
+        view = MagicMock()
+        view.feature_flag_key = "test_flag"
+        view.kwargs = {}
+        request = self._make_request(
+            path="/", data={"project_uuid": str(self.project.uuid)}
+        )
+        request.user = self.user
+        self.assertTrue(self.permission.has_permission(request, view))
+        mock_ff.assert_called_once_with(
+            "test_flag", user=self.user.email, project=self.project.uuid
+        )
+
+    @patch("insights.authentication.permissions.is_feature_active", return_value=False)
+    def test_feature_inactive(self, mock_ff):
+        view = MagicMock()
+        view.feature_flag_key = "test_flag"
+        view.kwargs = {}
+        request = self._make_request(
+            path="/", data={"project_uuid": str(self.project.uuid)}
+        )
+        request.user = self.user
+        self.assertFalse(self.permission.has_permission(request, view))
+
+    @patch("insights.authentication.permissions.is_feature_active", return_value=True)
+    def test_get_project_from_dashboard_pk(self, mock_ff):
+        dashboard = Dashboard.objects.create(
+            project=self.project,
+            name="Test Dashboard",
+            description="desc",
+        )
+        view = MagicMock()
+        view.feature_flag_key = "test_flag"
+        view.kwargs = {"pk": str(dashboard.uuid)}
+        request = self._make_request(path="/")
+        request.user = self.user
+        self.assertTrue(self.permission.has_permission(request, view))
+
+    def test_get_project_from_request_body(self):
+        view = MagicMock()
+        view.feature_flag_key = "test_flag"
+        view.kwargs = {}
+        wsgi_request = self.factory.post("/", data={}, format="json")
+        request = Request(wsgi_request)
+        request._full_data = {"project_uuid": str(self.project.uuid)}
+        request.user = self.user
+        with patch(
+            "insights.authentication.permissions.is_feature_active", return_value=True
+        ) as mock_ff:
+            self.assertTrue(self.permission.has_permission(request, view))
+            mock_ff.assert_called_once_with(
+                "test_flag", user=self.user.email, project=self.project.uuid
+            )
+
+
+class TestGetOidcLogoutUrl(TestCase):
+    def _make_request(self):
+        factory = RequestFactory()
+        request = factory.get("/admin/logout/")
+        request.session = {}
+        return request
+
+    @override_settings(OIDC_OP_LOGOUT_ENDPOINT="", LOGOUT_REDIRECT_URL="/admin/")
+    def test_without_logout_endpoint(self):
+        request = self._make_request()
+        url = get_oidc_logout_url(request)
+        self.assertEqual(url, request.build_absolute_uri("/admin/"))
+
+    @override_settings(
+        OIDC_OP_LOGOUT_ENDPOINT="https://idp.example.com/logout",
+        LOGOUT_REDIRECT_URL="/admin/",
+        OIDC_RP_CLIENT_ID="my-client",
+    )
+    def test_with_logout_endpoint_and_id_token(self):
+        request = self._make_request()
+        request.session["oidc_id_token"] = "tok123"
+        url = get_oidc_logout_url(request)
+        self.assertIn("https://idp.example.com/logout?", url)
+        self.assertIn("post_logout_redirect_uri=", url)
+        self.assertIn("id_token_hint=tok123", url)
+        self.assertIn("client_id=my-client", url)
+
+    @override_settings(
+        OIDC_OP_LOGOUT_ENDPOINT="https://idp.example.com/logout",
+        LOGOUT_REDIRECT_URL="/admin/",
+    )
+    def test_with_logout_endpoint_without_id_token(self):
+        request = self._make_request()
+        url = get_oidc_logout_url(request)
+        self.assertIn("post_logout_redirect_uri=", url)
+        self.assertNotIn("id_token_hint", url)
+
+
+class TestAdminOidcLogout(TestCase):
+    def _make_request(self, authenticated=True):
+        factory = RequestFactory()
+        request = factory.get("/admin/logout/")
+        from django.contrib.sessions.backends.db import SessionStore
+
+        request.session = SessionStore()
+        if authenticated:
+            user = User.objects.create_user(email=f"logout-{uuid.uuid4()}@test.com")
+            request.user = user
+        else:
+            from django.contrib.auth.models import AnonymousUser
+
+            request.user = AnonymousUser()
+        return request
+
+    @override_settings(OIDC_OP_LOGOUT_URL_METHOD="", LOGOUT_REDIRECT_URL="/admin/")
+    def test_logout_without_oidc_method(self):
+        request = self._make_request()
+        response = admin_oidc_logout(request)
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.url, "/admin/")
+
+    @override_settings(
+        OIDC_OP_LOGOUT_URL_METHOD="insights.authentication.admin_sso.get_oidc_logout_url",
+        OIDC_OP_LOGOUT_ENDPOINT="https://idp.example.com/logout",
+        LOGOUT_REDIRECT_URL="/admin/",
+    )
+    def test_logout_with_oidc_method_authenticated(self):
+        request = self._make_request(authenticated=True)
+        response = admin_oidc_logout(request)
+        self.assertEqual(response.status_code, 302)
+        self.assertIn("https://idp.example.com/logout", response.url)
+
+    @override_settings(
+        OIDC_OP_LOGOUT_URL_METHOD="insights.authentication.admin_sso.get_oidc_logout_url",
+        LOGOUT_REDIRECT_URL="/admin/",
+    )
+    def test_logout_with_oidc_method_unauthenticated(self):
+        request = self._make_request(authenticated=False)
+        response = admin_oidc_logout(request)
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.url, "/admin/")
+
+
+class TestAdminOIDCAuthenticationBackend(TestCase):
+    @patch.object(AdminOIDCAuthenticationBackend, "__init__", lambda self: None)
+    def test_filter_users_by_claims_returns_only_staff(self):
+        backend = AdminOIDCAuthenticationBackend()
+        staff_user = User.objects.create_user(email="staff@test.com", is_staff=True)
+        User.objects.create_user(email="regular@test.com", is_staff=False)
+
+        all_users = User.objects.filter(
+            email__in=["staff@test.com", "regular@test.com"]
+        )
+        with patch.object(
+            AdminOIDCAuthenticationBackend.__bases__[0],
+            "filter_users_by_claims",
+            return_value=all_users,
+        ):
+            result = backend.filter_users_by_claims({"email": "staff@test.com"})
+            self.assertEqual(list(result), [staff_user])
+
+    @patch.object(AdminOIDCAuthenticationBackend, "__init__", lambda self: None)
+    def test_create_user_returns_none(self):
+        backend = AdminOIDCAuthenticationBackend()
+        self.assertIsNone(backend.create_user({"email": "new@test.com"}))

--- a/insights/core/tests/test_pagination.py
+++ b/insights/core/tests/test_pagination.py
@@ -1,0 +1,248 @@
+from unittest.mock import MagicMock
+
+from django.test import TestCase
+
+from insights.core.urls.proxy_pagination import (
+    get_cursor_based_pagination_urls,
+    get_limit_offset_pagination_urls,
+)
+
+
+def _make_request(url: str) -> MagicMock:
+    request = MagicMock()
+    request.build_absolute_uri.return_value = url
+    return request
+
+
+class GetCursorBasedPaginationURLsTestCase(TestCase):
+    def test_both_next_and_previous(self):
+        request = _make_request(
+            "https://insights.example.com/api/messages/?page_size=10&cursor=abc"
+        )
+        response_body = {
+            "next": "https://upstream.service.com/messages/?cursor=next123&page_size=10",
+            "previous": "https://upstream.service.com/messages/?cursor=prev456&page_size=10",
+        }
+
+        result = get_cursor_based_pagination_urls(request, response_body)
+
+        self.assertIn("cursor=next123", result.next_url)
+        self.assertIn("page_size=10", result.next_url)
+        self.assertTrue(
+            result.next_url.startswith("https://insights.example.com/api/messages/")
+        )
+
+        self.assertIn("cursor=prev456", result.previous_url)
+        self.assertIn("page_size=10", result.previous_url)
+        self.assertTrue(
+            result.previous_url.startswith("https://insights.example.com/api/messages/")
+        )
+
+    def test_only_next(self):
+        request = _make_request(
+            "https://insights.example.com/api/messages/?page_size=5"
+        )
+        response_body = {
+            "next": "https://upstream.service.com/messages/?cursor=next789&page_size=5",
+            "previous": None,
+        }
+
+        result = get_cursor_based_pagination_urls(request, response_body)
+
+        self.assertIn("cursor=next789", result.next_url)
+        self.assertIn("page_size=5", result.next_url)
+        self.assertIsNone(result.previous_url)
+
+    def test_only_previous(self):
+        request = _make_request(
+            "https://insights.example.com/api/messages/?page_size=5&cursor=cur1"
+        )
+        response_body = {
+            "next": None,
+            "previous": "https://upstream.service.com/messages/?cursor=prev111&page_size=5",
+        }
+
+        result = get_cursor_based_pagination_urls(request, response_body)
+
+        self.assertIsNone(result.next_url)
+        self.assertIn("cursor=prev111", result.previous_url)
+        self.assertIn("page_size=5", result.previous_url)
+
+    def test_neither_next_nor_previous(self):
+        request = _make_request(
+            "https://insights.example.com/api/messages/?page_size=10"
+        )
+        response_body = {"next": None, "previous": None}
+
+        result = get_cursor_based_pagination_urls(request, response_body)
+
+        self.assertIsNone(result.next_url)
+        self.assertIsNone(result.previous_url)
+
+    def test_preserves_extra_query_params(self):
+        request = _make_request(
+            "https://insights.example.com/api/messages/?page_size=10&project=proj1&cursor=old"
+        )
+        response_body = {
+            "next": "https://upstream.service.com/messages/?cursor=nxt&page_size=10",
+            "previous": None,
+        }
+
+        result = get_cursor_based_pagination_urls(request, response_body)
+
+        self.assertIn("project=proj1", result.next_url)
+        self.assertIn("cursor=nxt", result.next_url)
+
+    def test_custom_param_names(self):
+        request = _make_request("https://insights.example.com/api/items/?ps=20&c=abc")
+        response_body = {
+            "next": "https://upstream.service.com/items/?c=next_c&ps=20",
+            "previous": None,
+        }
+
+        result = get_cursor_based_pagination_urls(
+            request, response_body, page_size_param="ps", cursor_param="c"
+        )
+
+        self.assertIn("c=next_c", result.next_url)
+        self.assertIn("ps=20", result.next_url)
+        self.assertIsNone(result.previous_url)
+
+    def test_no_page_size_in_request(self):
+        request = _make_request("https://insights.example.com/api/messages/")
+        response_body = {
+            "next": "https://upstream.service.com/messages/?cursor=nxt",
+            "previous": None,
+        }
+
+        result = get_cursor_based_pagination_urls(request, response_body)
+
+        self.assertIn("cursor=nxt", result.next_url)
+        self.assertNotIn("page_size", result.next_url)
+
+    def test_response_without_cursor_in_upstream_next(self):
+        request = _make_request(
+            "https://insights.example.com/api/messages/?page_size=10"
+        )
+        response_body = {
+            "next": "https://upstream.service.com/messages/?page_size=10",
+            "previous": None,
+        }
+
+        result = get_cursor_based_pagination_urls(request, response_body)
+
+        self.assertIsNotNone(result.next_url)
+        self.assertNotIn("cursor=", result.next_url)
+        self.assertIn("page_size=10", result.next_url)
+
+
+class GetLimitOffsetPaginationURLsTestCase(TestCase):
+    def test_both_next_and_previous(self):
+        request = _make_request(
+            "https://insights.example.com/api/items/?limit=10&offset=20"
+        )
+        response_body = {
+            "next": "https://upstream.service.com/items/?limit=10&offset=30",
+            "previous": "https://upstream.service.com/items/?limit=10&offset=10",
+        }
+
+        result = get_limit_offset_pagination_urls(request, response_body)
+
+        self.assertIn("limit=10", result.next_url)
+        self.assertIn("offset=30", result.next_url)
+        self.assertTrue(
+            result.next_url.startswith("https://insights.example.com/api/items/")
+        )
+
+        self.assertIn("limit=10", result.previous_url)
+        self.assertIn("offset=10", result.previous_url)
+        self.assertTrue(
+            result.previous_url.startswith("https://insights.example.com/api/items/")
+        )
+
+    def test_only_next(self):
+        request = _make_request(
+            "https://insights.example.com/api/items/?limit=5&offset=0"
+        )
+        response_body = {
+            "next": "https://upstream.service.com/items/?limit=5&offset=5",
+            "previous": None,
+        }
+
+        result = get_limit_offset_pagination_urls(request, response_body)
+
+        self.assertIn("limit=5", result.next_url)
+        self.assertIn("offset=5", result.next_url)
+        self.assertIsNone(result.previous_url)
+
+    def test_only_previous(self):
+        request = _make_request(
+            "https://insights.example.com/api/items/?limit=10&offset=10"
+        )
+        response_body = {
+            "next": None,
+            "previous": "https://upstream.service.com/items/?limit=10&offset=0",
+        }
+
+        result = get_limit_offset_pagination_urls(request, response_body)
+
+        self.assertIsNone(result.next_url)
+        self.assertIn("limit=10", result.previous_url)
+        self.assertIn("offset=0", result.previous_url)
+
+    def test_neither_next_nor_previous(self):
+        request = _make_request(
+            "https://insights.example.com/api/items/?limit=10&offset=0"
+        )
+        response_body = {"next": None, "previous": None}
+
+        result = get_limit_offset_pagination_urls(request, response_body)
+
+        self.assertIsNone(result.next_url)
+        self.assertIsNone(result.previous_url)
+
+    def test_preserves_extra_query_params(self):
+        request = _make_request(
+            "https://insights.example.com/api/items/?limit=10&offset=0&status=active"
+        )
+        response_body = {
+            "next": "https://upstream.service.com/items/?limit=10&offset=10",
+            "previous": None,
+        }
+
+        result = get_limit_offset_pagination_urls(request, response_body)
+
+        self.assertIn("status=active", result.next_url)
+        self.assertIn("limit=10", result.next_url)
+        self.assertIn("offset=10", result.next_url)
+
+    def test_custom_param_names(self):
+        request = _make_request("https://insights.example.com/api/items/?l=20&o=40")
+        response_body = {
+            "next": "https://upstream.service.com/items/?l=20&o=60",
+            "previous": "https://upstream.service.com/items/?l=20&o=20",
+        }
+
+        result = get_limit_offset_pagination_urls(
+            request, response_body, limit_param="l", offset_param="o"
+        )
+
+        self.assertIn("l=20", result.next_url)
+        self.assertIn("o=60", result.next_url)
+        self.assertIn("l=20", result.previous_url)
+        self.assertIn("o=20", result.previous_url)
+
+    def test_upstream_previous_without_offset(self):
+        request = _make_request(
+            "https://insights.example.com/api/items/?limit=10&offset=10"
+        )
+        response_body = {
+            "next": None,
+            "previous": "https://upstream.service.com/items/?limit=10",
+        }
+
+        result = get_limit_offset_pagination_urls(request, response_body)
+
+        self.assertIsNotNone(result.previous_url)
+        self.assertNotIn("offset=", result.previous_url)
+        self.assertIn("limit=10", result.previous_url)

--- a/insights/human_support/tests/test_services.py
+++ b/insights/human_support/tests/test_services.py
@@ -569,3 +569,592 @@ class TestHumanSupportDashboardService(TestCase):
             mock_rooms.execute.return_value = {"value": 1}
             result = service.get_attendance_status()
             self.assertEqual(result["is_waiting"], 1)
+
+    @patch("insights.human_support.services.RoomsQueryExecutor")
+    def test_get_attendance_status_with_scalar_filters(self, mock_rooms):
+        mock_rooms.execute.return_value = {"value": 3}
+        sec, que, tag = str(uuid4()), str(uuid4()), str(uuid4())
+        result = self.service.get_attendance_status(
+            filters={"sectors": sec, "queues": que, "tags": tag}
+        )
+        self.assertEqual(result["is_waiting"], 3)
+        call_filters = mock_rooms.execute.call_args[0][0]
+        self.assertIn("sector__in", call_filters)
+        self.assertIn("queue__in", call_filters)
+        self.assertIn("tags__in", call_filters)
+
+    @patch("insights.human_support.services.ChatsTimeMetricsClient")
+    def test_get_time_metrics_with_scalar_sector_filter(self, mock_client_class):
+        mock_client = MagicMock()
+        mock_client.retrieve_time_metrics.return_value = {}
+        mock_client_class.return_value = mock_client
+        sec, que, tag = str(uuid4()), str(uuid4()), str(uuid4())
+        self.service.get_time_metrics(
+            filters={"sectors": sec, "queues": que, "tags": tag}
+        )
+        call_params = mock_client.retrieve_time_metrics.call_args[1]["params"]
+        self.assertIn("sector", call_params)
+        self.assertIn("queue", call_params)
+        self.assertIn("tag", call_params)
+
+    @patch("insights.human_support.services.RoomsQueryExecutor")
+    def test_get_peaks_with_scalar_filters(self, mock_rooms):
+        mock_rooms.execute.return_value = {"results": []}
+        sec, que, tag = str(uuid4()), str(uuid4()), str(uuid4())
+        self.service.get_peaks_in_human_service(
+            filters={"sectors": sec, "queues": [que], "tags": tag}
+        )
+        call_filters = mock_rooms.execute.call_args[1]["filters"]
+        self.assertIn("sector__in", call_filters)
+        self.assertIn("queue__in", call_filters)
+        self.assertIn("tags__in", call_filters)
+
+    @patch("insights.human_support.services.RoomsQueryExecutor")
+    def test_get_analysis_peaks_with_dates_and_filters(self, mock_rooms):
+        mock_rooms.execute.return_value = {"results": []}
+        sec, que, tag = str(uuid4()), str(uuid4()), str(uuid4())
+        self.service.get_analysis_peaks_in_human_service(
+            filters={
+                "start_date": date(2025, 3, 1),
+                "end_date": date(2025, 3, 31),
+                "sectors": sec,
+                "queues": que,
+                "tags": tag,
+            }
+        )
+        call_filters = mock_rooms.execute.call_args[1]["filters"]
+        self.assertIn("created_on__gte", call_filters)
+        self.assertIn("created_on__lte", call_filters)
+        self.assertIn("sector__in", call_filters)
+        self.assertIn("queue__in", call_filters)
+        self.assertIn("tags__in", call_filters)
+
+    @patch("insights.human_support.services.RoomsQueryExecutor")
+    def test_get_detailed_monitoring_on_going_with_agent_contact_urn(self, mock_rooms):
+        mock_rooms.execute.return_value = {
+            "results": [],
+            "next": None,
+            "previous": None,
+            "count": 0,
+        }
+        self.service.get_detailed_monitoring_on_going(
+            filters={
+                "sectors": "s1",
+                "agent": "agent-uuid",
+                "contact": "contact-uuid",
+                "urn": "tel:+5511",
+            }
+        )
+        call_filters = mock_rooms.execute.call_args[0][0]
+        self.assertEqual(call_filters["agent"], "agent-uuid")
+        self.assertEqual(call_filters["contact"], "contact-uuid")
+        self.assertEqual(call_filters["urn"], "tel:+5511")
+
+    @patch("insights.human_support.services.RoomsQueryExecutor")
+    def test_get_detailed_monitoring_awaiting_with_filters(self, mock_rooms):
+        mock_rooms.execute.return_value = {
+            "results": [],
+            "next": None,
+            "previous": None,
+            "count": 0,
+        }
+        self.service.get_detailed_monitoring_awaiting(
+            filters={
+                "contact": "c-uuid",
+                "urn": "tel:+5511",
+                "limit": 10,
+                "offset": 5,
+                "ordering": "-Awaiting time",
+            }
+        )
+        call_filters = mock_rooms.execute.call_args[0][0]
+        self.assertEqual(call_filters["contact"], "c-uuid")
+        self.assertEqual(call_filters["urn"], "tel:+5511")
+        self.assertEqual(call_filters["limit"], 10)
+        self.assertEqual(call_filters["offset"], 5)
+        self.assertEqual(call_filters["ordering"], "-queue_time")
+
+    def test_get_detailed_monitoring_agents_filters_with_dates_and_lists(self):
+        from datetime import datetime as dt
+        import pytz
+
+        start = pytz.UTC.localize(dt(2025, 3, 1))
+        end = pytz.UTC.localize(dt(2025, 3, 31))
+        sec = str(uuid4())
+        que = str(uuid4())
+        tag1, tag2 = str(uuid4()), str(uuid4())
+        params = self.service._get_detailed_monitoring_agents_filters(
+            {
+                "sectors": [sec],
+                "queues": que,
+                "tags": [tag1, tag2],
+                "status": "online",
+                "custom_status": "break",
+                "start_date": start,
+                "end_date": end,
+                "agent": "agent-uuid",
+                "user_request": "search-term",
+                "limit": 10,
+                "offset": 5,
+                "ordering": "-first_name",
+            }
+        )
+        self.assertEqual(params["start_date"], "2025-03-01")
+        self.assertEqual(params["end_date"], "2025-03-31")
+        self.assertIn("sector", params)
+        self.assertEqual(params["agent"], "agent-uuid")
+        self.assertEqual(params["user_request"], "search-term")
+        self.assertEqual(params["limit"], 10)
+        self.assertEqual(params["offset"], 5)
+        self.assertEqual(params["ordering"], "-first_name")
+
+    @patch("insights.human_support.services.ChatsRESTClient")
+    def test_get_detailed_monitoring_agents_v2(self, mock_client_class):
+        mock_client = MagicMock()
+        mock_client.get_agents.return_value = {
+            "results": [
+                {
+                    "agent": {
+                        "name": "Agent A",
+                        "email": "a@x.com",
+                        "is_deleted": False,
+                    },
+                    "status": {"status": "online", "label": "Available"},
+                    "opened": 3,
+                    "closed": 7,
+                    "avg_first_response_time": 5.0,
+                    "avg_message_response_time": 10.0,
+                    "avg_interaction_time": 120.0,
+                    "time_in_service": 3600,
+                    "link": "https://agent/link",
+                },
+            ],
+            "next": None,
+            "previous": None,
+            "count": 1,
+        }
+        mock_client_class.return_value = mock_client
+        result = self.service.get_detailed_monitoring_agents_v2()
+        self.assertEqual(result["count"], 1)
+        agent = result["results"][0]
+        self.assertEqual(agent["agent"]["name"], "Agent A")
+        self.assertEqual(agent["status"]["status"], "online")
+        self.assertEqual(agent["ongoing"], 3)
+        self.assertEqual(agent["finished"], 7)
+
+    @patch("insights.human_support.services.ChatsRESTClient")
+    def test_get_detailed_monitoring_status_v2_with_filters(self, mock_client_class):
+        mock_client_class.return_value.get_status_by_agent.return_value = {
+            "results": [],
+            "next": None,
+            "previous": None,
+            "count": 0,
+        }
+        from datetime import datetime as dt
+        import pytz
+
+        self.service.get_detailed_monitoring_status_v2(
+            filters={
+                "agent": "agent-uuid",
+                "start_date": pytz.UTC.localize(dt(2025, 3, 1)),
+                "end_date": pytz.UTC.localize(dt(2025, 3, 31)),
+                "user_request": "search",
+                "limit": 5,
+                "offset": 10,
+            }
+        )
+        call_args = mock_client_class.return_value.get_status_by_agent.call_args
+        params = call_args[0][1]
+        self.assertEqual(params["user_request"], "search")
+        self.assertEqual(params["limit"], 5)
+        self.assertEqual(params["offset"], 10)
+        self.assertEqual(params["agent"], "agent-uuid")
+
+    @patch("insights.human_support.services.AgentsRESTClient")
+    def test_get_detailed_monitoring_agents_totals(self, mock_client_class):
+        mock_client = MagicMock()
+        mock_client.agents_totals.return_value = {"online": 5, "offline": 3}
+        mock_client_class.return_value = mock_client
+        result = self.service.get_detailed_monitoring_agents_totals()
+        self.assertEqual(result, {"online": 5, "offline": 3})
+        mock_client.agents_totals.assert_called_once()
+
+    @patch("insights.human_support.services.CustomStatusRESTClient")
+    def test_get_detailed_monitoring_status_with_user_request_and_filters(
+        self, mock_client_class
+    ):
+        mock_client_class.return_value.list_custom_status_by_agent.return_value = {
+            "results": [],
+            "next": None,
+            "previous": None,
+            "count": 0,
+        }
+        from datetime import datetime as dt
+        import pytz
+
+        self.service.get_detailed_monitoring_status(
+            filters={
+                "user_request": "test",
+                "agent": "agent-uuid",
+                "start_date": pytz.UTC.localize(dt(2025, 3, 1)),
+                "end_date": pytz.UTC.localize(dt(2025, 3, 31)),
+            }
+        )
+        call_args = (
+            mock_client_class.return_value.list_custom_status_by_agent.call_args[0][0]
+        )
+        self.assertEqual(call_args["user_request"], "test")
+        self.assertEqual(call_args["agent"], "agent-uuid")
+
+    def test_params_for_finished_rooms_list_with_agent_contact_ticket(self):
+        from datetime import datetime as dt
+        import pytz
+
+        start = pytz.UTC.localize(dt(2025, 3, 1))
+        end = pytz.UTC.localize(dt(2025, 3, 31))
+        normalized = {
+            "sectors": ["s1"],
+            "agent": "agent-uuid",
+            "contact": "contact-uuid",
+            "ticket_id": "TICKET-001",
+            "start_date": start,
+            "end_date": end,
+        }
+        result = self.service._params_for_finished_rooms_list(
+            normalized,
+            filters={
+                "limit": 20,
+                "offset": 5,
+                "ordering": "-agent",
+            },
+        )
+        self.assertEqual(result["agent"], "agent-uuid")
+        self.assertEqual(result["contact_external_id"], "contact-uuid")
+        self.assertEqual(result["protocol"], "TICKET-001")
+        self.assertIn("ended_at__gte", result)
+        self.assertIn("ended_at__lte", result)
+        self.assertEqual(result["ordering"], "-user_full_name")
+        self.assertEqual(result["limit"], 20)
+        self.assertEqual(result["offset"], 5)
+
+    def test_format_finished_room_v2_item_without_agent(self):
+        room = {
+            "agent": None,
+            "sector": {"name": "S1", "is_deleted": False},
+            "queue": {"name": "Q1", "is_deleted": False},
+            "contact": "C1",
+            "protocol": "TICKET-001",
+            "waiting_time": 10,
+            "first_response_time": 5,
+            "duration": 100,
+            "ended_at": "2025-02-06T12:00:00",
+            "csat_rating": 5,
+            "link": {"url": "chats:closed-chats/uuid", "type": "internal"},
+        }
+        result = self.service._format_finished_room_v2_item(room)
+        self.assertIsNone(result["agent"])
+        self.assertEqual(result["sector"]["name"], "S1")
+
+    def test_get_analysis_status_finished_filters_scalar_values(self):
+        normalized = {
+            "sectors": "s1",
+            "queues": "q1",
+            "tags": "t1",
+        }
+        result = self.service._get_analysis_status_finished_filters(normalized)
+        self.assertEqual(result["sector__in"], ["s1"])
+        self.assertEqual(result["queue__in"], ["q1"])
+        self.assertEqual(result["tags__in"], ["t1"])
+
+    def test_get_analysis_status_metrics_filters_scalar_values(self):
+        normalized = {
+            "sectors": "s1",
+            "queues": "q1",
+            "tags": "t1",
+            "start_date": date(2025, 1, 1),
+            "end_date": date(2025, 1, 31),
+        }
+        result = self.service._get_analysis_status_metrics_filters(normalized)
+        self.assertEqual(result["sector"], ["s1"])
+        self.assertEqual(result["queue"], ["q1"])
+        self.assertEqual(result["tag"], ["t1"])
+
+    def test_build_volume_by_queue_base_filters(self):
+        normalized = {
+            "sectors": "s1",
+            "queues": ["q1", "q2"],
+            "tags": "t1",
+        }
+        result = self.service._build_volume_by_queue_base_filters(normalized)
+        self.assertEqual(result["project"], str(self.project.uuid))
+        self.assertEqual(result["sector__in"], ["s1"])
+        self.assertEqual(result["queue__in"], ["q1", "q2"])
+        self.assertEqual(result["tags__in"], ["t1"])
+
+    @patch("insights.human_support.services.RoomsQueryExecutor")
+    def test_get_volume_by_queue_waiting(self, mock_rooms):
+        mock_rooms.execute.return_value = {"results": [], "count": 0}
+        self.service.get_volume_by_queue(filters={"chip_name": "waiting", "limit": 10})
+        call_kwargs = mock_rooms.execute.call_args[1]
+        self.assertTrue(call_kwargs["filters"]["is_active"])
+        self.assertTrue(call_kwargs["filters"]["user_id__isnull"])
+        self.assertEqual(call_kwargs["query_kwargs"]["limit"], 10)
+
+    @patch("insights.human_support.services.RoomsQueryExecutor")
+    def test_get_volume_by_queue_ongoing(self, mock_rooms):
+        mock_rooms.execute.return_value = {"results": [], "count": 0}
+        self.service.get_volume_by_queue(filters={"chip_name": "ongoing"})
+        call_kwargs = mock_rooms.execute.call_args[1]
+        self.assertTrue(call_kwargs["filters"]["is_active"])
+        self.assertFalse(call_kwargs["filters"]["user_id__isnull"])
+
+    @patch("insights.human_support.services.RoomsQueryExecutor")
+    def test_get_volume_by_queue_closed(self, mock_rooms):
+        mock_rooms.execute.return_value = {"results": [], "count": 0}
+        self.service.get_volume_by_queue(filters={"chip_name": "closed"})
+        call_kwargs = mock_rooms.execute.call_args[1]
+        self.assertFalse(call_kwargs["filters"]["is_active"])
+        self.assertIn("ended_at__gte", call_kwargs["filters"])
+        self.assertIn("ended_at__lte", call_kwargs["filters"])
+
+    @patch("insights.human_support.services.RoomsQueryExecutor")
+    def test_get_analysis_volume_by_queue_waiting_with_dates(self, mock_rooms):
+        mock_rooms.execute.return_value = {"results": [], "count": 0}
+        from datetime import datetime as dt
+        import pytz
+
+        self.service.get_analysis_volume_by_queue(
+            filters={
+                "chip_name": "waiting",
+                "start_date": pytz.UTC.localize(dt(2025, 3, 1)),
+                "end_date": pytz.UTC.localize(dt(2025, 3, 31)),
+            }
+        )
+        call_kwargs = mock_rooms.execute.call_args[1]
+        self.assertTrue(call_kwargs["filters"]["is_active"])
+        self.assertTrue(call_kwargs["filters"]["user_id__isnull"])
+        self.assertIn("created_on__gte", call_kwargs["filters"])
+
+    @patch("insights.human_support.services.RoomsQueryExecutor")
+    def test_get_analysis_volume_by_queue_ongoing(self, mock_rooms):
+        mock_rooms.execute.return_value = {"results": [], "count": 0}
+        from datetime import datetime as dt
+        import pytz
+
+        self.service.get_analysis_volume_by_queue(
+            filters={
+                "chip_name": "ongoing",
+                "start_date": pytz.UTC.localize(dt(2025, 3, 1)),
+                "end_date": pytz.UTC.localize(dt(2025, 3, 31)),
+            }
+        )
+        call_kwargs = mock_rooms.execute.call_args[1]
+        self.assertTrue(call_kwargs["filters"]["is_active"])
+        self.assertFalse(call_kwargs["filters"]["user_id__isnull"])
+
+    @patch("insights.human_support.services.RoomsQueryExecutor")
+    def test_get_analysis_volume_by_queue_closed(self, mock_rooms):
+        mock_rooms.execute.return_value = {"results": [], "count": 0}
+        from datetime import datetime as dt
+        import pytz
+
+        self.service.get_analysis_volume_by_queue(
+            filters={
+                "chip_name": "closed",
+                "start_date": pytz.UTC.localize(dt(2025, 3, 1)),
+                "end_date": pytz.UTC.localize(dt(2025, 3, 31)),
+            }
+        )
+        call_kwargs = mock_rooms.execute.call_args[1]
+        self.assertFalse(call_kwargs["filters"]["is_active"])
+        self.assertIn("ended_at__gte", call_kwargs["filters"])
+
+    @patch("insights.human_support.services.RoomsQueryExecutor")
+    def test_get_analysis_volume_by_queue_no_chip(self, mock_rooms):
+        mock_rooms.execute.return_value = {"results": [], "count": 0}
+        from datetime import datetime as dt
+        import pytz
+
+        self.service.get_analysis_volume_by_queue(
+            filters={
+                "start_date": pytz.UTC.localize(dt(2025, 3, 1)),
+                "end_date": pytz.UTC.localize(dt(2025, 3, 31)),
+            }
+        )
+        call_kwargs = mock_rooms.execute.call_args[1]
+        self.assertIn("created_on__gte", call_kwargs["filters"])
+        self.assertNotIn("is_active", call_kwargs["filters"])
+
+    def test_build_volume_by_tag_base_filters(self):
+        normalized = {
+            "sectors": "s1",
+            "queues": ["q1"],
+            "tags": "t1",
+        }
+        result = self.service._build_volume_by_tag_base_filters(normalized)
+        self.assertEqual(result["project"], str(self.project.uuid))
+        self.assertEqual(result["sector__in"], ["s1"])
+        self.assertEqual(result["tags__in"], ["t1"])
+
+    @patch("insights.human_support.services.RoomsQueryExecutor")
+    def test_get_volume_by_tag_ongoing(self, mock_rooms):
+        mock_rooms.execute.return_value = {"results": [], "count": 0}
+        self.service.get_volume_by_tag(filters={"chip_name": "ongoing"})
+        call_kwargs = mock_rooms.execute.call_args[1]
+        self.assertTrue(call_kwargs["filters"]["is_active"])
+        self.assertFalse(call_kwargs["filters"]["user_id__isnull"])
+
+    @patch("insights.human_support.services.RoomsQueryExecutor")
+    def test_get_volume_by_tag_closed(self, mock_rooms):
+        mock_rooms.execute.return_value = {"results": [], "count": 0}
+        self.service.get_volume_by_tag(filters={"chip_name": "closed"})
+        call_kwargs = mock_rooms.execute.call_args[1]
+        self.assertFalse(call_kwargs["filters"]["is_active"])
+        self.assertIn("ended_at__gte", call_kwargs["filters"])
+
+    @patch("insights.human_support.services.RoomsQueryExecutor")
+    def test_get_analysis_volume_by_tag_ongoing_with_dates(self, mock_rooms):
+        mock_rooms.execute.return_value = {"results": [], "count": 0}
+        from datetime import datetime as dt
+        import pytz
+
+        self.service.get_analysis_volume_by_tag(
+            filters={
+                "chip_name": "ongoing",
+                "start_date": pytz.UTC.localize(dt(2025, 3, 1)),
+                "end_date": pytz.UTC.localize(dt(2025, 3, 31)),
+            }
+        )
+        call_kwargs = mock_rooms.execute.call_args[1]
+        self.assertTrue(call_kwargs["filters"]["is_active"])
+        self.assertIn("created_on__gte", call_kwargs["filters"])
+
+    @patch("insights.human_support.services.RoomsQueryExecutor")
+    def test_get_analysis_volume_by_tag_closed_with_dates(self, mock_rooms):
+        mock_rooms.execute.return_value = {"results": [], "count": 0}
+        from datetime import datetime as dt
+        import pytz
+
+        self.service.get_analysis_volume_by_tag(
+            filters={
+                "chip_name": "closed",
+                "start_date": pytz.UTC.localize(dt(2025, 3, 1)),
+                "end_date": pytz.UTC.localize(dt(2025, 3, 31)),
+            }
+        )
+        call_kwargs = mock_rooms.execute.call_args[1]
+        self.assertFalse(call_kwargs["filters"]["is_active"])
+        self.assertIn("ended_at__gte", call_kwargs["filters"])
+
+    @patch("insights.human_support.services.RoomsQueryExecutor")
+    def test_get_analysis_volume_by_tag_no_chip(self, mock_rooms):
+        mock_rooms.execute.return_value = {"results": [], "count": 0}
+        from datetime import datetime as dt
+        import pytz
+
+        self.service.get_analysis_volume_by_tag(
+            filters={
+                "start_date": pytz.UTC.localize(dt(2025, 3, 1)),
+                "end_date": pytz.UTC.localize(dt(2025, 3, 31)),
+            }
+        )
+        call_kwargs = mock_rooms.execute.call_args[1]
+        self.assertIn("created_on__gte", call_kwargs["filters"])
+        self.assertNotIn("is_active", call_kwargs["filters"])
+
+    def test_get_csat_ratings_skips_invalid_rating(self):
+        mock_chats = MagicMock()
+        mock_chats.csat_ratings.return_value = {
+            "csat_ratings": [
+                {"rating": 1, "value": 2, "full_value": 2},
+                {"rating": 99, "value": 5, "full_value": 5},
+            ],
+        }
+        service = HumanSupportDashboardService(
+            project=self.project, chats_client=mock_chats
+        )
+        result = service.get_csat_ratings()
+        self.assertEqual(result["1"]["value"], 2)
+        self.assertEqual(result["2"]["value"], 0)
+
+    @patch("insights.human_support.services.RoomsQueryExecutor")
+    @patch("insights.human_support.services.ChatsTimeMetricsClient")
+    def test_get_analysis_status_with_dates(self, mock_time_class, mock_rooms):
+        mock_rooms.execute.return_value = {"value": 10}
+        mock_time = MagicMock()
+        mock_time.retrieve_time_metrics_for_analysis.return_value = {
+            "avg_waiting_time": 1.0,
+            "avg_first_response_time": 2.0,
+            "avg_message_response_time": 3.0,
+            "avg_conversation_duration": 4.0,
+        }
+        mock_time_class.return_value = mock_time
+        from datetime import datetime as dt
+        import pytz
+
+        result = self.service.get_analysis_status(
+            filters={
+                "start_date": pytz.UTC.localize(dt(2025, 3, 1)),
+                "end_date": pytz.UTC.localize(dt(2025, 3, 31)),
+            }
+        )
+        self.assertEqual(result["finished"], 10)
+        self.assertEqual(result["average_waiting_time"], 1.0)
+
+    @patch("insights.human_support.services.CustomStatusRESTClient")
+    def test_get_analysis_detailed_monitoring_status_with_filters(
+        self, mock_client_class
+    ):
+        mock_client_class.return_value.list_custom_status_by_agent.return_value = {
+            "results": [],
+            "next": None,
+            "previous": None,
+            "count": 0,
+        }
+        from datetime import datetime as dt
+        import pytz
+
+        self.service.get_analysis_detailed_monitoring_status(
+            filters={
+                "user_request": "search",
+                "sectors": ["sec-1"],
+                "queues": ["q-1"],
+                "agent": "agent-uuid",
+                "start_date": pytz.UTC.localize(dt(2025, 3, 1)),
+                "end_date": pytz.UTC.localize(dt(2025, 3, 31)),
+                "limit": 5,
+                "offset": 10,
+            }
+        )
+        call_args = (
+            mock_client_class.return_value.list_custom_status_by_agent.call_args[0][0]
+        )
+        self.assertEqual(call_args["user_request"], "search")
+        self.assertEqual(call_args["limit"], 5)
+        self.assertEqual(call_args["offset"], 10)
+
+    @patch("insights.human_support.services.ChatsRESTClient")
+    def test_get_analysis_detailed_monitoring_status_v2_with_filters(
+        self, mock_client_class
+    ):
+        mock_client_class.return_value.get_status_by_agent.return_value = {
+            "results": [
+                {
+                    "agent": "a1",
+                    "agent_email": "a@x.com",
+                    "custom_status": [],
+                    "link": "https://link",
+                }
+            ],
+            "next": None,
+            "previous": None,
+            "count": 1,
+        }
+        result = self.service.get_analysis_detailed_monitoring_status_v2(
+            filters={
+                "sectors": ["sec-1"],
+                "agent": "agent-uuid",
+            }
+        )
+        self.assertEqual(result["count"], 1)
+        self.assertEqual(result["results"][0]["agent"], "a1")

--- a/insights/metrics/conversations/tests/test_tasks.py
+++ b/insights/metrics/conversations/tests/test_tasks.py
@@ -1,0 +1,236 @@
+from datetime import timedelta
+from unittest.mock import MagicMock, patch
+from uuid import uuid4
+
+from django.test import TestCase, override_settings
+from django.utils import timezone
+
+from insights.metrics.conversations.tasks import (
+    check_project_sales_funnel_on_datalake,
+    generate_conversations_report,
+    timeout_reports,
+)
+from insights.projects.models import Project
+from insights.reports.choices import ReportStatus
+from insights.reports.models import Report
+
+
+class TestGenerateConversationsReport(TestCase):
+    def setUp(self):
+        self.project = Project.objects.create(name="Test Project")
+
+    @override_settings(
+        HOSTNAME="host-1",
+        REPORT_GENERATION_MAX_CONCURRENT_REPORTS=2,
+    )
+    def test_returns_early_when_max_concurrent_reports_reached(self):
+        Report.objects.create(
+            project=self.project,
+            source="CONVERSATIONS_DASHBOARD",
+            format="CSV",
+            status=ReportStatus.IN_PROGRESS,
+        )
+        Report.objects.create(
+            project=self.project,
+            source="CONVERSATIONS_DASHBOARD",
+            format="CSV",
+            status=ReportStatus.IN_PROGRESS,
+        )
+
+        result = generate_conversations_report()
+
+        self.assertIsNone(result)
+
+    @override_settings(
+        HOSTNAME="host-2",
+        REPORT_GENERATION_MAX_CONCURRENT_REPORTS=5,
+        CONVERSATIONS_REPORT_EVENTS_LIMIT_PER_PAGE=100,
+        CONVERSATIONS_REPORT_PAGE_LIMIT=10,
+        CONVERSATIONS_REPORT_ELASTIC_PAGE_SIZE=100,
+        CONVERSATIONS_REPORT_ELASTIC_PAGE_LIMIT=10,
+    )
+    @patch("insights.metrics.conversations.tasks.ConversationsReportService")
+    @patch("insights.metrics.conversations.tasks.ElasticsearchClient")
+    @patch("insights.metrics.conversations.tasks.DataLakeEventsClient")
+    @patch("insights.metrics.conversations.tasks.CacheClient")
+    def test_picks_interrupted_report_from_another_host(
+        self,
+        mock_cache_client,
+        mock_datalake_client,
+        mock_es_client,
+        mock_report_service_cls,
+    ):
+        interrupted_report = Report.objects.create(
+            project=self.project,
+            source="CONVERSATIONS_DASHBOARD",
+            format="CSV",
+            status=ReportStatus.IN_PROGRESS,
+            config={
+                "interrupted": True,
+                "interrupted_on_host": "host-1",
+                "interrupted_at": "2024-01-01T00:00:00Z",
+            },
+        )
+
+        mock_service_instance = MagicMock()
+        mock_report_service_cls.return_value = mock_service_instance
+
+        generate_conversations_report()
+
+        mock_service_instance.generate.assert_called_once()
+        call_arg = mock_service_instance.generate.call_args[0][0]
+        self.assertEqual(call_arg.uuid, interrupted_report.uuid)
+
+        interrupted_report.refresh_from_db()
+        self.assertFalse(interrupted_report.config["interrupted"])
+        self.assertEqual(interrupted_report.config["task_host"], "host-2")
+
+    @override_settings(
+        HOSTNAME="host-1",
+        REPORT_GENERATION_MAX_CONCURRENT_REPORTS=5,
+        CONVERSATIONS_REPORT_EVENTS_LIMIT_PER_PAGE=100,
+        CONVERSATIONS_REPORT_PAGE_LIMIT=10,
+        CONVERSATIONS_REPORT_ELASTIC_PAGE_SIZE=100,
+        CONVERSATIONS_REPORT_ELASTIC_PAGE_LIMIT=10,
+    )
+    @patch("insights.metrics.conversations.tasks.ConversationsReportService")
+    @patch("insights.metrics.conversations.tasks.ElasticsearchClient")
+    @patch("insights.metrics.conversations.tasks.DataLakeEventsClient")
+    @patch("insights.metrics.conversations.tasks.CacheClient")
+    def test_generates_oldest_pending_report(
+        self,
+        mock_cache_client,
+        mock_datalake_client,
+        mock_es_client,
+        mock_report_service_cls,
+    ):
+        older_report = Report.objects.create(
+            project=self.project,
+            source="CONVERSATIONS_DASHBOARD",
+            format="CSV",
+            status=ReportStatus.PENDING,
+        )
+        Report.objects.create(
+            project=self.project,
+            source="CONVERSATIONS_DASHBOARD",
+            format="CSV",
+            status=ReportStatus.PENDING,
+        )
+
+        mock_service_instance = MagicMock()
+        mock_report_service_cls.return_value = mock_service_instance
+
+        generate_conversations_report()
+
+        mock_service_instance.generate.assert_called_once()
+        call_arg = mock_service_instance.generate.call_args[0][0]
+        self.assertEqual(call_arg.uuid, older_report.uuid)
+
+    @override_settings(
+        HOSTNAME="host-1",
+        REPORT_GENERATION_MAX_CONCURRENT_REPORTS=5,
+    )
+    def test_returns_early_when_no_pending_reports(self):
+        Report.objects.create(
+            project=self.project,
+            source="CONVERSATIONS_DASHBOARD",
+            format="CSV",
+            status=ReportStatus.READY,
+        )
+
+        result = generate_conversations_report()
+
+        self.assertIsNone(result)
+
+    @override_settings(
+        HOSTNAME="host-1",
+        REPORT_GENERATION_MAX_CONCURRENT_REPORTS=5,
+        CONVERSATIONS_REPORT_EVENTS_LIMIT_PER_PAGE=100,
+        CONVERSATIONS_REPORT_PAGE_LIMIT=10,
+        CONVERSATIONS_REPORT_ELASTIC_PAGE_SIZE=100,
+        CONVERSATIONS_REPORT_ELASTIC_PAGE_LIMIT=10,
+    )
+    @patch("insights.metrics.conversations.tasks.ConversationsReportService")
+    @patch("insights.metrics.conversations.tasks.ElasticsearchClient")
+    @patch("insights.metrics.conversations.tasks.DataLakeEventsClient")
+    @patch("insights.metrics.conversations.tasks.CacheClient")
+    def test_exception_during_generate_is_logged_not_raised(
+        self,
+        mock_cache_client,
+        mock_datalake_client,
+        mock_es_client,
+        mock_report_service_cls,
+    ):
+        Report.objects.create(
+            project=self.project,
+            source="CONVERSATIONS_DASHBOARD",
+            format="CSV",
+            status=ReportStatus.PENDING,
+        )
+
+        mock_service_instance = MagicMock()
+        mock_service_instance.generate.side_effect = Exception("Something broke")
+        mock_report_service_cls.return_value = mock_service_instance
+
+        generate_conversations_report()
+
+
+class TestTimeoutReports(TestCase):
+    def setUp(self):
+        self.project = Project.objects.create(name="Test Project")
+
+    @override_settings(REPORT_GENERATION_TIMEOUT=3600)
+    def test_marks_timed_out_reports_as_failed(self):
+        timed_out_report = Report.objects.create(
+            project=self.project,
+            source="CONVERSATIONS_DASHBOARD",
+            format="CSV",
+            status=ReportStatus.IN_PROGRESS,
+            started_at=timezone.now() - timedelta(seconds=7200),
+        )
+
+        timeout_reports()
+
+        timed_out_report.refresh_from_db()
+        self.assertEqual(timed_out_report.status, ReportStatus.FAILED)
+        self.assertIsNotNone(timed_out_report.completed_at)
+        self.assertEqual(
+            timed_out_report.errors, {"timeout": "Report generation timed out"}
+        )
+
+    @override_settings(REPORT_GENERATION_TIMEOUT=3600)
+    def test_returns_early_when_no_in_progress_reports(self):
+        Report.objects.create(
+            project=self.project,
+            source="CONVERSATIONS_DASHBOARD",
+            format="CSV",
+            status=ReportStatus.PENDING,
+            started_at=timezone.now() - timedelta(seconds=7200),
+        )
+
+        result = timeout_reports()
+
+        self.assertIsNone(result)
+
+
+class TestCheckProjectSalesFunnelOnDatalake(TestCase):
+    @patch(
+        "insights.metrics.conversations.tasks.CheckProjectSalesFunnelOnDatalakeUseCase"
+    )
+    @patch("insights.metrics.conversations.tasks.DatalakeConversationsMetricsService")
+    def test_executes_use_case_with_project_uuid(
+        self,
+        mock_datalake_service_cls,
+        mock_use_case_cls,
+    ):
+        project_uuid = uuid4()
+        mock_datalake_service = MagicMock()
+        mock_datalake_service_cls.return_value = mock_datalake_service
+
+        mock_use_case_instance = MagicMock()
+        mock_use_case_cls.return_value = mock_use_case_instance
+
+        check_project_sales_funnel_on_datalake(project_uuid)
+
+        mock_use_case_cls.assert_called_once_with(mock_datalake_service)
+        mock_use_case_instance.execute.assert_called_once_with(project_uuid)

--- a/insights/metrics/human_support/tests/test_views.py
+++ b/insights/metrics/human_support/tests/test_views.py
@@ -1,0 +1,335 @@
+from unittest.mock import patch
+
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+from insights.authentication.authentication import User
+from insights.authentication.tests.decorators import with_project_auth
+from insights.projects.models import Project
+
+
+SERVICE_PATH = (
+    "insights.human_support.services.HumanSupportDashboardService"
+)
+
+
+class BaseHumanSupportViewTest(APITestCase):
+    def setUp(self):
+        self.user = User.objects.create(email="test@test.com")
+        self.project = Project.objects.create(name="Test Project")
+        self.client.force_authenticate(self.user)
+
+
+class TestDetailedMonitoringOnGoingViewAsAnonymous(APITestCase):
+    def test_returns_401_when_unauthenticated(self):
+        url = "/v1/metrics/human-support/detailed-monitoring/on-going/"
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+
+class TestDetailedMonitoringOnGoingView(BaseHumanSupportViewTest):
+    URL = "/v1/metrics/human-support/detailed-monitoring/on-going/"
+
+    def test_returns_400_without_project_uuid(self):
+        response = self.client.get(self.URL)
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_returns_403_without_project_auth(self):
+        response = self.client.get(self.URL, {"project_uuid": self.project.uuid})
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    @with_project_auth
+    @patch(f"{SERVICE_PATH}.get_detailed_monitoring_on_going")
+    def test_returns_200_with_valid_request(self, mock_service_method):
+        mock_service_method.return_value = {"results": [], "count": 0}
+
+        response = self.client.get(self.URL, {"project_uuid": self.project.uuid})
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data, {"results": [], "count": 0})
+        mock_service_method.assert_called_once()
+
+
+class TestDetailedMonitoringAwaitingViewAsAnonymous(APITestCase):
+    def test_returns_401_when_unauthenticated(self):
+        url = "/v1/metrics/human-support/detailed-monitoring/awaiting/"
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+
+class TestDetailedMonitoringAwaitingView(BaseHumanSupportViewTest):
+    URL = "/v1/metrics/human-support/detailed-monitoring/awaiting/"
+
+    def test_returns_400_without_project_uuid(self):
+        response = self.client.get(self.URL)
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_returns_403_without_project_auth(self):
+        response = self.client.get(self.URL, {"project_uuid": self.project.uuid})
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    @with_project_auth
+    @patch(f"{SERVICE_PATH}.get_detailed_monitoring_awaiting")
+    def test_returns_200_with_valid_request(self, mock_service_method):
+        mock_service_method.return_value = {"results": [], "count": 0}
+
+        response = self.client.get(self.URL, {"project_uuid": self.project.uuid})
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data, {"results": [], "count": 0})
+        mock_service_method.assert_called_once()
+
+
+class TestDetailedMonitoringAgentsViewAsAnonymous(APITestCase):
+    def test_returns_401_when_unauthenticated(self):
+        url = "/v1/metrics/human-support/detailed-monitoring/agents/"
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+
+class TestDetailedMonitoringAgentsView(BaseHumanSupportViewTest):
+    URL = "/v1/metrics/human-support/detailed-monitoring/agents/"
+
+    def test_returns_400_without_project_uuid(self):
+        response = self.client.get(self.URL)
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_returns_403_without_project_auth(self):
+        response = self.client.get(self.URL, {"project_uuid": self.project.uuid})
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    @with_project_auth
+    @patch(f"{SERVICE_PATH}.get_detailed_monitoring_agents")
+    def test_returns_200_with_valid_request(self, mock_service_method):
+        mock_service_method.return_value = {
+            "results": [
+                {"agent": "Agent 1", "status": "online"},
+                {"agent": "Agent 2", "status": "offline"},
+            ]
+        }
+
+        response = self.client.get(self.URL, {"project_uuid": self.project.uuid})
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["count"], 2)
+        self.assertEqual(len(response.data["results"]), 2)
+        mock_service_method.assert_called_once()
+
+
+class TestDetailedMonitoringStatusViewAsAnonymous(APITestCase):
+    def test_returns_401_when_unauthenticated(self):
+        url = "/v1/metrics/human-support/detailed-monitoring/status/"
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+
+class TestDetailedMonitoringStatusView(BaseHumanSupportViewTest):
+    URL = "/v1/metrics/human-support/detailed-monitoring/status/"
+
+    def test_returns_400_without_project_uuid(self):
+        response = self.client.get(self.URL)
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_returns_403_without_project_auth(self):
+        response = self.client.get(self.URL, {"project_uuid": self.project.uuid})
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    @with_project_auth
+    @patch(f"{SERVICE_PATH}.get_detailed_monitoring_status")
+    def test_returns_200_with_valid_request(self, mock_service_method):
+        mock_service_method.return_value = {"online": 5, "offline": 3}
+
+        response = self.client.get(self.URL, {"project_uuid": self.project.uuid})
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data, {"online": 5, "offline": 3})
+        mock_service_method.assert_called_once()
+
+
+class TestDetailedMonitoringAgentsTotalsViewAsAnonymous(APITestCase):
+    def test_returns_401_when_unauthenticated(self):
+        url = "/v1/metrics/human-support/detailed-monitoring/agents_totals/"
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+
+class TestDetailedMonitoringAgentsTotalsView(BaseHumanSupportViewTest):
+    URL = "/v1/metrics/human-support/detailed-monitoring/agents_totals/"
+
+    def test_returns_400_without_project_uuid(self):
+        response = self.client.get(self.URL)
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_returns_403_without_project_auth(self):
+        response = self.client.get(self.URL, {"project_uuid": self.project.uuid})
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    @with_project_auth
+    @patch(f"{SERVICE_PATH}.get_detailed_monitoring_agents_totals")
+    def test_returns_200_with_valid_request(self, mock_service_method):
+        mock_service_method.return_value = {"total": 10, "online": 7}
+
+        response = self.client.get(self.URL, {"project_uuid": self.project.uuid})
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data, {"total": 10, "online": 7})
+        mock_service_method.assert_called_once()
+
+
+class TestAnalysisDetailedMonitoringStatusViewAsAnonymous(APITestCase):
+    def test_returns_401_when_unauthenticated(self):
+        url = "/v1/metrics/human-support/analysis/detailed-monitoring/status/"
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+
+class TestAnalysisDetailedMonitoringStatusView(BaseHumanSupportViewTest):
+    URL = "/v1/metrics/human-support/analysis/detailed-monitoring/status/"
+
+    def test_returns_400_without_project_uuid(self):
+        response = self.client.get(self.URL)
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_returns_403_without_project_auth(self):
+        response = self.client.get(self.URL, {"project_uuid": self.project.uuid})
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    @with_project_auth
+    @patch(f"{SERVICE_PATH}.get_analysis_detailed_monitoring_status")
+    def test_returns_200_with_valid_request(self, mock_service_method):
+        mock_service_method.return_value = {"status": "active", "count": 5}
+
+        response = self.client.get(self.URL, {"project_uuid": self.project.uuid})
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data, {"status": "active", "count": 5})
+        mock_service_method.assert_called_once()
+
+
+# --- V2 Views ---
+
+
+class TestDetailedMonitoringAgentsViewV2AsAnonymous(APITestCase):
+    def test_returns_401_when_unauthenticated(self):
+        url = "/v2/metrics/human-support/detailed-monitoring/agents/"
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+
+class TestDetailedMonitoringAgentsViewV2(BaseHumanSupportViewTest):
+    URL = "/v2/metrics/human-support/detailed-monitoring/agents/"
+
+    def test_returns_400_without_project_uuid(self):
+        response = self.client.get(self.URL)
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_returns_403_without_project_auth(self):
+        response = self.client.get(self.URL, {"project_uuid": self.project.uuid})
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    @with_project_auth
+    @patch(f"{SERVICE_PATH}.get_detailed_monitoring_agents_v2")
+    def test_returns_200_with_valid_request(self, mock_service_method):
+        mock_service_method.return_value = {
+            "count": 2,
+            "results": [
+                {"agent": "Agent 1", "status": "online"},
+                {"agent": "Agent 2", "status": "offline"},
+            ],
+        }
+
+        response = self.client.get(self.URL, {"project_uuid": self.project.uuid})
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["count"], 2)
+        self.assertEqual(len(response.data["results"]), 2)
+        self.assertIn("next", response.data)
+        self.assertIn("previous", response.data)
+        mock_service_method.assert_called_once()
+
+
+class TestDetailedMonitoringStatusViewV2AsAnonymous(APITestCase):
+    def test_returns_401_when_unauthenticated(self):
+        url = "/v2/metrics/human-support/detailed-monitoring/status/"
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+
+class TestDetailedMonitoringStatusViewV2(BaseHumanSupportViewTest):
+    URL = "/v2/metrics/human-support/detailed-monitoring/status/"
+
+    def test_returns_400_without_project_uuid(self):
+        response = self.client.get(self.URL)
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_returns_403_without_project_auth(self):
+        response = self.client.get(self.URL, {"project_uuid": self.project.uuid})
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    @with_project_auth
+    @patch(f"{SERVICE_PATH}.get_detailed_monitoring_status_v2")
+    def test_returns_200_with_valid_request(self, mock_service_method):
+        mock_service_method.return_value = {"online": 5, "offline": 3}
+
+        response = self.client.get(self.URL, {"project_uuid": self.project.uuid})
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data, {"online": 5, "offline": 3})
+        mock_service_method.assert_called_once()
+
+
+class TestAnalysisDetailedMonitoringStatusViewV2AsAnonymous(APITestCase):
+    def test_returns_401_when_unauthenticated(self):
+        url = "/v2/metrics/human-support/analysis/detailed-monitoring/status/"
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+
+class TestAnalysisDetailedMonitoringStatusViewV2(BaseHumanSupportViewTest):
+    URL = "/v2/metrics/human-support/analysis/detailed-monitoring/status/"
+
+    def test_returns_400_without_project_uuid(self):
+        response = self.client.get(self.URL)
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_returns_403_without_project_auth(self):
+        response = self.client.get(self.URL, {"project_uuid": self.project.uuid})
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    @with_project_auth
+    @patch(f"{SERVICE_PATH}.get_analysis_detailed_monitoring_status_v2")
+    def test_returns_200_with_valid_request(self, mock_service_method):
+        mock_service_method.return_value = {"status": "active", "count": 5}
+
+        response = self.client.get(self.URL, {"project_uuid": self.project.uuid})
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data, {"status": "active", "count": 5})
+        mock_service_method.assert_called_once()

--- a/insights/metrics/human_support/tests/test_views.py
+++ b/insights/metrics/human_support/tests/test_views.py
@@ -8,9 +8,7 @@ from insights.authentication.tests.decorators import with_project_auth
 from insights.projects.models import Project
 
 
-SERVICE_PATH = (
-    "insights.human_support.services.HumanSupportDashboardService"
-)
+SERVICE_PATH = "insights.human_support.services.HumanSupportDashboardService"
 
 
 class BaseHumanSupportViewTest(APITestCase):

--- a/insights/metrics/meta/tests/test_permissions.py
+++ b/insights/metrics/meta/tests/test_permissions.py
@@ -1,0 +1,129 @@
+from unittest.mock import patch, MagicMock
+
+from django.test import TestCase
+
+from insights.metrics.meta.permissions import (
+    ProjectWABAPermission,
+    ProjectDashboardWABAPermission,
+)
+
+
+class TestProjectWABAPermission(TestCase):
+    def setUp(self):
+        self.permission = ProjectWABAPermission()
+        self.request = MagicMock()
+        self.view = MagicMock()
+
+    def test_returns_false_when_project_uuid_missing(self):
+        self.request.query_params = {"waba_id": "123"}
+        self.assertFalse(self.permission.has_permission(self.request, self.view))
+
+    def test_returns_false_when_waba_id_missing(self):
+        self.request.query_params = {"project_uuid": "some-uuid"}
+        self.assertFalse(self.permission.has_permission(self.request, self.view))
+
+    def test_returns_false_when_both_params_missing(self):
+        self.request.query_params = {}
+        self.assertFalse(self.permission.has_permission(self.request, self.view))
+
+    @patch("insights.metrics.meta.permissions.WeniIntegrationsClient")
+    def test_returns_true_when_waba_id_matches(self, mock_client_cls):
+        self.request.query_params = {
+            "project_uuid": "some-uuid",
+            "waba_id": "waba-123",
+        }
+        mock_client = MagicMock()
+        mock_client_cls.return_value = mock_client
+        mock_client.get_wabas_for_project.return_value = [
+            {"waba_id": "waba-123"},
+            {"waba_id": "waba-456"},
+        ]
+
+        self.assertTrue(self.permission.has_permission(self.request, self.view))
+
+    @patch("insights.metrics.meta.permissions.WeniIntegrationsClient")
+    def test_returns_false_when_waba_id_not_found(self, mock_client_cls):
+        self.request.query_params = {
+            "project_uuid": "some-uuid",
+            "waba_id": "waba-999",
+        }
+        mock_client = MagicMock()
+        mock_client_cls.return_value = mock_client
+        mock_client.get_wabas_for_project.return_value = [
+            {"waba_id": "waba-123"},
+        ]
+
+        self.assertFalse(self.permission.has_permission(self.request, self.view))
+
+    @patch("insights.metrics.meta.permissions.WeniIntegrationsClient")
+    def test_returns_false_on_value_error(self, mock_client_cls):
+        self.request.query_params = {
+            "project_uuid": "some-uuid",
+            "waba_id": "waba-123",
+        }
+        mock_client = MagicMock()
+        mock_client_cls.return_value = mock_client
+        mock_client.get_wabas_for_project.side_effect = ValueError("invalid")
+
+        self.assertFalse(self.permission.has_permission(self.request, self.view))
+
+
+class TestProjectDashboardWABAPermission(TestCase):
+    def setUp(self):
+        self.permission = ProjectDashboardWABAPermission()
+        self.request = MagicMock()
+        self.view = MagicMock(spec=[])
+
+    def test_returns_false_when_project_uuid_missing(self):
+        self.request.query_params = {"waba_id": "123"}
+        self.assertFalse(self.permission.has_permission(self.request, self.view))
+
+    def test_returns_false_when_waba_id_missing(self):
+        self.request.query_params = {"project_uuid": "some-uuid"}
+        self.assertFalse(self.permission.has_permission(self.request, self.view))
+
+    def test_returns_false_when_both_params_missing(self):
+        self.request.query_params = {}
+        self.assertFalse(self.permission.has_permission(self.request, self.view))
+
+    @patch("insights.metrics.meta.permissions.Dashboard.objects.filter")
+    def test_returns_true_when_dashboard_exists(self, mock_filter):
+        self.request.query_params = {
+            "project_uuid": "some-uuid",
+            "waba_id": "waba-123",
+        }
+        mock_filter.return_value.exists.return_value = True
+
+        self.assertTrue(self.permission.has_permission(self.request, self.view))
+        mock_filter.assert_called_once_with(
+            project__uuid="some-uuid",
+            config__is_whatsapp_integration=True,
+            config__waba_id="waba-123",
+        )
+
+    @patch("insights.metrics.meta.permissions.Dashboard.objects.filter")
+    def test_returns_false_when_dashboard_not_found(self, mock_filter):
+        self.request.query_params = {
+            "project_uuid": "some-uuid",
+            "waba_id": "waba-123",
+        }
+        mock_filter.return_value.exists.return_value = False
+
+        self.assertFalse(self.permission.has_permission(self.request, self.view))
+
+    @patch("insights.metrics.meta.permissions.Dashboard.objects.filter")
+    def test_uses_custom_project_uuid_field_from_view(self, mock_filter):
+        self.view = MagicMock()
+        self.view.project_uuid_field = "custom_project_field"
+        self.request.query_params = {
+            "custom_project_field": "custom-uuid",
+            "waba_id": "waba-789",
+        }
+        mock_filter.return_value.exists.return_value = True
+
+        self.assertTrue(self.permission.has_permission(self.request, self.view))
+        mock_filter.assert_called_once_with(
+            project__uuid="custom-uuid",
+            config__is_whatsapp_integration=True,
+            config__waba_id="waba-789",
+        )

--- a/insights/metrics/meta/tests/test_tasks.py
+++ b/insights/metrics/meta/tests/test_tasks.py
@@ -1,0 +1,173 @@
+import uuid
+from datetime import timedelta
+from unittest.mock import MagicMock, patch
+
+from django.test import TestCase
+from django.utils import timezone
+
+from insights.dashboards.models import Dashboard
+from insights.projects.models import Project
+
+
+class TestCheckDashboardsMarketingMessagesStatusForProject(TestCase):
+    def setUp(self):
+        self.project = Project.objects.create(name="Test Project")
+        self.task_path = (
+            "insights.metrics.meta.tasks" ".check_marketing_messages_status"
+        )
+
+    def _create_dashboard(self, config=None):
+        return Dashboard.objects.create(
+            project=self.project,
+            name="Test Dashboard",
+            description="desc",
+            config=config,
+        )
+
+    def _call_task(self):
+        from insights.metrics.meta.tasks import (
+            check_dashboards_marketing_messages_status_for_project,
+        )
+
+        check_dashboards_marketing_messages_status_for_project(
+            self.project.uuid,
+        )
+
+    def test_no_whatsapp_dashboards(self):
+        self._create_dashboard(config={"is_whatsapp_integration": False})
+
+        with patch(self.task_path) as mock_task:
+            self._call_task()
+            mock_task.apply_async.assert_not_called()
+
+    def test_skips_recently_checked_dashboard(self):
+        recent = (timezone.now() - timedelta(minutes=5)).isoformat()
+        self._create_dashboard(
+            config={
+                "is_whatsapp_integration": True,
+                "marketing_messages_status_last_checked_at": recent,
+            },
+        )
+
+        with patch(self.task_path) as mock_task:
+            self._call_task()
+            mock_task.apply_async.assert_not_called()
+
+    def test_dispatches_for_old_check(self):
+        old = (timezone.now() - timedelta(minutes=20)).isoformat()
+        dashboard = self._create_dashboard(
+            config={
+                "is_whatsapp_integration": True,
+                "marketing_messages_status_last_checked_at": old,
+            },
+        )
+
+        with patch(self.task_path) as mock_task:
+            self._call_task()
+            mock_task.apply_async.assert_called_once()
+            args = mock_task.apply_async.call_args
+            self.assertEqual(args.kwargs["args"], [dashboard.uuid])
+
+    def test_dispatches_when_never_checked(self):
+        dashboard = self._create_dashboard(
+            config={"is_whatsapp_integration": True},
+        )
+
+        with patch(self.task_path) as mock_task:
+            self._call_task()
+            mock_task.apply_async.assert_called_once()
+            args = mock_task.apply_async.call_args
+            self.assertEqual(args.kwargs["args"], [dashboard.uuid])
+
+    @patch("insights.metrics.meta.tasks.capture_exception")
+    def test_captures_exception_for_invalid_datetime(self, mock_capture):
+        mock_capture.return_value = "event-123"
+        self._create_dashboard(
+            config={
+                "is_whatsapp_integration": True,
+                "marketing_messages_status_last_checked_at": "not-a-date",
+            },
+        )
+
+        with patch(self.task_path) as mock_task:
+            self._call_task()
+            mock_capture.assert_called_once()
+            mock_task.apply_async.assert_not_called()
+
+
+class TestCheckMarketingMessagesStatus(TestCase):
+    def setUp(self):
+        self.project = Project.objects.create(name="Test Project")
+
+    def _call_task(self, dashboard_uuid):
+        from insights.metrics.meta.tasks import check_marketing_messages_status
+
+        check_marketing_messages_status(dashboard_uuid)
+
+    @patch("insights.metrics.meta.tasks.capture_exception")
+    def test_nonexistent_dashboard(self, mock_capture):
+        mock_capture.return_value = "event-456"
+        missing_uuid = uuid.uuid4()
+
+        self._call_task(missing_uuid)
+
+        mock_capture.assert_called_once()
+        exc = mock_capture.call_args[0][0]
+        self.assertIsInstance(exc, Dashboard.DoesNotExist)
+
+    def test_not_whatsapp_integration(self):
+        dashboard = Dashboard.objects.create(
+            project=self.project,
+            name="Non-WA",
+            description="desc",
+            config={"is_whatsapp_integration": False},
+        )
+
+        with patch(
+            "insights.metrics.meta.tasks.MetaMessageTemplatesService"
+        ) as mock_svc_cls:
+            self._call_task(dashboard.uuid)
+            mock_svc_cls.assert_not_called()
+
+    def test_missing_waba_id(self):
+        dashboard = Dashboard.objects.create(
+            project=self.project,
+            name="WA no waba",
+            description="desc",
+            config={"is_whatsapp_integration": True},
+        )
+
+        with patch(
+            "insights.metrics.meta.tasks.MetaMessageTemplatesService"
+        ) as mock_svc_cls:
+            self._call_task(dashboard.uuid)
+            mock_svc_cls.assert_not_called()
+
+    @patch("insights.metrics.meta.tasks.MetaMessageTemplatesService")
+    def test_successful_check_updates_config(self, mock_svc_cls):
+        mock_service = MagicMock()
+        mock_service.check_marketing_messages_status.return_value = True
+        mock_svc_cls.return_value = mock_service
+
+        dashboard = Dashboard.objects.create(
+            project=self.project,
+            name="WA Dashboard",
+            description="desc",
+            config={
+                "is_whatsapp_integration": True,
+                "waba_id": "123456",
+            },
+        )
+
+        self._call_task(dashboard.uuid)
+
+        mock_service.check_marketing_messages_status.assert_called_once_with(
+            waba_id="123456",
+        )
+
+        dashboard.refresh_from_db()
+        self.assertTrue(dashboard.config["is_mm_lite_active"])
+        self.assertIn(
+            "marketing_messages_status_last_checked_at",
+            dashboard.config,
+        )


### PR DESCRIPTION
### What
- Added comprehensive unit tests across multiple modules to increase test coverage:
  - **Authentication**: Tests for `ProjectAuthBodyPermission`, `ProjectQueryParamPermission`, `FeatureFlagPermission`, OIDC logout (`get_oidc_logout_url`, `admin_oidc_logout`), and `AdminOIDCAuthenticationBackend`
  - **Core pagination**: Tests for `get_cursor_based_pagination_urls` and `get_limit_offset_pagination_urls` proxy pagination utilities
  - **Human support services**: Tests for filter normalization (scalar-to-list coercion), detailed monitoring endpoints (on-going, awaiting, agents, status), volume by queue/tag, CSAT ratings, analysis status, and finished rooms formatting
  - **Human support views**: Tests for v1 and v2 detailed monitoring views (on-going, awaiting, agents, status, agents totals, analysis status) covering authentication, authorization, and happy-path scenarios
  - **Conversations tasks**: Tests for `generate_conversations_report` (concurrency limits, interrupted reports, pending report selection, error handling), `timeout_reports`, and `check_project_sales_funnel_on_datalake`
  - **Meta permissions**: Tests for `ProjectWABAPermission` and `ProjectDashboardWABAPermission`
  - **Meta tasks**: Tests for `check_dashboards_marketing_messages_status_for_project` (dispatch logic, skip conditions, exception handling) and `check_marketing_messages_status` (config updates, guard clauses)

### Why
- Existing test coverage was insufficient, leaving critical business logic paths (permissions, background tasks, service layer filters, and API views) unverified and prone to regressions