### PR TITLE
feat: implement vtex account update logic to remove conflicting accounts

### DIFF
--- a/insights/internals/api/projects/serializers.py
+++ b/insights/internals/api/projects/serializers.py
@@ -9,7 +9,18 @@ class UpdateProjectVTEXAccountRequestSerializer(serializers.Serializer):
     )
 
 
+class UnlinkedProjectSerializer(serializers.Serializer):
+    uuid = serializers.CharField()
+    name = serializers.CharField()
+
+
 class ProjectVTEXAccountSerializer(serializers.ModelSerializer):
+    projects_unlinked = serializers.SerializerMethodField()
+
     class Meta:
         model = Project
-        fields = ["name", "uuid", "vtex_account"]
+        fields = ["name", "uuid", "vtex_account", "projects_unlinked"]
+
+    def get_projects_unlinked(self, obj):
+        projects = self.context.get("projects_unlinked", [])
+        return UnlinkedProjectSerializer(projects, many=True).data

--- a/insights/internals/api/projects/tests/test_update_vtex_account_view.py
+++ b/insights/internals/api/projects/tests/test_update_vtex_account_view.py
@@ -59,6 +59,7 @@ class TestUpdateProjectVTEXAccountViewAsAuthenticatedUser(
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data["vtex_account"], "xyz")
+        self.assertEqual(response.data["projects_unlinked"], [])
         self.project.refresh_from_db()
         self.assertEqual(self.project.vtex_account, "xyz")
 
@@ -73,6 +74,9 @@ class TestUpdateProjectVTEXAccountViewAsAuthenticatedUser(
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data["vtex_account"], "xyz")
+        self.assertEqual(response.data["projects_unlinked"], [
+            {"uuid": str(other_project.uuid), "name": "Other"},
+        ])
 
         self.project.refresh_from_db()
         self.assertEqual(self.project.vtex_account, "xyz")
@@ -106,6 +110,7 @@ class TestUpdateProjectVTEXAccountViewWithJWTAuthentication(
                 "name": self.project.name,
                 "uuid": str(self.project.uuid),
                 "vtex_account": "xyz",
+                "projects_unlinked": [],
             },
         )
 

--- a/insights/internals/api/projects/tests/test_update_vtex_account_view.py
+++ b/insights/internals/api/projects/tests/test_update_vtex_account_view.py
@@ -62,6 +62,24 @@ class TestUpdateProjectVTEXAccountViewAsAuthenticatedUser(
         self.project.refresh_from_db()
         self.assertEqual(self.project.vtex_account, "xyz")
 
+    @with_internal_auth
+    def test_removes_vtex_account_from_other_projects_on_update(self):
+        other_project = Project.objects.create(
+            name="Other",
+            vtex_account="xyz",
+        )
+
+        response = self.update_vtex_account(self.project.uuid, {"vtex_account": "xyz"})
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["vtex_account"], "xyz")
+
+        self.project.refresh_from_db()
+        self.assertEqual(self.project.vtex_account, "xyz")
+
+        other_project.refresh_from_db()
+        self.assertIsNone(other_project.vtex_account)
+
 
 @override_settings(JWT_SECRET_KEY=JWT_PRIVATE_KEY_PEM)
 @override_settings(JWT_PUBLIC_KEY=JWT_PUBLIC_KEY_PEM)

--- a/insights/internals/api/projects/views.py
+++ b/insights/internals/api/projects/views.py
@@ -41,12 +41,15 @@ class UpdateProjectVTEXAccountView(views.APIView):
         user = getattr(request, "user", None)
         user_email = user.email if user is not None and user.is_authenticated else None
 
