### PR TITLE
Fix: cross tab with none values in metadata

### DIFF
--- a/insights/metrics/conversations/integrations/datalake/serializers.py
+++ b/insights/metrics/conversations/integrations/datalake/serializers.py
@@ -288,6 +288,13 @@ class CrosstabLabelsSerializer(BaseSerializer):
 
             join_key = self._get_join_key(metadata)
 
+            # When a reference_field is explicitly provided, events that don't
+            # carry that field must be ignored. Otherwise every event missing
+            # the field would collapse into a single None bucket and pollute
+            # the join, attributing unrelated source B events to a single label.
+            if self.reference_field and not join_key:
+                continue
+
             label = (
                 event.get("value")
                 if self.field == "value"
@@ -346,6 +353,13 @@ class CrosstabDataSerializer(BaseSerializer):
                 continue
 
             join_key = self._get_join_key(metadata)
+
+            # Mirrors the guard on CrosstabLabelsSerializer: when reference_field
+            # is set, source B events without that field cannot be reliably
+            # joined and must be dropped instead of falling back to a None key.
+            if self.reference_field and not join_key:
+                continue
+
             source_a_label = self.join_keys.get(join_key)
 
             if not source_a_label:

--- a/insights/metrics/conversations/integrations/datalake/tests/test_serializers.py
+++ b/insights/metrics/conversations/integrations/datalake/tests/test_serializers.py
@@ -305,6 +305,108 @@ class TestCrosstabLabelsSerializer(TestCase):
             {"ref-aaa": "value1", "ref-bbb": "value2"},
         )
 
+    def test_serialize_with_reference_field_skips_events_without_reference(self):
+        """
+        When reference_field is set, events whose metadata does not carry that
+        field must be skipped: they should not pollute join_keys with a None
+        entry nor leak their label into the labels set.
+        """
+        events = [
+            {
+                "event_name": "weni_nexus_data",
+                "key": "source_a_key",
+                "value": "with_ref",
+                "date": 1716883200,
+                "contact_urn": "1234567890",
+                "value_type": "string",
+                "metadata": json.dumps(
+                    {
+                        "conversation_uuid": "conv-1",
+                        "interaction_id": "ref-aaa",
+                    }
+                ),
+            },
+            {
+                "event_name": "weni_nexus_data",
+                "key": "source_a_key",
+                "value": "legacy_without_ref",
+                "date": 1716883200,
+                "contact_urn": "1234567891",
+                "value_type": "string",
+                "metadata": json.dumps(
+                    {
+                        "conversation_uuid": "conv-2",
+                    }
+                ),
+            },
+            {
+                "event_name": "weni_nexus_data",
+                "key": "source_a_key",
+                "value": "another_legacy",
+                "date": 1716883200,
+                "contact_urn": "1234567892",
+                "value_type": "string",
+                "metadata": json.dumps(
+                    {
+                        "conversation_uuid": "conv-3",
+                    }
+                ),
+            },
+        ]
+
+        serializer = self.serializer_class(
+            events, "value", reference_field="interaction_id"
+        )
+        data = serializer.serialize()
+
+        self.assertEqual(data["labels"], {"with_ref"})
+        self.assertEqual(data["join_keys"], {"ref-aaa": "with_ref"})
+        self.assertNotIn(None, data["join_keys"])
+
+    def test_serialize_without_reference_field_still_uses_conversation_uuid(self):
+        """
+        Regression check: when reference_field is not set, the serializer must
+        keep using conversation_uuid as the join key. Events without the
+        reference_field metadata should NOT be filtered out on this path.
+        """
+        events = [
+            {
+                "event_name": "weni_nexus_data",
+                "key": "source_a_key",
+                "value": "value1",
+                "date": 1716883200,
+                "contact_urn": "1234567890",
+                "value_type": "string",
+                "metadata": json.dumps(
+                    {
+                        "conversation_uuid": "conv-1",
+                    }
+                ),
+            },
+            {
+                "event_name": "weni_nexus_data",
+                "key": "source_a_key",
+                "value": "value2",
+                "date": 1716883200,
+                "contact_urn": "1234567891",
+                "value_type": "string",
+                "metadata": json.dumps(
+                    {
+                        "conversation_uuid": "conv-2",
+                    }
+                ),
+            },
+        ]
+
+        serializer = self.serializer_class(events, "value")
+        data = serializer.serialize()
+
+        self.assertEqual(data["labels"], {"value1", "value2"})
+        self.assertEqual(
+            data["join_keys"],
+            {"conv-1": "value1", "conv-2": "value2"},
+        )
+
 
 class TestCrosstabDataSerializer(TestCase):
     def setUp(self) -> None:
@@ -454,6 +556,135 @@ class TestCrosstabDataSerializer(TestCase):
             {
                 "Delivery": {"Satisfied": 1},
                 "Shopping": {"Unsatisfied": 1},
+            },
+        )
+
+    def test_serialize_with_reference_field_skips_events_without_reference(self):
+        """
+        When reference_field is set, source B events whose metadata does not
+        carry that field must be skipped instead of falling back to
+        join_keys[None]. This prevents legacy events (emitted before the
+        metadata roll-out) from collapsing into a single source A label.
+        """
+        labels = {"Delivery", "Shopping"}
+        join_keys = {
+            "ref-aaa": "Delivery",
+            "ref-bbb": "Shopping",
+        }
+        events = [
+            {
+                "event_name": "weni_nexus_data",
+                "key": "source_b_key",
+                "value": "Satisfied",
+                "date": 1716883200,
+                "contact_urn": "1234567890",
+                "value_type": "string",
+                "metadata": json.dumps(
+                    {
+                        "conversation_uuid": "conv-1",
+                        "interaction_id": "ref-aaa",
+                    }
+                ),
+            },
+            {
+                "event_name": "weni_nexus_data",
+                "key": "source_b_key",
+                "value": "Satisfied",
+                "date": 1716883200,
+                "contact_urn": "1234567891",
+                "value_type": "string",
+                "metadata": json.dumps(
+                    {
+                        "conversation_uuid": "conv-legacy-1",
+                    }
+                ),
+            },
+            {
+                "event_name": "weni_nexus_data",
+                "key": "source_b_key",
+                "value": "Unsatisfied",
+                "date": 1716883200,
+                "contact_urn": "1234567892",
+                "value_type": "string",
+                "metadata": json.dumps(
+                    {
+                        "conversation_uuid": "conv-legacy-2",
+                    }
+                ),
+            },
+        ]
+
+        serializer = self.serializer_class(
+            labels,
+            join_keys,
+            events,
+            "value",
+            reference_field="interaction_id",
+        )
+        data = serializer.serialize()
+
+        self.assertEqual(
+            data,
+            {
+                "Delivery": {"Satisfied": 1},
+                "Shopping": {},
+            },
+        )
+
+    def test_serialize_with_reference_field_ignores_none_bucket_in_join_keys(self):
+        """
+        Even if join_keys contains a None entry (defensive case), source B
+        events without the reference_field must not be attributed to it.
+        """
+        labels = {"Delivery", "Ghost"}
+        join_keys = {
+            "ref-aaa": "Delivery",
+            None: "Ghost",
+        }
+        events = [
+            {
+                "event_name": "weni_nexus_data",
+                "key": "source_b_key",
+                "value": "Satisfied",
+                "date": 1716883200,
+                "contact_urn": "1234567890",
+                "value_type": "string",
+                "metadata": json.dumps(
+                    {
+                        "conversation_uuid": "conv-1",
+                        "interaction_id": "ref-aaa",
+                    }
+                ),
+            },
+            {
+                "event_name": "weni_nexus_data",
+                "key": "source_b_key",
+                "value": "Satisfied",
+                "date": 1716883200,
+                "contact_urn": "1234567891",
+                "value_type": "string",
+                "metadata": json.dumps(
+                    {
+                        "conversation_uuid": "conv-legacy",
+                    }
+                ),
+            },
+        ]
+
+        serializer = self.serializer_class(
+            labels,
+            join_keys,
+            events,
+            "value",
+            reference_field="interaction_id",
+        )
+        data = serializer.serialize()
+
+        self.assertEqual(
+            data,
+            {
+                "Delivery": {"Satisfied": 1},
+                "Ghost": {},
             },
         )
 


### PR DESCRIPTION
### **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Do we need to implement analytics?


### **What**
Fixes the crosstab widget join logic so that events missing the configured `reference_field` metadata key no longer collapse into a single bucket. Previously, both `CrosstabLabelsSerializer` and `CrosstabDataSerializer` fell back to `metadata.get(reference_field)` without filtering, which returned `None` for any event that did not carry the field. The first source A event with a missing field would set `join_keys[None] = "<first label seen>"`, and every source B event also missing the field would be silently attributed to that single label — heavily distorting the chart on projects where the metadata roll-out was partial or recent.

The fix adds a symmetric guard on both serializers: when `reference_field` is explicitly set, events without that field in their metadata are dropped instead of being routed to a `None` bucket. The guard is gated by `if self.reference_field`, so the default `conversation_uuid` path is untouched.

**Affected endpoint:**

