### PR TITLE
feat: implement WhatsApp integration use cases for saving and removing dashboards

### DIFF
--- a/insights/metrics/meta/tests/test_usecases.py
+++ b/insights/metrics/meta/tests/test_usecases.py
@@ -1,0 +1,349 @@
+import uuid
+
+from django.test import TestCase
+
+from insights.dashboards.models import Dashboard
+from insights.metrics.meta.usecases.remove_whatsapp_integration import (
+    RemoveWhatsappIntegrationUseCase,
+)
+from insights.metrics.meta.usecases.save_whatsapp_integration import (
+    SaveWhatsappIntegrationUseCase,
+)
+from insights.projects.models import Project
+
+
+class TestSaveWhatsappIntegrationUseCase(TestCase):
+    def setUp(self):
+        self.project = Project.objects.create(name="Test Project")
+        self.app_uuid = uuid.uuid4()
+        self.waba_id = "1234567890"
+        self.phone_number = {
+            "id": "445303688657575",
+            "display_phone_number": "+55 82 98877 6655",
+        }
+
+    def test_creates_dashboard_when_none_exists(self):
+        self.assertFalse(
+            Dashboard.objects.filter(
+                project=self.project, config__is_whatsapp_integration=True
+            ).exists()
+        )
+
+        dashboard = SaveWhatsappIntegrationUseCase().execute(
+            project=self.project,
+            app_uuid=self.app_uuid,
+            waba_id=self.waba_id,
+            phone_number=self.phone_number,
+        )
+
+        self.assertIsNotNone(dashboard)
+        self.assertEqual(dashboard.project, self.project)
+        self.assertEqual(
+            dashboard.name, f"Meta {self.phone_number['display_phone_number']}"
+        )
+        self.assertEqual(dashboard.config["waba_id"], self.waba_id)
+        self.assertEqual(dashboard.config["app_uuid"], str(self.app_uuid))
+        self.assertEqual(dashboard.config["phone_number"], self.phone_number)
+        self.assertTrue(dashboard.config["is_whatsapp_integration"])
+
+    def test_returns_dashboard_with_expected_config(self):
+        dashboard = SaveWhatsappIntegrationUseCase().execute(
+            project=self.project,
+            app_uuid=self.app_uuid,
+            waba_id=self.waba_id,
+            phone_number=self.phone_number,
+        )
+
+        self.assertEqual(
+            dashboard.config,
+            {
+                "is_whatsapp_integration": True,
+                "app_uuid": str(self.app_uuid),
+                "waba_id": self.waba_id,
+                "phone_number": self.phone_number,
+            },
+        )
+
+    def test_updates_existing_dashboard_when_phone_number_id_matches(self):
+        existing = Dashboard.objects.create(
+            project=self.project,
+            name="Existing",
+            config={
+                "is_whatsapp_integration": True,
+                "app_uuid": str(uuid.uuid4()),
+                "waba_id": "old_waba",
+                "phone_number": {
+                    "id": self.phone_number["id"],
+                    "display_phone_number": "+55 11 11111 1111",
+                },
+            },
+        )
+
+        dashboard = SaveWhatsappIntegrationUseCase().execute(
+            project=self.project,
+            app_uuid=self.app_uuid,
+            waba_id=self.waba_id,
+            phone_number=self.phone_number,
+        )
+
+        self.assertEqual(dashboard.pk, existing.pk)
+        self.assertEqual(dashboard.config["waba_id"], self.waba_id)
+        self.assertEqual(dashboard.config["app_uuid"], str(self.app_uuid))
+        self.assertEqual(dashboard.config["phone_number"], self.phone_number)
+
+        self.assertEqual(
+            Dashboard.objects.filter(
+                project=self.project, config__is_whatsapp_integration=True
+            ).count(),
+            1,
+        )
+
+    def test_does_not_update_dashboard_from_a_different_project(self):
+        other_project = Project.objects.create(name="Other Project")
+        other_dashboard = Dashboard.objects.create(
+            project=other_project,
+            name="Other Dashboard",
+            config={
+                "is_whatsapp_integration": True,
+                "app_uuid": str(uuid.uuid4()),
+                "waba_id": "other_waba",
+                "phone_number": self.phone_number,
+            },
+        )
+
+        SaveWhatsappIntegrationUseCase().execute(
+            project=self.project,
+            app_uuid=self.app_uuid,
+            waba_id=self.waba_id,
+            phone_number=self.phone_number,
+        )
+
+        other_dashboard.refresh_from_db()
+        self.assertEqual(other_dashboard.config["waba_id"], "other_waba")
+
+    def test_does_not_update_dashboard_with_different_phone_number_id(self):
+        existing = Dashboard.objects.create(
+            project=self.project,
+            name="Other Phone Dashboard",
+            config={
+                "is_whatsapp_integration": True,
+                "app_uuid": str(uuid.uuid4()),
+                "waba_id": "other_waba",
+                "phone_number": {
+                    "id": "999999999999999",
+                    "display_phone_number": "+55 99 99999 9999",
+                },
+            },
+        )
+
+        SaveWhatsappIntegrationUseCase().execute(
+            project=self.project,
+            app_uuid=self.app_uuid,
+            waba_id=self.waba_id,
+            phone_number=self.phone_number,
+        )
+
+        existing.refresh_from_db()
+        self.assertEqual(existing.config["waba_id"], "other_waba")
+        self.assertEqual(
+            Dashboard.objects.filter(
+                project=self.project, config__is_whatsapp_integration=True
+            ).count(),
+            2,
+        )
+
+    def test_does_not_create_copy_when_no_main_project_in_org(self):
+        org_uuid = uuid.uuid4()
+        self.project.org_uuid = org_uuid
+        self.project.save(update_fields=["org_uuid"])
+
+        SaveWhatsappIntegrationUseCase().execute(
+            project=self.project,
+            app_uuid=self.app_uuid,
+            waba_id=self.waba_id,
+            phone_number=self.phone_number,
+        )
+
+        self.assertEqual(
+            Dashboard.objects.filter(
+                config__is_whatsapp_integration=True,
+                config__waba_id=self.waba_id,
+            ).count(),
+            1,
+        )
+
+    def test_creates_copy_in_main_project_when_it_exists(self):
+        org_uuid = uuid.uuid4()
+        secondary_project = Project.objects.create(
+            name="Secondary Project",
+            org_uuid=org_uuid,
+            config={"is_secondary_project": True},
+        )
+        main_project = Project.objects.create(
+            name="Main Project",
+            org_uuid=org_uuid,
+            config={"is_main_project": True},
+        )
+
+        SaveWhatsappIntegrationUseCase().execute(
+            project=secondary_project,
+            app_uuid=self.app_uuid,
+            waba_id=self.waba_id,
+            phone_number=self.phone_number,
+        )
+
+        secondary_dashboard = Dashboard.objects.filter(
+            project=secondary_project, config__is_whatsapp_integration=True
+        ).first()
+        self.assertIsNotNone(secondary_dashboard)
+        self.assertEqual(
+            secondary_dashboard.name,
+            f"Meta {self.phone_number['display_phone_number']}",
+        )
+
+        main_dashboard = Dashboard.objects.filter(
+            project=main_project, config__is_whatsapp_integration=True
+        ).first()
+        self.assertIsNotNone(main_dashboard)
+        self.assertEqual(
+            main_dashboard.name,
+            f"{secondary_project.name} {self.phone_number['display_phone_number']}",
+        )
+        self.assertEqual(main_dashboard.config["waba_id"], self.waba_id)
+        self.assertEqual(main_dashboard.config["app_uuid"], str(self.app_uuid))
+
+    def test_ignores_main_project_from_a_different_org(self):
+        self.project.org_uuid = uuid.uuid4()
+        self.project.save(update_fields=["org_uuid"])
+
+        Project.objects.create(
+            name="Main Project From Another Org",
+            org_uuid=uuid.uuid4(),
+            config={"is_main_project": True},
+        )
+
+        SaveWhatsappIntegrationUseCase().execute(
+            project=self.project,
+            app_uuid=self.app_uuid,
+            waba_id=self.waba_id,
+            phone_number=self.phone_number,
+        )
+
+        self.assertEqual(
+            Dashboard.objects.filter(
+                config__is_whatsapp_integration=True,
+                config__waba_id=self.waba_id,
+            ).count(),
+            1,
+        )
+
+
+class TestRemoveWhatsappIntegrationUseCase(TestCase):
+    def setUp(self):
+        self.project = Project.objects.create(name="Test Project")
+        self.waba_id = "1234567890"
+
+    def _create_whatsapp_dashboard(
+        self, project: Project, waba_id: str, name: str = "Whatsapp Dashboard"
+    ) -> Dashboard:
+        return Dashboard.objects.create(
+            project=project,
+            name=name,
+            config={
+                "is_whatsapp_integration": True,
+                "waba_id": waba_id,
+            },
+        )
+
+    def test_removes_matching_dashboard(self):
+        self._create_whatsapp_dashboard(self.project, self.waba_id)
+
+        deleted_count = RemoveWhatsappIntegrationUseCase().execute(
+            project=self.project, waba_id=self.waba_id
+        )
+
+        self.assertEqual(deleted_count, 1)
+        self.assertFalse(
+            Dashboard.objects.filter(
+                project=self.project, config__is_whatsapp_integration=True
+            ).exists()
+        )
+
+    def test_returns_zero_when_no_matching_dashboard_exists(self):
+        deleted_count = RemoveWhatsappIntegrationUseCase().execute(
+            project=self.project, waba_id=self.waba_id
+        )
+
+        self.assertEqual(deleted_count, 0)
+
+    def test_does_not_remove_dashboard_with_different_waba_id(self):
+        dashboard = self._create_whatsapp_dashboard(self.project, "other_waba")
+
+        deleted_count = RemoveWhatsappIntegrationUseCase().execute(
+            project=self.project, waba_id=self.waba_id
+        )
+
+        self.assertEqual(deleted_count, 0)
+        self.assertTrue(Dashboard.objects.filter(pk=dashboard.pk).exists())
+
+    def test_does_not_remove_dashboard_from_a_different_project(self):
+        other_project = Project.objects.create(name="Other Project")
+        other_dashboard = self._create_whatsapp_dashboard(other_project, self.waba_id)
+
+        deleted_count = RemoveWhatsappIntegrationUseCase().execute(
+            project=self.project, waba_id=self.waba_id
+        )
+
+        self.assertEqual(deleted_count, 0)
+        self.assertTrue(Dashboard.objects.filter(pk=other_dashboard.pk).exists())
+
+    def test_removes_dashboard_copy_from_main_project(self):
+        org_uuid = uuid.uuid4()
+        secondary_project = Project.objects.create(
+            name="Secondary Project",
+            org_uuid=org_uuid,
+            config={"is_secondary_project": True},
+        )
+        main_project = Project.objects.create(
+            name="Main Project",
+            org_uuid=org_uuid,
+            config={"is_main_project": True},
+        )
+
+        self._create_whatsapp_dashboard(secondary_project, self.waba_id)
+        self._create_whatsapp_dashboard(
+            main_project, self.waba_id, name="Main Copy"
+        )
+
+        deleted_count = RemoveWhatsappIntegrationUseCase().execute(
+            project=secondary_project, waba_id=self.waba_id
+        )
+
+        self.assertEqual(deleted_count, 2)
+        self.assertFalse(
+            Dashboard.objects.filter(
+                config__is_whatsapp_integration=True,
+                config__waba_id=self.waba_id,
+            ).exists()
+        )
+
+    def test_does_not_remove_main_project_dashboard_from_a_different_org(self):
+        self.project.org_uuid = uuid.uuid4()
+        self.project.save(update_fields=["org_uuid"])
+
+        unrelated_main = Project.objects.create(
+            name="Unrelated Main",
+            org_uuid=uuid.uuid4(),
+            config={"is_main_project": True},
+        )
+        unrelated_dashboard = self._create_whatsapp_dashboard(
+            unrelated_main, self.waba_id
+        )
+        self._create_whatsapp_dashboard(self.project, self.waba_id)
+
+        deleted_count = RemoveWhatsappIntegrationUseCase().execute(
+            project=self.project, waba_id=self.waba_id
+        )
+
+        self.assertEqual(deleted_count, 1)
+        self.assertTrue(Dashboard.objects.filter(pk=unrelated_dashboard.pk).exists())