-        UpdateProjectVTEXAccount().execute(
+        project, projects_unlinked = UpdateProjectVTEXAccount().execute(
             project=project,
             vtex_account=serializer.validated_data["vtex_account"],
             user_email=user_email,
         )
 
-        response_data = ProjectVTEXAccountSerializer(project).data
+        response_data = ProjectVTEXAccountSerializer(
+            project,
+            context={"projects_unlinked": projects_unlinked},
+        ).data
 
         return Response(response_data, status=status.HTTP_200_OK)

--- a/insights/projects/dataclass.py
+++ b/insights/projects/dataclass.py
@@ -7,3 +7,9 @@ class TicketID:
 
     def __init__(self, ticket_id: str):
         self.ticket_id = ticket_id
+
+
+@dataclass
+class UnlinkedProject:
+    uuid: str
+    name: str

--- a/insights/projects/tests/test_usecases/test_update_project_vtex_account.py
+++ b/insights/projects/tests/test_usecases/test_update_project_vtex_account.py
@@ -78,3 +78,83 @@ class TestUpdateProjectVTEXAccount(TestCase):
         )
 
         self.assertIn(expected_message, logs.output[0])
+
+    def test_removes_vtex_account_from_other_projects(self):
+        other_project = Project.objects.create(
+            name="Other",
+            vtex_account="xyz",
+        )
+
+        self.use_case.execute(project=self.project, vtex_account="xyz")
+
+        other_project.refresh_from_db()
+        self.assertIsNone(other_project.vtex_account)
+
+    def test_removes_vtex_account_from_multiple_conflicting_projects(self):
+        other_a = Project.objects.create(name="Other A", vtex_account="xyz")
+        other_b = Project.objects.create(name="Other B", vtex_account="xyz")
+
+        self.use_case.execute(project=self.project, vtex_account="xyz")
+
+        other_a.refresh_from_db()
+        other_b.refresh_from_db()
+        self.assertIsNone(other_a.vtex_account)
+        self.assertIsNone(other_b.vtex_account)
+
+    def test_logs_removed_projects(self):
+        other_project = Project.objects.create(
+            name="Other",
+            vtex_account="xyz",
+        )
+
+        with self.assertLogs(
+            "insights.projects.usecases.update_vtex_account", level="INFO"
+        ) as logs:
+            self.use_case.execute(
+                project=self.project,
+                vtex_account="xyz",
+                user_email="example@vtex.com",
+            )
+
+        removal_message = (
+            f"[UpdateProjectVTEXAccount] Removed VTEX Account 'xyz' "
+            f"from project {other_project.name} ({other_project.uuid}) "
+            f"by example@vtex.com"
+        )
+
+        self.assertTrue(
+            any(removal_message in line for line in logs.output),
+        )
+
+    def test_does_not_remove_when_vtex_account_is_empty(self):
+        other_project = Project.objects.create(
+            name="Other",
+            vtex_account="",
+        )
+
+        self.use_case.execute(project=self.project, vtex_account="")
+
+        other_project.refresh_from_db()
+        self.assertEqual(other_project.vtex_account, "")
+
+    def test_does_not_remove_when_vtex_account_is_none(self):
+        other_project = Project.objects.create(
+            name="Other",
+            vtex_account=None,
+        )
+
+        self.use_case.execute(project=self.project, vtex_account=None)
+
+        other_project.refresh_from_db()
+        self.assertIsNone(other_project.vtex_account)
+
+    def test_no_removal_when_no_conflicts(self):
+        other_project = Project.objects.create(
+            name="Other",
+            vtex_account="xyz",
+        )
+
+        self.use_case.execute(project=self.project, vtex_account="def")
+
+        other_project.refresh_from_db()
+        self.assertEqual(other_project.vtex_account, "xyz")

--- a/insights/projects/tests/test_usecases/test_update_project_vtex_account.py
+++ b/insights/projects/tests/test_usecases/test_update_project_vtex_account.py
@@ -1,5 +1,6 @@
 from django.test import TestCase
 
+from insights.projects.dataclass import UnlinkedProject
 from insights.projects.models import Project
 from insights.projects.usecases.update_vtex_account import UpdateProjectVTEXAccount
 
