### PR TITLE
feat: Use JWT authentication on Live Desk calls

### DIFF
--- a/insights/core/accessors.py
+++ b/insights/core/accessors.py
@@ -1,0 +1,23 @@
+_sentinel = object()
+
+
+def get_nested_attr(obj, attr, default=_sentinel):
+    """
+    Get a nested attribute from an object.
+
+    Args:
+        obj: The object to get the attribute from.
+        attr: The attribute to get.
+        default: The default value to return if the attribute is not found.
+
+    Returns:
+        The value of the attribute.
+    """
+    try:
+        for part in attr.split("."):
+            obj = getattr(obj, part)
+        return obj
+    except AttributeError:
+        if default is _sentinel:
+            raise
+        return default

--- a/insights/core/tests/test_accessors.py
+++ b/insights/core/tests/test_accessors.py
@@ -1,0 +1,60 @@
+import pytest
+
+from insights.core.accessors import get_nested_attr
+
+
+class Leaf:
+    value = 42
+
+
+class Branch:
+    leaf = Leaf()
+
+
+class Root:
+    branch = Branch()
+    name = "root"
+
+
+class TestGetNestedAttr:
+    def test_single_level_attribute(self):
+        obj = Root()
+        assert get_nested_attr(obj, "name") == "root"
+
+    def test_two_level_nested_attribute(self):
+        obj = Root()
+        assert get_nested_attr(obj, "branch.leaf") is obj.branch.leaf
+
+    def test_three_level_nested_attribute(self):
+        obj = Root()
+        assert get_nested_attr(obj, "branch.leaf.value") == 42
+
+    def test_missing_attribute_raises_attribute_error(self):
+        obj = Root()
+        with pytest.raises(AttributeError):
+            get_nested_attr(obj, "nonexistent")
+
+    def test_missing_nested_attribute_raises_attribute_error(self):
+        obj = Root()
+        with pytest.raises(AttributeError):
+            get_nested_attr(obj, "branch.nonexistent")
+
+    def test_missing_attribute_returns_default(self):
+        obj = Root()
+        assert get_nested_attr(obj, "nonexistent", "fallback") == "fallback"
+
+    def test_missing_nested_attribute_returns_default(self):
+        obj = Root()
+        assert get_nested_attr(obj, "branch.nonexistent", None) is None
+
+    def test_default_none_is_returned(self):
+        obj = Root()
+        assert get_nested_attr(obj, "missing", None) is None
+
+    def test_default_false_is_returned(self):
+        obj = Root()
+        assert get_nested_attr(obj, "missing", False) is False
+
+    def test_deeply_missing_intermediate_returns_default(self):
+        obj = Root()
+        assert get_nested_attr(obj, "x.y.z", "default") == "default"

--- a/insights/core/tests/test_accessors.py
+++ b/insights/core/tests/test_accessors.py
@@ -1,4 +1,4 @@
-import pytest
+from django.test import TestCase
 
 from insights.core.accessors import get_nested_attr
 
@@ -16,45 +16,45 @@ class Root:
     name = "root"
 
 
-class TestGetNestedAttr:
+class TestGetNestedAttr(TestCase):
     def test_single_level_attribute(self):
         obj = Root()
-        assert get_nested_attr(obj, "name") == "root"
+        self.assertEqual(get_nested_attr(obj, "name"), "root")
 
     def test_two_level_nested_attribute(self):
         obj = Root()
-        assert get_nested_attr(obj, "branch.leaf") is obj.branch.leaf
+        self.assertIs(get_nested_attr(obj, "branch.leaf"), obj.branch.leaf)
 
     def test_three_level_nested_attribute(self):
         obj = Root()
-        assert get_nested_attr(obj, "branch.leaf.value") == 42
+        self.assertEqual(get_nested_attr(obj, "branch.leaf.value"), 42)
 
     def test_missing_attribute_raises_attribute_error(self):
         obj = Root()
-        with pytest.raises(AttributeError):
+        with self.assertRaises(AttributeError):
             get_nested_attr(obj, "nonexistent")
 
     def test_missing_nested_attribute_raises_attribute_error(self):
         obj = Root()
-        with pytest.raises(AttributeError):
+        with self.assertRaises(AttributeError):
             get_nested_attr(obj, "branch.nonexistent")
 
     def test_missing_attribute_returns_default(self):
         obj = Root()
-        assert get_nested_attr(obj, "nonexistent", "fallback") == "fallback"
+        self.assertEqual(get_nested_attr(obj, "nonexistent", "fallback"), "fallback")
 
     def test_missing_nested_attribute_returns_default(self):
         obj = Root()