| # | Endpoint | Behavior |
|---|---|---|
| A | `GET /v1/metrics/conversations/crosstab/?widget_uuid=...&start_date=...&end_date=...` | When the widget config sets `reference_field`, source A and source B events lacking that metadata key are now excluded from the join. Counts and labels reflect only events with a valid reference, eliminating the false `None` bucket. |

**Out of scope (intentionally not changed):**
- The default `conversation_uuid` join path (when `reference_field` is not set) — `conversation_uuid` is part of the standard event envelope and is present on 100% of records.
- Bug 2 (duplicate `reference_field` value across source A events with different labels) — kept as-is per business rule: first label wins.
- All other widgets that consume `get_raw_events_data` / `CrosstabSource` without a `reference_field`.

**Modified files**
- `insights/metrics/conversations/integrations/datalake/serializers.py` — adds the `if self.reference_field and not join_key: continue` guard to both `CrosstabLabelsSerializer.serialize` and `CrosstabDataSerializer.serialize`.
- `insights/metrics/conversations/integrations/datalake/tests/test_serializers.py` — adds 5 new unit tests covering the new behavior and a regression check for the unchanged path.

**New tests**
- `TestCrosstabLabelsSerializer.test_serialize_with_reference_field_skips_events_without_reference` — source A events without the reference field do not appear in `labels` or `join_keys`, and `join_keys` does not contain a `None` entry.
- `TestCrosstabLabelsSerializer.test_serialize_without_reference_field_still_uses_conversation_uuid` — regression: when no `reference_field` is configured, the serializer keeps using `conversation_uuid` and the new filter has no effect.
- `TestCrosstabDataSerializer.test_serialize_with_reference_field_skips_events_without_reference` — source B events without the reference field are not counted.
- `TestCrosstabDataSerializer.test_serialize_with_reference_field_ignores_none_bucket_in_join_keys` — defensive check: even if `join_keys` is built with a `None` entry, source B events without the reference field are not attributed to it.
- Existing tests for both serializers continue to pass without modification.

**Test results**
- 13/13 serializer tests passing (8 pre-existing + 5 new).
- 240/240 tests in `insights.metrics.conversations.integrations.datalake.tests` and `insights.metrics.conversations.tests` passing — no regressions in downstream services or use cases.

### **Why**
The crosstab widget pairs two event keys (source A and source B) via a join key extracted from the events' metadata. When users configure an explicit `reference_field` — e.g. `satisfaction_id` to link `satisfaction_context` and `satisfaction_feedback` — events emitted before that field was rolled out (or any event that never carried the field) returned `None` from `metadata.get(reference_field)`. The serializers stored those events under `join_keys[None]`, and the first source A label encountered with a missing field "won" the bucket. Every source B event also missing the field was then counted against that single label.

In a real customer scenario this produced a dramatic visual artifact: one category jumped to 167 occurrences (all the legacy events collapsed together) while the rest of the chart kept correct but tiny counts. Dropping events without the reference field is the safe behavior — it never affects the legacy `conversation_uuid` path used by every other crosstab widget, and it keeps the chart honest about what the join can actually resolve.

### **Architecture diagram**

```mermaid
flowchart TD
    Client[Client request]

    Client -->|GET /v1/metrics/conversations/crosstab/| View[ConversationsMetricsViewSet.crosstab]
    View --> Service[ConversationsMetricsService.get_crosstab_data]
    Service --> Datalake[DatalakeConversationsMetricsService.get_crosstab_data]

    Datalake --> FetchA[Fetch source A events]
    Datalake --> FetchB[Fetch source B events]

    FetchA --> Labels[CrosstabLabelsSerializer.serialize]
    FetchB --> Data[CrosstabDataSerializer.serialize]

    Labels --> RefCheckA{reference_field set?}
    Data --> RefCheckB{reference_field set?}

    RefCheckA -- No --> JoinByConvA["join_key = metadata.conversation_uuid"]
    RefCheckB -- No --> JoinByConvB["join_key = metadata.conversation_uuid"]

    RefCheckA -- Yes --> JoinByRefA["join_key = metadata.reference_field"]
    RefCheckB -- Yes --> JoinByRefB["join_key = metadata.reference_field"]

    JoinByRefA --> MissingA{join_key empty?}
    JoinByRefB --> MissingB{join_key empty?}

    MissingA -- Yes --> SkipA[Skip event - no None bucket]
    MissingB -- Yes --> SkipB[Skip event - no None bucket]

    MissingA -- No --> RegisterLabel["Register label and join_keys mapping"]
    MissingB -- No --> Lookup["Look up source A label via join_keys"]
    Lookup --> Count[Increment count under source A label]

    JoinByConvA --> RegisterLabel
    JoinByConvB --> Lookup

    Labels --> Response[CrosstabItemSerializer response]
    Data --> Response