@@ -18,10 +19,13 @@ class TestUpdateProjectVTEXAccount(TestCase):
         self.project.refresh_from_db()
         self.assertEqual(self.project.vtex_account, "xyz")
 
-    def test_returns_project_instance(self):
-        result = self.use_case.execute(project=self.project, vtex_account="xyz")
+    def test_returns_project_instance_and_unlinked_list(self):
+        result_project, projects_unlinked = self.use_case.execute(
+            project=self.project, vtex_account="xyz"
+        )
 
-        self.assertIs(result, self.project)
+        self.assertIs(result_project, self.project)
+        self.assertEqual(projects_unlinked, [])
 
     def test_logs_change_with_user_email(self):
         user_email = "example@vtex.com"
@@ -85,21 +89,31 @@ class TestUpdateProjectVTEXAccount(TestCase):
             vtex_account="xyz",
         )
 
-        self.use_case.execute(project=self.project, vtex_account="xyz")
+        _, projects_unlinked = self.use_case.execute(
+            project=self.project, vtex_account="xyz"
+        )
 
         other_project.refresh_from_db()
         self.assertIsNone(other_project.vtex_account)
+        self.assertEqual(projects_unlinked, [
+            UnlinkedProject(uuid=str(other_project.uuid), name="Other"),
+        ])
 
     def test_removes_vtex_account_from_multiple_conflicting_projects(self):
         other_a = Project.objects.create(name="Other A", vtex_account="xyz")
         other_b = Project.objects.create(name="Other B", vtex_account="xyz")
 
-        self.use_case.execute(project=self.project, vtex_account="xyz")
+        _, projects_unlinked = self.use_case.execute(
+            project=self.project, vtex_account="xyz"
+        )
 
         other_a.refresh_from_db()
         other_b.refresh_from_db()
         self.assertIsNone(other_a.vtex_account)
         self.assertIsNone(other_b.vtex_account)
+
+        unlinked_uuids = {p.uuid for p in projects_unlinked}
+        self.assertEqual(unlinked_uuids, {str(other_a.uuid), str(other_b.uuid)})
 
     def test_logs_removed_projects(self):
         other_project = Project.objects.create(
@@ -132,10 +146,13 @@ class TestUpdateProjectVTEXAccount(TestCase):
             vtex_account="",
         )
 
-        self.use_case.execute(project=self.project, vtex_account="")
+        _, projects_unlinked = self.use_case.execute(
+            project=self.project, vtex_account=""
+        )
 
         other_project.refresh_from_db()
         self.assertEqual(other_project.vtex_account, "")
+        self.assertEqual(projects_unlinked, [])
 
     def test_does_not_remove_when_vtex_account_is_none(self):
         other_project = Project.objects.create(
@@ -143,10 +160,13 @@ class TestUpdateProjectVTEXAccount(TestCase):
             vtex_account=None,
         )
 
-        self.use_case.execute(project=self.project, vtex_account=None)
+        _, projects_unlinked = self.use_case.execute(
+            project=self.project, vtex_account=None
+        )
 
         other_project.refresh_from_db()
         self.assertIsNone(other_project.vtex_account)
+        self.assertEqual(projects_unlinked, [])
 
     def test_no_removal_when_no_conflicts(self):
         other_project = Project.objects.create(
@@ -154,7 +174,10 @@ class TestUpdateProjectVTEXAccount(TestCase):
             vtex_account="xyz",
         )
 
-        self.use_case.execute(project=self.project, vtex_account="def")
+        _, projects_unlinked = self.use_case.execute(
+            project=self.project, vtex_account="def"
+        )
 
         other_project.refresh_from_db()
         self.assertEqual(other_project.vtex_account, "xyz")
+        self.assertEqual(projects_unlinked, [])

--- a/insights/projects/usecases/update_vtex_account.py
+++ b/insights/projects/usecases/update_vtex_account.py
@@ -2,6 +2,7 @@ import logging
 
 from django.db import transaction
 
+from insights.projects.dataclass import UnlinkedProject
 from insights.projects.models import Project
 
 logger = logging.getLogger(__name__)
