### PR TITLE
feat: Add project's agents request to Nexus client

### DIFF
--- a/insights/sources/integrations/clients.py
+++ b/insights/sources/integrations/clients.py
@@ -72,18 +72,35 @@ class BaseNexusClient(ABC):
         Get the status of the multi agents for a project.
         """
 
+    @abstractmethod
+    def get_project_agents_team(self, project_uuid: UUID) -> Response:
+        """
+        Get the agents team for a project.
+        """
+
 
 class NexusClient(BaseNexusClient):
     """
     Client for Nexus API.
     """
 
+    class AuthTypes:
+        API_TOKEN = "api_token"
+        KEYCLOAK_INTERNAL = "keycloak_internal"
+
     def __init__(self):
         self.base_url = settings.NEXUS_BASE_URL
-        self.headers = {
-            "Authorization": f"Bearer {settings.NEXUS_API_TOKEN}",
-        }
         self.timeout = 60
+
+    def get_headers(self, auth_type: AuthTypes) -> dict:
+        if auth_type == self.AuthTypes.API_TOKEN:
+            return {
+                "Authorization": f"Bearer {settings.NEXUS_API_TOKEN}",
+            }
+        elif auth_type == self.AuthTypes.KEYCLOAK_INTERNAL:
+            return InternalAuthentication().headers
+        else:
+            raise ValueError(f"Invalid auth type: {auth_type}")
 
     def get_project_multi_agents_status(self, project_uuid: UUID) -> Response:
         """
@@ -92,7 +109,24 @@ class NexusClient(BaseNexusClient):
 
         url = f"{self.base_url}/project/{project_uuid}/multi-agents"
 
-        return requests.get(url=url, headers=self.headers, timeout=self.timeout)
+        return requests.get(
+            url=url,
+            headers=self.get_headers(self.AuthTypes.API_TOKEN),
+            timeout=self.timeout,
+        )
+
+    def get_project_agents_team(self, project_uuid: UUID) -> Response:
+        """
+        Get the agents team for a project.
+        """
+
+        url = f"{self.base_url}/agents/teams/{project_uuid}"
+
+        return requests.get(
+            url=url,
+            headers=self.get_headers(self.AuthTypes.KEYCLOAK_INTERNAL),
+            timeout=self.timeout,
+        )
 
 
 class BaseNexusConversationsAPIClient(ABC):

--- a/insights/sources/integrations/tests/mock_clients.py
+++ b/insights/sources/integrations/tests/mock_clients.py
@@ -86,3 +86,21 @@ class MockNexusClient(BaseNexusClient):
         return MockResponse(
             status_code=200, content=json.dumps({"multi_agents": False})
         )
+
+    def get_project_agents_team(self, project_uuid: UUID) -> MockResponse:
+        agents_team = {
+            "manager": {"external_id": ""},
+            "agents": [
+                {
+                    "uuid": "00000000-0000-0000-0000-000000000000",
+                    "slug": "mock-agent",
+                    "name": "Mock Agent",
+                    "about": {"en": "", "pt": None, "es": None},
+                    "group": None,
+                    "is_official": True,
+                    "mcps": None,
+                    "active": True,
+                }
+            ],
+        }
+        return MockResponse(status_code=200, content=json.dumps(agents_team))