-        assert get_nested_attr(obj, "branch.nonexistent", None) is None
+        self.assertIsNone(get_nested_attr(obj, "branch.nonexistent", None))
 
     def test_default_none_is_returned(self):
         obj = Root()
-        assert get_nested_attr(obj, "missing", None) is None
+        self.assertIsNone(get_nested_attr(obj, "missing", None))
 
     def test_default_false_is_returned(self):
         obj = Root()
-        assert get_nested_attr(obj, "missing", False) is False
+        self.assertIs(get_nested_attr(obj, "missing", False), False)
 
     def test_deeply_missing_intermediate_returns_default(self):
         obj = Root()
-        assert get_nested_attr(obj, "x.y.z", "default") == "default"
+        self.assertEqual(get_nested_attr(obj, "x.y.z", "default"), "default")

--- a/insights/human_support/clients/chats.py
+++ b/insights/human_support/clients/chats.py
@@ -1,12 +1,13 @@
 from insights.core.requests import request_with_retry
-from insights.internals.base import InternalAuthentication
+from insights.internals.base import InternalJWTAuthentication
 from django.conf import settings
 
 import requests
 
 
-class ChatsClient(InternalAuthentication):
-    def __init__(self):
+class ChatsClient(InternalJWTAuthentication):
+    def __init__(self, project):
+        self.project = project
         self.url = settings.CHATS_URL
 
     def get_contacts(self, query_params: dict):
@@ -27,10 +28,8 @@ class ChatsClient(InternalAuthentication):
 
         return response.json()
 