@@ -15,7 +16,7 @@ class UpdateProjectVTEXAccount:
         project: Project,
         vtex_account: str,
         user_email: str | None = None,
-    ) -> Project:
+    ) -> tuple[Project, list[UnlinkedProject]]:
         """Update the ``vtex_account`` field of the given project.
 
         If other projects already hold the same ``vtex_account``, their
@@ -30,7 +31,9 @@ class UpdateProjectVTEXAccount:
                 ``"INTERNAL"`` in the audit log.
 
         Returns:
-            The updated ``Project`` instance.
+            A tuple of the updated ``Project`` instance and a list of
+            ``UnlinkedProject`` dataclass instances representing the
+            projects that were unlinked.
         """
         actor = user_email if user_email else "INTERNAL"
 
@@ -71,4 +74,9 @@ class UpdateProjectVTEXAccount:
             actor,
         )
 
-        return project
+        projects_unlinked = [
+            UnlinkedProject(uuid=str(uuid), name=name)
+            for name, uuid in removed_projects
+        ]
+
+        return project, projects_unlinked

--- a/insights/projects/usecases/update_vtex_account.py
+++ b/insights/projects/usecases/update_vtex_account.py
@@ -1,5 +1,7 @@
 import logging
 
+from django.db import transaction
+
 from insights.projects.models import Project
 
 logger = logging.getLogger(__name__)
@@ -16,6 +18,10 @@ class UpdateProjectVTEXAccount:
     ) -> Project:
         """Update the ``vtex_account`` field of the given project.
 
+        If other projects already hold the same ``vtex_account``, their
+        value is set to ``None`` within the same database transaction so
+        that only one project owns a given VTEX account at a time.
+
         Args:
             project: The project to update.
             vtex_account: The new VTEX account value.
@@ -26,11 +32,34 @@ class UpdateProjectVTEXAccount:
         Returns:
             The updated ``Project`` instance.
         """
-        previous_value = project.vtex_account
-        project.vtex_account = vtex_account
-        project.save(update_fields=["vtex_account"])
-
         actor = user_email if user_email else "INTERNAL"
+
+        removed_projects = []
+
+        with transaction.atomic():
+            if vtex_account:
+                conflicting = Project.objects.filter(
+                    vtex_account=vtex_account,
+                ).exclude(pk=project.pk)
+
+                removed_projects = list(conflicting.values_list("name", "uuid"))
+
+                if removed_projects:
+                    conflicting.update(vtex_account=None)
+
+            previous_value = project.vtex_account
+            project.vtex_account = vtex_account
+            project.save(update_fields=["vtex_account"])
+
+        for name, uuid in removed_projects:
+            logger.info(
+                "[UpdateProjectVTEXAccount] Removed VTEX Account '%s' "
+                "from project %s (%s) by %s",
+                vtex_account,
+                name,
+                uuid,
+                actor,
+            )
 
         logger.info(
             "[UpdateProjectVTEXAccount] VTEX Account for project %s (%s) "


### PR DESCRIPTION
### What

- Added uniqueness enforcement for the `vtex_account` field across projects: when a VTEX account is assigned to a project, any other projects holding the same account are automatically unlinked (their `vtex_account` is set to `None`) within an atomic database transaction.
- The `UpdateProjectVTEXAccount` use case now returns a tuple containing the updated project and a list of `UnlinkedProject` dataclass instances representing the projects that lost their VTEX account.
- The API response for the update endpoint now includes a `projects_unlinked` field listing the UUID and name of any projects that were unlinked as a result of the operation.
- Added comprehensive test coverage for conflict resolution, logging of removals, and edge cases (empty/null accounts, no conflicts).

### Why

A VTEX account should only be linked to a single project at a time. Previously, assigning the same account to multiple projects was silently allowed, leading to data inconsistency. This change enforces that invariant at the use-case level and provides visibility to API consumers about which projects were affected by the reassignment.