### PR TITLE
refactor: streamline conversation dashboard creation logic

### DIFF
--- a/insights/dashboards/tasks.py
+++ b/insights/dashboards/tasks.py
@@ -1,6 +1,5 @@
 import logging
 from insights.celery import app
-from insights.dashboards.models import CONVERSATIONS_DASHBOARD_NAME, Dashboard
 from insights.dashboards.usecases.conversations_dashboard_creation import (
     CreateConversationsDashboard,
 )
@@ -21,15 +20,6 @@ def create_conversation_dashboard(project_uuid: str):
         "[ create_conversation_dashboard task ] Creating conversation dashboard for project %s",
         project.uuid,
     )
-
-    if Dashboard.objects.filter(
-        project=project, name=CONVERSATIONS_DASHBOARD_NAME
-    ).exists():
-        logger.info(
-            "[ create_conversation_dashboard task ] Conversation dashboard already exists for project %s",
-            project.uuid,
-        )
-        return
 
     CreateConversationsDashboard().create_dashboard(project)
 

--- a/insights/dashboards/usecases/conversations_dashboard_creation.py
+++ b/insights/dashboards/usecases/conversations_dashboard_creation.py
@@ -3,23 +3,20 @@ from insights.dashboards.models import CONVERSATIONS_DASHBOARD_NAME, Dashboard
 
 class CreateConversationsDashboard:
     def create_dashboard(self, project):
-        if Dashboard.objects.filter(
-            project=project, name=CONVERSATIONS_DASHBOARD_NAME
-        ).exists():
-            raise Exception("Conversation dashboard already exists for this project")
-
-        dashboard = Dashboard.objects.create(
+        dashboard, created = Dashboard.objects.get_or_create(
             project=project,
             name=CONVERSATIONS_DASHBOARD_NAME,
-            description="Conversations dashboard",
-            is_default=False,
-            grid=[0, 0],
-            is_deletable=False,
-            is_editable=True,
-            config={
-                "type": "conversational",
-                "show_tool_result": True,
-                "show_agent_invocation": True,
+            defaults={
+                "description": "Conversations dashboard",
+                "is_default": False,
+                "grid": [0, 0],
+                "is_deletable": False,
+                "is_editable": True,
+                "config": {
+                    "type": "conversational",
+                    "show_tool_result": True,
+                    "show_agent_invocation": True,
+                },
             },
         )
         return dashboard


### PR DESCRIPTION
### What

Replaced the explicit duplicate-check logic in both the Celery task and the `CreateConversationsDashboard` use case with a single `get_or_create` call. The pre-check in the task and the exception raised in the use case when a conversations dashboard already existed have been removed.

### Why

Using `get_or_create` is the idiomatic and atomic way to handle this scenario, eliminating the redundant existence checks and the need to raise an exception for an already-existing dashboard. This simplifies the code and avoids potential race conditions between the check and the creation.