--- a/insights/metrics/meta/usecases/remove_whatsapp_integration.py
+++ b/insights/metrics/meta/usecases/remove_whatsapp_integration.py
@@ -1,0 +1,30 @@
+from insights.dashboards.models import Dashboard
+from insights.projects.models import Project
+
+
+class RemoveWhatsappIntegrationUseCase:
+    """
+    Remove the dashboards that represent a WhatsApp integration for the
+    given project and waba_id. When the project belongs to an organization
+    that has a main project, the dashboard copy in the main project is also
+    removed.
+    """
+
+    def execute(self, project: Project, waba_id: str) -> int:
+        projects = [project]
+
+        main_project = Project.objects.filter(
+            org_uuid=project.org_uuid,
+            config__is_main_project=True,
+        ).first()
+
+        if main_project and main_project.pk != project.pk:
+            projects.append(main_project)
+
+        deleted_count, _ = Dashboard.objects.filter(
+            project__in=projects,
+            config__waba_id=waba_id,
+            config__is_whatsapp_integration=True,
+        ).delete()
+
+        return deleted_count

--- a/insights/metrics/meta/usecases/save_whatsapp_integration.py
+++ b/insights/metrics/meta/usecases/save_whatsapp_integration.py
@@ -1,0 +1,64 @@
+import uuid
+from typing import TypedDict
+
+from insights.dashboards.models import Dashboard
+from insights.projects.models import Project
+
+
+class WhatsappPhoneNumber(TypedDict):
+    id: str
+    display_phone_number: str
+
+
+class SaveWhatsappIntegrationUseCase:
+    """
+    Create or update the dashboard that represents a WhatsApp integration
+    for a project. When the project belongs to an organization that has a
+    main project, a copy of the dashboard is also created in the main project.
+    """
+
+    def execute(
+        self,
+        project: Project,
+        app_uuid: uuid.UUID,
+        waba_id: str,
+        phone_number: WhatsappPhoneNumber,
+    ) -> Dashboard:
+        config = {
+            "is_whatsapp_integration": True,
+            "app_uuid": str(app_uuid),
+            "waba_id": waba_id,
+            "phone_number": phone_number,
+        }
+
+        dashboard = Dashboard.objects.filter(
+            project=project,
+            config__phone_number__id=phone_number["id"],
+            config__is_whatsapp_integration=True,
+        ).first()
+
+        if dashboard:
+            dashboard.config = config
+            dashboard.save(update_fields=["config"])
+        else:
+            name = f"Meta {phone_number['display_phone_number']}"
+            dashboard = Dashboard.objects.create(
+                project=project,
+                config=config,
+                name=name,
+            )
+
+        main_project = Project.objects.filter(
+            org_uuid=project.org_uuid,
+            config__is_main_project=True,
+        ).first()
+
+        if main_project:
+            copy_name = f"{project.name} {phone_number['display_phone_number']}"
+            Dashboard.objects.create(
+                project=main_project,
+                config=config,
+                name=copy_name,
+            )
+
+        return dashboard