--- a/insights/sources/integrations/tests/test_nexus_client.py
+++ b/insights/sources/integrations/tests/test_nexus_client.py
@@ -1,0 +1,93 @@
+from unittest.mock import patch
+
+import responses
+
+from django.conf import settings
+from django.test import TestCase, override_settings
+
+from insights.sources.integrations.clients import NexusClient
+
+
+@override_settings(NEXUS_BASE_URL="https://nexus.weni.ai")
+class TestNexusClient(TestCase):
+    def setUp(self):
+        self.client = NexusClient()
+
+    def test_base_url(self):
+        self.assertEqual(self.client.base_url, settings.NEXUS_BASE_URL)
+
+    def test_get_headers_api_token(self):
+        self.assertEqual(
+            self.client.get_headers(NexusClient.AuthTypes.API_TOKEN),
+            {
+                "Authorization": f"Bearer {settings.NEXUS_API_TOKEN}",
+            },
+        )
+
+    @patch(
+        "insights.sources.integrations.clients.InternalAuthentication.get_module_token",
+        return_value="Bearer internal-token",
+    )
+    def test_get_headers_keycloak_internal(self, mock_get_module_token):
+        self.assertEqual(
+            self.client.get_headers(NexusClient.AuthTypes.KEYCLOAK_INTERNAL),
+            {
+                "Content-Type": "application/json; charset: utf-8",
+                "Authorization": "Bearer internal-token",
+            },
+        )
+        mock_get_module_token.assert_called_once()
+
+    def test_get_headers_invalid_auth_type(self):
+        with self.assertRaises(ValueError):
+            self.client.get_headers("invalid-auth-type")
+
+    def test_get_project_multi_agents_status(self):
+        with responses.RequestsMock() as rsps:
+            rsps.add(
+                responses.GET,
+                f"{settings.NEXUS_BASE_URL}/project/123/multi-agents",
+                json={"multi_agents": True},
+                status=200,
+            )
+            response = self.client.get_project_multi_agents_status(project_uuid="123")
+            self.assertEqual(response.status_code, 200)
+            self.assertEqual(response.json(), {"multi_agents": True})
+
+            self.assertEqual(len(rsps.calls), 1)
+
+    @patch(
+        "insights.sources.integrations.clients.InternalAuthentication.get_module_token",
+        return_value="Bearer internal-token",
+    )
+    def test_get_project_agents_team(self, mock_get_module_token):
+        agents_team = {
+            "manager": {"external_id": ""},
+            "agents": [
+                {
+                    "uuid": "11111111-1111-1111-1111-111111111111",
+                    "slug": "agent-slug",
+                    "name": "Agent Name",
+                    "about": {"en": "", "pt": None, "es": None},
+                    "group": None,
+                    "is_official": True,
+                    "mcps": None,
+                    "active": True,
+                }
+            ],
+        }
+
+        with responses.RequestsMock() as rsps:
+            rsps.add(
+                responses.GET,
+                f"{settings.NEXUS_BASE_URL}/agents/teams/123",
+                json=agents_team,
+                status=200,
+            )
+            response = self.client.get_project_agents_team(project_uuid="123")
+            self.assertEqual(response.status_code, 200)
+            self.assertEqual(response.json(), agents_team)
+
+            self.assertEqual(len(rsps.calls), 1)
+
+        mock_get_module_token.assert_called_once()


### PR DESCRIPTION
### What
- Add a new `get_project_agents_team` method to `NexusClient` (and the `BaseNexusClient` interface) that fetches a project's agents team from `GET /agents/teams/{project_uuid}` using internal Keycloak authentication.
- Refactor `NexusClient` authentication: introduce a nested `AuthTypes` enum (`API_TOKEN`, `KEYCLOAK_INTERNAL`) and a `get_headers(auth_type)` method, replacing the single hardcoded `self.headers` attribute. The existing `get_project_multi_agents_status` now explicitly requests `API_TOKEN` headers.
- Update `MockNexusClient` to implement the new `get_project_agents_team` method, returning a representative agents team payload.
- Add a new test module `test_nexus_client.py` covering `base_url`, header generation for both auth types (including invalid auth type handling), `get_project_multi_agents_status`, and `get_project_agents_team`.

### Why
Insights needs to consume the agents team data exposed by Nexus, which is served behind an endpoint that requires internal Keycloak authentication rather than the static API token used for other Nexus calls. Centralizing header construction via `get_headers` allows a single client to support multiple authentication schemes per endpoint, keeps the existing multi-agents flow working unchanged, and adds explicit test coverage for the new behavior.