-    def csat_score_by_agents(
-        self, project_uuid: str, params: dict | None = None
-    ) -> dict:
-        url = f"{self.url}/v1/internal/dashboard/{project_uuid}/csat-score-by-agents/"
+    def csat_score_by_agents(self, params: dict | None = None) -> dict:
+        url = f"{self.url}/v1/internal/dashboard/{self.project.uuid}/csat-score-by-agents/"
 
         response = requests.get(
             url=url,
@@ -41,8 +40,8 @@ class ChatsClient(InternalAuthentication):
 
         return response.json()
 
-    def csat_ratings(self, project_uuid: str, params: dict | None = None) -> dict:
-        url = f"{self.url}/v1/internal/dashboard/{project_uuid}/csat_ratings/"
+    def csat_ratings(self, params: dict | None = None) -> dict:
+        url = f"{self.url}/v1/internal/dashboard/{self.project.uuid}/csat_ratings/"
 
         response = requests.get(
             url=url,

--- a/insights/human_support/clients/chats_raw_data.py
+++ b/insights/human_support/clients/chats_raw_data.py
@@ -1,10 +1,10 @@
 import requests
 from django.conf import settings
 
-from insights.internals.base import InternalAuthentication
+from insights.internals.base import InternalJWTAuthentication
 
 
-class ChatsRawDataClient(InternalAuthentication):
+class ChatsRawDataClient(InternalJWTAuthentication):
     def __init__(self, project) -> None:
         self.project = project
         self.url = f"{settings.CHATS_URL}/v1/dashboard/{self.project.uuid}/raw_data/"

--- a/insights/human_support/clients/chats_time_metrics.py
+++ b/insights/human_support/clients/chats_time_metrics.py
@@ -1,10 +1,10 @@
 import requests
 from django.conf import settings
 
-from insights.internals.base import InternalAuthentication
+from insights.internals.base import InternalJWTAuthentication
 
 
-class ChatsTimeMetricsClient(InternalAuthentication):
+class ChatsTimeMetricsClient(InternalJWTAuthentication):
     def __init__(self, project) -> None:
         self.project = project
         self.base_url = settings.CHATS_URL

--- a/insights/human_support/services.py
+++ b/insights/human_support/services.py
@@ -32,11 +32,11 @@ from insights.sources.tags.usecases.query_execute import (
 
 class HumanSupportDashboardService:
     def __init__(
-        self, project: Project, chats_client: ChatsClient = ChatsClient()
+        self, project: Project, chats_client: ChatsClient | None = None
     ) -> None:
         self.project = project
         self.client = ChatsRawDataClient(project)
-        self.chats_client = chats_client
+        self.chats_client = chats_client or ChatsClient(project)
 
     def _expand_all_tokens(self, incoming_filters: dict | None) -> dict:
         """
@@ -588,7 +588,7 @@ class HumanSupportDashboardService:
     def get_detailed_monitoring_agents_v2(self, filters: dict = {}):
         params = self._get_detailed_monitoring_agents_filters(filters)
 
-        response = ChatsRESTClient().get_agents(str(self.project.uuid), params)
+        response = ChatsRESTClient(self.project).get_agents(params)
 
         formatted_results = []
         for agent in response.get("results", []):
@@ -655,7 +655,7 @@ class HumanSupportDashboardService:
                     value = value.isoformat()
                 params[param] = str(value) if param_type == str else value
 
-        return ChatsRESTClient().get_status_by_agent(str(self.project.uuid), params)
+        return ChatsRESTClient(self.project).get_status_by_agent(params)
 
     def get_detailed_monitoring_agents_totals(self, filters: dict = {}) -> dict:
         params = self._get_detailed_monitoring_agents_filters(filters)
@@ -721,9 +721,7 @@ class HumanSupportDashboardService:
                 datetime.combine(today, datetime.max.time())
             )
 
-        return self.chats_client.csat_score_by_agents(
-            project_uuid=str(self.project.uuid), params=normalized_filters
-        )
+        return self.chats_client.csat_score_by_agents(params=normalized_filters)
 
     def _get_analysis_detailed_monitoring_status_filters(
         self, filters: dict, ordering_fields: set
@@ -851,7 +849,7 @@ class HumanSupportDashboardService:
             filters, ordering_fields
         )
 
-        response = ChatsRESTClient().get_status_by_agent(str(self.project.uuid), params)
+        response = ChatsRESTClient(self.project).get_status_by_agent(params)
 
         formatted_results = []
         for agent_data in response.get("results", []):
@@ -1125,9 +1123,7 @@ class HumanSupportDashboardService:
             if value:
                 params[filter_value] = value
 
-        ratings_from_chats = self.chats_client.csat_ratings(
-            project_uuid=str(self.project.uuid), params=params
-        )
+        ratings_from_chats = self.chats_client.csat_ratings(params=params)
         ratings_data = {
             str(rating): {"value": 0, "full_value": 0} for rating in range(1, 6)
         }

--- a/insights/human_support/tests/test_services.py
+++ b/insights/human_support/tests/test_services.py
@@ -288,8 +288,6 @@ class TestHumanSupportDashboardService(TestCase):
         result = service.csat_score_by_agents(user_request="test", filters={})
         self.assertEqual(result, {"results": []})
         mock_chats.csat_score_by_agents.assert_called_once()
-        call_kwargs = mock_chats.csat_score_by_agents.call_args[1]
-        self.assertEqual(call_kwargs["project_uuid"], str(self.project.uuid))
 
     @patch("insights.human_support.services.CustomStatusRESTClient")
     def test_get_analysis_detailed_monitoring_status(self, mock_client_class):
@@ -526,7 +524,7 @@ class TestHumanSupportDashboardService(TestCase):
             filters={"ordering": "agent", "limit": 5, "offset": 10}
         )
         call_args = mock_client_class.return_value.get_status_by_agent.call_args
-        params = call_args[0][1]
+        params = call_args[0][0]
         self.assertEqual(params.get("ordering"), "agent")
         self.assertEqual(params.get("limit"), 5)
         self.assertEqual(params.get("offset"), 10)

--- a/insights/internals/base.py
+++ b/insights/internals/base.py
@@ -1,6 +1,8 @@
 import requests
 from django.conf import settings
 
+from insights.core.accessors import get_nested_attr
+
 
 class InternalAuthentication:
     def get_module_token(self):
@@ -21,6 +23,23 @@ class InternalAuthentication:
         return {
             "Content-Type": "application/json; charset: utf-8",
             "Authorization": self.get_module_token(),
+        }
+
+
+class InternalJWTAuthentication:
+    project_uuid_field = "project.uuid"
+
+    def _get_project_uuid(self):
+        return get_nested_attr(self, self.project_uuid_field)
+
+    @property
+    def headers(self):
+        from insights.authentication.services.jwt_service import JWTService
+
+        token = JWTService().generate_jwt_token(project_uuid=self._get_project_uuid())
+        return {
+            "Content-Type": "application/json; charset: utf-8",
+            "Authorization": f"Bearer {token}",
         }
 
 

--- a/insights/projects/viewsets.py
+++ b/insights/projects/viewsets.py
@@ -165,7 +165,7 @@ class ProjectViewSet(mixins.RetrieveModelMixin, viewsets.GenericViewSet):
         chats_params = query_params.validated_data.copy()
         chats_params["project"] = str(project.uuid)
 
-        chats_client = ChatsClient()
+        chats_client = ChatsClient(project)
         response = chats_client.get_contacts(query_params=chats_params)
 
         pagination_urls = get_cursor_based_pagination_urls(request, response)
@@ -193,7 +193,7 @@ class ProjectViewSet(mixins.RetrieveModelMixin, viewsets.GenericViewSet):
         chats_params = query_params.validated_data.copy()
         chats_params["project"] = str(project.uuid)
 
-        chats_client = ChatsClient()
+        chats_client = ChatsClient(project)
         response = chats_client.get_protocols(query_params=chats_params)
         ticket_ids = [
             TicketID(protocol["protocol"]) for protocol in response.get("results")
@@ -228,9 +228,9 @@ class ProjectViewSet(mixins.RetrieveModelMixin, viewsets.GenericViewSet):
     )
     def verify_csat(self, request, *args, **kwargs):
         project = self.get_object()
-        chats_client = ChatsRESTClient()
+        chats_client = ChatsRESTClient(project)
 
-        project_data = chats_client.get_project(str(project.uuid))
+        project_data = chats_client.get_project()
         is_csat_enabled = project_data.get("is_csat_enabled", False)
 
         return Response(is_csat_enabled, status=status.HTTP_200_OK)

--- a/insights/sources/agents/clients.py
+++ b/insights/sources/agents/clients.py
@@ -1,7 +1,7 @@
 import requests
 from django.conf import settings
 
-from insights.internals.base import InternalAuthentication
+from insights.internals.base import InternalJWTAuthentication
 from insights.sources.clients import GenericSQLQueryGenerator
 
 
@@ -9,7 +9,7 @@ class AgentSQLQueryGenerator(GenericSQLQueryGenerator):
     default_query_type = "list"
 
 
-class AgentsRESTClient(InternalAuthentication):
+class AgentsRESTClient(InternalJWTAuthentication):
     def __init__(self, project) -> None:
         self.project = project
         self.base_url = (

--- a/insights/sources/chats/clients.py
+++ b/insights/sources/chats/clients.py
@@ -1,16 +1,17 @@
 from django.conf import settings
 
-from insights.internals.base import InternalAuthentication
+from insights.internals.base import InternalJWTAuthentication
 from insights.core.requests import request_with_retry
 
 
-class ChatsRESTClient(InternalAuthentication):
-    def __init__(self):
+class ChatsRESTClient(InternalJWTAuthentication):
+    def __init__(self, project):
+        self.project = project
         self.base_url = f"{settings.CHATS_URL}"
 
-    def get_project(self, project_uuid: str) -> dict:
+    def get_project(self) -> dict:
         response = request_with_retry(
-            url=f"{self.base_url}/v1/internal/project/{project_uuid}/",
+            url=f"{self.base_url}/v1/internal/project/{self.project.uuid}/",
             headers=self.headers,
             params={},
             method="GET",
@@ -20,9 +21,9 @@ class ChatsRESTClient(InternalAuthentication):
 
         return response.json()
 
-    def get_agents(self, project_uuid: str, query_filters: dict) -> dict:
+    def get_agents(self, query_filters: dict) -> dict:
         response = request_with_retry(
-            url=f"{self.base_url}/v2/internal/dashboard/{project_uuid}/agent/",
+            url=f"{self.base_url}/v2/internal/dashboard/{self.project.uuid}/agent/",
             headers=self.headers,
             params=query_filters,
             method="GET",
@@ -31,9 +32,9 @@ class ChatsRESTClient(InternalAuthentication):
         )
         return response.json()
 
-    def get_status_by_agent(self, project_uuid: str, query_filters: dict) -> dict:
+    def get_status_by_agent(self, query_filters: dict) -> dict:
         response = request_with_retry(
-            url=f"{self.base_url}/v2/internal/dashboard/{project_uuid}/custom-status-by-agent/",
+            url=f"{self.base_url}/v2/internal/dashboard/{self.project.uuid}/custom-status-by-agent/",
             headers=self.headers,
             params=query_filters,
             method="GET",

--- a/insights/sources/chats/tests/test_clients.py
+++ b/insights/sources/chats/tests/test_clients.py
@@ -1,30 +1,29 @@
-from unittest.mock import patch
+from unittest.mock import patch, MagicMock, PropertyMock
 import uuid
 
 from django.test import TestCase
 
-from unittest.mock import MagicMock
-from insights.internals.base import InternalAuthentication
 from insights.sources.chats.clients import ChatsRESTClient
 
 
-@patch.object(
-    InternalAuthentication,
-    "headers",
-    new_callable=lambda: {
-        "Content-Type": "application/json; charset: utf-8",
-        "Authorization": "Bearer mock-token",
-    },
-)
 class ChatsRESTClientTestCase(TestCase):
     def setUp(self):
-        self.client = ChatsRESTClient()
+        self.project = MagicMock()
+        self.project.uuid = uuid.uuid4()
 
     @patch("insights.sources.chats.clients.request_with_retry")
-    def test_get_project(self, mock_request_with_retry, mock_headers):
-        project_uuid = str(uuid.uuid4())
+    @patch.object(
+        ChatsRESTClient,
+        "headers",
+        new_callable=PropertyMock,
+        return_value={
+            "Content-Type": "application/json; charset: utf-8",
+            "Authorization": "Bearer mock-token",
+        },
+    )
+    def test_get_project(self, mock_headers, mock_request_with_retry):
         expected_response = {
-            "uuid": project_uuid,
+            "uuid": str(self.project.uuid),
             "name": "Test Project",
             "date_format": "D",
             "timezone": "America/Fortaleza",
@@ -36,12 +35,13 @@ class ChatsRESTClientTestCase(TestCase):
         mock_response.json.return_value = expected_response
         mock_request_with_retry.return_value = mock_response
 
-        project = self.client.get_project(project_uuid=project_uuid)
+        client = ChatsRESTClient(self.project)
+        project = client.get_project()
 
         self.assertEqual(project, expected_response)
 
         mock_request_with_retry.assert_called_once_with(
-            url=f"/v1/internal/project/{project_uuid}/",
+            url=f"/v1/internal/project/{self.project.uuid}/",
             headers={
                 "Content-Type": "application/json; charset: utf-8",
                 "Authorization": "Bearer mock-token",

--- a/insights/sources/custom_status/client.py
+++ b/insights/sources/custom_status/client.py
@@ -1,10 +1,10 @@
 import requests
 from django.conf import settings
 
-from insights.internals.base import InternalAuthentication
+from insights.internals.base import InternalJWTAuthentication
 
 
-class CustomStatusRESTClient(InternalAuthentication):
+class CustomStatusRESTClient(InternalJWTAuthentication):
     def __init__(self, project) -> None:
         self.project = project
         self.base_url = f"{settings.CHATS_URL}"

--- a/insights/sources/custom_status/tests/test_clients.py
+++ b/insights/sources/custom_status/tests/test_clients.py
@@ -10,11 +10,7 @@ class TestCustomStatusRESTClient(TestCase):
     def setUp(self):
         self.project = MagicMock()
         self.project.uuid = uuid.uuid4()
-
-        with patch.object(
-            CustomStatusRESTClient, "get_module_token", return_value="Bearer fake"
-        ):
-            self.client = CustomStatusRESTClient(project=self.project)
+        self.client = CustomStatusRESTClient(project=self.project)
 
     @patch("insights.sources.custom_status.client.requests.get")
     @patch.object(

--- a/insights/sources/rooms/clients.py
+++ b/insights/sources/rooms/clients.py
@@ -1,7 +1,7 @@
 import requests
 from django.conf import settings
 
-from insights.internals.base import InternalAuthentication
+from insights.internals.base import InternalJWTAuthentication
 from insights.sources.clients import GenericSQLQueryGenerator
 
 
@@ -9,7 +9,7 @@ class RoomSQLQueryGenerator(GenericSQLQueryGenerator):
     default_query_type = "count"
 
 
-class RoomRESTClient(InternalAuthentication):
+class RoomRESTClient(InternalJWTAuthentication):
     def __init__(self, project) -> None:
         self.project = project
         self.url = f"{settings.CHATS_URL}/v1/internal/rooms/"


### PR DESCRIPTION
### What

Introduces a new `InternalJWTAuthentication` base class that generates JWT-based authorization headers using a `JWTService`, replacing the previous `InternalAuthentication` class across all internal REST clients (`ChatsRESTClient`, `ChatsClient`, `ChatsRawDataClient`, `ChatsTimeMetricsClient`, `ChatsRESTClient`, `AgentsRESTClient`, `RoomRESTClient`, `CustomStatusRESTClient`).

All clients that previously required a `project_uuid` string passed explicitly to each method now accept a `project` object at construction time, storing it as an instance attribute and deriving the UUID internally. This removes the need to pass `project_uuid` as a parameter to individual methods like `get_project`, `get_agents`, `get_status_by_agent`, `csat_score_by_agents`, and `csat_ratings`.

A new `get_nested_attr` utility is added to `insights/core/accessors.py` to support dot-notation attribute traversal on objects, which `InternalJWTAuthentication` uses to resolve the project UUID from a configurable field path.

### Why

Centralizing project context at the client level reduces repetitive argument passing and makes the authentication mechanism consistent across all internal service clients. Switching to JWT-based authentication aligns the internal client communication with a more secure and standardized token strategy, replacing the previous module token approach.