--- a/insights/metrics/meta/views.py
+++ b/insights/metrics/meta/views.py
@@ -15,7 +15,6 @@ from insights.authentication.permissions import (
     InternalAuthenticationPermission,
     ProjectAuthQueryParamPermission,
 )
-from insights.dashboards.models import Dashboard
 from insights.metrics.meta.choices import (
     WhatsAppMessageTemplatesCategories,
     WhatsAppMessageTemplatesLanguages,
@@ -44,6 +43,12 @@ from insights.metrics.meta.serializers import (
     WhatsappIntegrationWebhookSerializer,
 )
 from insights.metrics.meta.services import MetaMessageTemplatesService
+from insights.metrics.meta.usecases.remove_whatsapp_integration import (
+    RemoveWhatsappIntegrationUseCase,
+)
+from insights.metrics.meta.usecases.save_whatsapp_integration import (
+    SaveWhatsappIntegrationUseCase,
+)
 from insights.metrics.meta.utils import (
     get_edit_template_url_from_template_data,
 )
@@ -334,50 +339,12 @@ class WhatsappIntegrationWebhookView(APIView):
                 uuid=serializer.validated_data["project_uuid"]
             )
 
-            config = {
-                "is_whatsapp_integration": True,
-                "app_uuid": str(serializer.validated_data["app_uuid"]),
-                "waba_id": serializer.validated_data["waba_id"],
-                "phone_number": serializer.validated_data["phone_number"],
-            }
-
-            existing_dashboard = Dashboard.objects.filter(
+            SaveWhatsappIntegrationUseCase().execute(
                 project=project,
-                config__phone_number__id=serializer.validated_data["phone_number"][
-                    "id"
-                ],
-                config__is_whatsapp_integration=True,
-            ).first()
-
-            if existing_dashboard:
-                existing_dashboard.config = config
-                existing_dashboard.save(update_fields=["config"])
-
-            else:
-                name = f"Meta {serializer.validated_data['phone_number']['display_phone_number']}"
-
-                existing_dashboard = Dashboard.objects.create(
-                    project=project,
-                    config=config,
-                    name=name,
-                )
-
-            current_project = existing_dashboard.project
-
-            main_project = Project.objects.filter(
-                org_uuid=current_project.org_uuid,
-                config__is_main_project=True,
-            ).first()
-
-            if main_project:
-                # Create a copy of this dashboard in the main project
-                name = f"{current_project.name} {serializer.validated_data['phone_number']['display_phone_number']}"
-                Dashboard.objects.create(
-                    project=main_project,
-                    config=config,
-                    name=name,
-                )
-
+                app_uuid=serializer.validated_data["app_uuid"],
+                waba_id=serializer.validated_data["waba_id"],
+                phone_number=serializer.validated_data["phone_number"],
+            )
         except Exception as e:
             logger.exception(f"Database error in WhatsApp integration: {e}")
             return Response(
@@ -395,25 +362,15 @@ class WhatsappIntegrationWebhookView(APIView):
         serializer = WhatsappIntegrationWebhookRemoveSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
 
-        current_project = Project.objects.filter(
+        project = Project.objects.filter(
             uuid=serializer.validated_data["project_uuid"],
         ).first()
 
-        projects = [current_project]
-
-        main_project = Project.objects.filter(
-            org_uuid=current_project.org_uuid,
-            config__is_main_project=True,
-        ).first()
-
-        if main_project:
-            projects.append(main_project)
-
         try:
-            Dashboard.objects.filter(
-                project__in=projects,
-                config__waba_id=serializer.validated_data["waba_id"],
-            ).delete()
+            RemoveWhatsappIntegrationUseCase().execute(
+                project=project,
+                waba_id=serializer.validated_data["waba_id"],
+            )
         except Exception as e:
             logger.exception(f"Database error removing WhatsApp integration: {e}")
             return Response(


### PR DESCRIPTION
### What

Refactor the WhatsApp integration webhook to delegate its business logic to dedicated use case classes:

- New `SaveWhatsappIntegrationUseCase` in `insights/metrics/meta/usecases/save_whatsapp_integration.py`, encapsulating the create/update of the WhatsApp integration dashboard and the creation of the dashboard copy in the organization's main project.
- New `RemoveWhatsappIntegrationUseCase` in `insights/metrics/meta/usecases/remove_whatsapp_integration.py`, encapsulating the deletion of WhatsApp integration dashboards from the project and (when applicable) from the organization's main project.
- `WhatsappIntegrationWebhookView` (POST and DELETE handlers) now only resolves the project from the payload and dispatches to the corresponding use case, removing all direct `Dashboard` / `Project` lookups from the view.
- Added `insights/metrics/meta/tests/test_usecases.py` with full unit coverage for both use cases, including: dashboard creation, updates by matching `phone_number.id`, isolation across projects and organizations, main-project copy behavior, and removal scenarios.

### Why

The webhook view was holding orchestration logic (config building, dashboard upsert, main-project mirroring, multi-project deletion) that was hard to test in isolation and easy to drift between the save and remove flows. Extracting it into use cases makes the behavior:

- Reusable from other entry points (commands, tasks, other views).
- Directly unit-testable without going through the HTTP layer.
- Easier to evolve, with the main-project copy/removal rules expressed in a single place per operation.

### Sequence diagram

```mermaid
sequenceDiagram
    participant Client as Webhook Client
    participant View as WhatsappIntegrationWebhookView
    participant SaveUC as SaveWhatsappIntegrationUseCase
    participant RemoveUC as RemoveWhatsappIntegrationUseCase
    participant ProjectRepo as Project model
    participant DashRepo as Dashboard model

    Note over Client,View: Create or update integration (POST)
    Client->>View: POST /whatsapp-integration-webhook (project_uuid, app_uuid, waba_id, phone_number)
    View->>View: Validate payload
    View->>ProjectRepo: get(uuid=project_uuid)
    ProjectRepo-->>View: project
    View->>SaveUC: execute(project, app_uuid, waba_id, phone_number)
    SaveUC->>DashRepo: filter(project, phone_number.id, is_whatsapp_integration).first()
    DashRepo-->>SaveUC: existing dashboard or None
    alt Dashboard exists
        SaveUC->>DashRepo: update config
    else No dashboard
        SaveUC->>DashRepo: create("Meta {display_phone_number}", config)
    end
    SaveUC->>ProjectRepo: filter(org_uuid, is_main_project=True).first()
    ProjectRepo-->>SaveUC: main_project or None
    opt Main project exists
        SaveUC->>DashRepo: create("{project.name} {display_phone_number}" copy in main_project)
    end
    SaveUC-->>View: dashboard
    View-->>Client: 200 OK

    Note over Client,View: Remove integration (DELETE)
    Client->>View: DELETE /whatsapp-integration-webhook (project_uuid, waba_id)
    View->>View: Validate payload
    View->>ProjectRepo: filter(uuid=project_uuid).first()
    ProjectRepo-->>View: project
    View->>RemoveUC: execute(project, waba_id)
    RemoveUC->>ProjectRepo: filter(org_uuid, is_main_project=True).first()
    ProjectRepo-->>RemoveUC: main_project or None
    RemoveUC->>DashRepo: delete(project in [project, main_project?], waba_id, is_whatsapp_integration)
    DashRepo-->>RemoveUC: deleted_count
    RemoveUC-->>View: deleted_count
    View-->>Client: 200 OK