### PR TITLE
feat: implement search terms metrics endpoint

### DIFF
--- a/insights/metrics/conversations/api/v1/serializers.py
+++ b/insights/metrics/conversations/api/v1/serializers.py
@@ -618,6 +618,12 @@ class ContactsMetricsQueryParamsSerializer(ConversationBaseQueryParamsSerializer
     """
 
 
+class SearchTermsMetricsQueryParamsSerializer(ConversationBaseQueryParamsSerializer):
+    """
+    Serializer for search terms metrics query params
+    """
+
+
 class UniqueContactsMetricsSerializer(serializers.Serializer):
     value = serializers.IntegerField()
 

--- a/insights/metrics/conversations/api/v1/tests/test_views.py
+++ b/insights/metrics/conversations/api/v1/tests/test_views.py
@@ -196,6 +196,11 @@ class BaseTestConversationsMetricsViewSet(APITestCase):
 
         return self.client.get(url, query_params, format="json")
 
+    def get_search_terms_metrics(self, query_params: dict) -> Response:
+        url = reverse("conversations-search-terms")
+
+        return self.client.get(url, query_params, format="json")
+
 
 class TestConversationsMetricsViewSetAsAnonymousUser(
     BaseTestConversationsMetricsViewSet
@@ -287,6 +292,11 @@ class TestConversationsMetricsViewSetAsAnonymousUser(
 
     def test_cannot_get_contacts_metrics_when_unauthenticated(self):
         response = self.get_contacts_metrics({})
+
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    def test_cannot_get_search_terms_metrics_when_unauthenticated(self):
+        response = self.get_search_terms_metrics({})
 
         self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
 
@@ -1380,6 +1390,79 @@ class TestConversationsMetricsViewSetAsAuthenticatedUser(
         mock_get_contacts_metrics.side_effect = RuntimeError("Service error")
 
         response = self.get_contacts_metrics(
+            {
+                "project_uuid": self.project.uuid,
+                "start_date": "2024-01-01",
+                "end_date": "2024-01-31",
+            }
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_500_INTERNAL_SERVER_ERROR)
+        data = json.loads(response.content)
+        self.assertIn("code", data)
+        self.assertEqual(data["code"], "INTERNAL_ERROR")
+        self.assertIn("event_id", data)
+
+    def test_cannot_get_search_terms_metrics_without_project_uuid(self):
+        response = self.get_search_terms_metrics({})
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.data["project_uuid"][0].code, "required")
+
+    def test_cannot_get_search_terms_metrics_without_permission(self):
+        response = self.get_search_terms_metrics({"project_uuid": self.project.uuid})
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    @with_project_auth
+    def test_cannot_get_search_terms_metrics_without_required_params(self):
+        response = self.get_search_terms_metrics({"project_uuid": self.project.uuid})
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.data["start_date"][0].code, "required")
+        self.assertEqual(response.data["end_date"][0].code, "required")
+
+    @with_project_auth
+    @patch(
+        "insights.metrics.conversations.services.ConversationsMetricsService.get_search_terms_metrics"
+    )
+    def test_get_search_terms_metrics(self, mock_get_search_terms_metrics):
+        mock_get_search_terms_metrics.return_value = {
+            "results": [
+                {"label": "azeite", "value": 85.0, "full_value": 17},
+                {"label": "arroz", "value": 15.0, "full_value": 3},
+            ]
+        }
+
+        response = self.get_search_terms_metrics(
+            {
+                "project_uuid": self.project.uuid,
+                "start_date": "2024-01-01",
+                "end_date": "2024-01-31",
+            }
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data["results"]), 2)
+
+        self.assertEqual(response.data["results"][0]["label"], "azeite")
+        self.assertEqual(response.data["results"][0]["value"], 85.0)
+        self.assertEqual(response.data["results"][0]["full_value"], 17)
+
+        self.assertEqual(response.data["results"][1]["label"], "arroz")
+        self.assertEqual(response.data["results"][1]["value"], 15.0)
+        self.assertEqual(response.data["results"][1]["full_value"], 3)
+
+    @with_project_auth
+    @patch(
+        "insights.metrics.conversations.services.ConversationsMetricsService.get_search_terms_metrics"
+    )
+    def test_get_search_terms_metrics_returns_500_on_service_error(
+        self, mock_get_search_terms_metrics
+    ):
+        mock_get_search_terms_metrics.side_effect = RuntimeError("Service error")
+
+        response = self.get_search_terms_metrics(
             {
                 "project_uuid": self.project.uuid,
                 "start_date": "2024-01-01",

--- a/insights/metrics/conversations/api/v1/views.py
+++ b/insights/metrics/conversations/api/v1/views.py
@@ -45,6 +45,7 @@ from insights.metrics.conversations.api.v1.serializers import (
     NpsMetricsQueryParamsSerializer,
     SalesFunnelMetricsQueryParamsSerializer,
     SalesFunnelMetricsSerializer,
+    SearchTermsMetricsQueryParamsSerializer,
     ToolResultMetricsSerializer,
     ToolResultQueryParamsSerializer,
     TopicsDistributionMetricsQueryParamsSerializer,
@@ -559,6 +560,29 @@ class ConversationsMetricsViewSet(
             ContactsMetricsSerializer(metrics).data,
             status=status.HTTP_200_OK,
         )
+
+    @action(
+        detail=False,
+        methods=["get"],
+        url_path="search-terms",
+        url_name="search-terms",
+    )
+    def search_terms(self, request: "Request", *args, **kwargs) -> Response:
+        """
+        Get search terms metrics
+        """
+        query_params = SearchTermsMetricsQueryParamsSerializer(
+            data=request.query_params
+        )
+        query_params.is_valid(raise_exception=True)
+
+        metrics = self.service.get_search_terms_metrics(
+            project_uuid=query_params.validated_data["project_uuid"],
+            start_date=query_params.validated_data["start_date"],
+            end_date=query_params.validated_data["end_date"],
+        )
+
+        return Response(metrics, status=status.HTTP_200_OK)
 
 
 class InternalConversationsMetricsViewSet(GenericViewSet):

--- a/insights/metrics/conversations/mock/services.py
+++ b/insights/metrics/conversations/mock/services.py
@@ -312,3 +312,44 @@ class MockConversationsMetricsService(BaseConversationsMetricsService):
         end_date: datetime,
     ) -> dict:
         return {}
+
+    def get_search_terms_metrics(
+        self,
+        project_uuid: UUID,
+        start_date: datetime,
+        end_date: datetime,
+    ) -> dict:
+        counts = [
+            ("azeite", 120),
+            ("arroz", 95),
+            ("feijão", 80),
+            ("café", 72),
+            ("leite", 65),
+            ("açúcar", 58),
+            ("farinha", 50),
+            ("macarrão", 45),
+            ("óleo", 40),
+            ("sal", 36),
+            ("manteiga", 32),
+            ("biscoito", 28),
+            ("chocolate", 24),
+            ("iogurte", 20),
+            ("queijo", 18),
+            ("presunto", 15),
+            ("refrigerante", 12),
+            ("suco", 10),
+            ("água", 8),
+            ("cerveja", 5),
+        ]
+        total = sum(count for _, count in counts)
+
+        return {
+            "results": [
+                {
+                    "label": label,
+                    "value": round((count / total) * 100, 2),
+                    "full_value": count,
+                }
+                for label, count in counts
+            ]
+        }


### PR DESCRIPTION
### What
Adds a new `GET /search-terms` endpoint to the `ConversationsMetricsViewSet`, exposing search terms metrics for a project within a given date range. The change introduces:

- A `SearchTermsMetricsQueryParamsSerializer` (extending the base conversation query params serializer with `project_uuid`, `start_date`, and `end_date`).
- A `search_terms` action on `ConversationsMetricsViewSet` that delegates to `ConversationsMetricsService.get_search_terms_metrics`.
- A mock implementation in `MockConversationsMetricsService.get_search_terms_metrics` returning a deterministic list of terms with `label`, `value` (percentage share), and `full_value` (absolute count).
- Test coverage for unauthenticated, unauthorized, missing-param, success, and service-error scenarios.

### Why
The conversations metrics surface needs a way to display the most relevant search terms used by contacts during a period, so the dashboard can show which queries drive engagement and inform content/catalog decisions. Following the same pattern as the other conversation metrics endpoints keeps the API surface consistent and lets the frontend integrate against a mocked response while the real service implementation is finalized.

### Sequence diagram

```mermaid
sequenceDiagram
    participant Client
    participant ViewSet as ConversationsMetricsViewSet
    participant Serializer as SearchTermsMetricsQueryParamsSerializer
    participant Auth as Project Auth
    participant Service as ConversationsMetricsService
    participant Mock as MockConversationsMetricsService

    Client->>ViewSet: GET /search-terms?project_uuid&start_date&end_date
    ViewSet->>Auth: Validate authentication and project permission
    Auth-->>ViewSet: Authorized
    ViewSet->>Serializer: Validate query params
    Serializer-->>ViewSet: validated_data (project_uuid, start_date, end_date)
    ViewSet->>Service: get_search_terms_metrics(project_uuid, start_date, end_date)
    Service->>Mock: get_search_terms_metrics(...)
    Mock-->>Service: { results: [{ label, value, full_value }, ...] }
    Service-->>ViewSet: metrics payload
    ViewSet-->>Client: 200 OK { results: [...] }