### PR TITLE
fix: unsupported operations with none types

### DIFF
--- a/insights/widgets/usecases/get_source_data.py
+++ b/insights/widgets/usecases/get_source_data.py
@@ -150,7 +150,7 @@ def simple_source_data_operation(
     return serialized_source
 
 
-def get_subwidget_data(data):
+def get_subwidget_data(data={}) -> dict:
     if "results" in data:
         if len(data["results"]) == 0:
             return {}

--- a/insights/widgets/usecases/get_source_data.py
+++ b/insights/widgets/usecases/get_source_data.py
@@ -59,7 +59,7 @@ def convert_to_iso(default_filters):
 
 
 class Calculator:
-    def __init__(self, operand_1, operand_2, operator) -> None:
+    def __init__(self, operand_1=0, operand_2=0, operator=None) -> None:
         self.operand_1 = operand_1
         self.operand_2 = operand_2
         self.operator = operator
@@ -80,6 +80,9 @@ class Calculator:
         return 100 * (self.operand_1 / self.operand_2)
 
     def evaluate(self):
+        if self.operator is None or not hasattr(self, self.operator):
+            raise ValueError(f"Invalid operator: {self.operator}")
+
         return getattr(self, self.operator)()
 
 

--- a/insights/widgets/usecases/tests/test_get_source_data.py
+++ b/insights/widgets/usecases/tests/test_get_source_data.py
@@ -140,8 +140,24 @@ class TestCalculator(TestCase):
         calc_percentage = Calculator(50, 100, "percentage")
         self.assertEqual(calc_percentage.evaluate(), 50.0)
 
-        with self.assertRaises(AttributeError):  # Test invalid operator
+    def test_calculator_default_values(self):
+        calc = Calculator()
+        self.assertEqual(calc.operand_1, 0)
+        self.assertEqual(calc.operand_2, 0)
+        self.assertIsNone(calc.operator)
+
+    def test_percentage_with_zero_divisor_returns_zero(self):
+        self.assertEqual(Calculator(50, 0, "percentage").evaluate(), 0)
+
+    def test_evaluate_with_none_operator_raises_value_error(self):
+        with self.assertRaises(ValueError) as ctx:
+            Calculator(1, 1).evaluate()
+        self.assertIn("Invalid operator", str(ctx.exception))
+
+    def test_evaluate_with_invalid_operator_raises_value_error(self):
+        with self.assertRaises(ValueError) as ctx:
             Calculator(1, 1, "invalid").evaluate()
+        self.assertIn("Invalid operator", str(ctx.exception))
 
 
 class TestDataSourceOperations(TestCase):


### PR DESCRIPTION
### What
- `Calculator.__init__` now accepts default values (`operand_1=0`, `operand_2=0`, `operator=None`), so it can be instantiated without arguments.
- `Calculator.evaluate` now raises a `ValueError` with a descriptive message (`"Invalid operator: ..."`) when the operator is `None` or not a valid method, replacing the previous implicit `AttributeError`.
- `get_subwidget_data` signature updated to `get_subwidget_data(data={}) -> dict`, adding a default empty dict and an explicit return type annotation.
- New unit tests added covering: default `Calculator` values, `percentage` with a zero divisor returning `0`, and `evaluate` raising `ValueError` for both `None` and invalid operators.

### Why
Make the `Calculator` API safer and more predictable by validating the operator up front and surfacing a clear, domain-specific error instead of a generic `AttributeError`. Default values reduce boilerplate at call sites and allow `get_subwidget_data` to be invoked safely without arguments. The added tests lock in the new defaults, error contract, and edge-case behavior to prevent regressions.