### PR TITLE
refactor: update permission check for internal communication

### DIFF
--- a/insights/authentication/permissions.py
+++ b/insights/authentication/permissions.py
@@ -76,7 +76,10 @@ class ProjectAuthBodyPermission(permissions.BasePermission):
 
 class InternalAuthenticationPermission(permissions.BasePermission):
     def has_permission(self, request: Request, view: APIView) -> bool:
-        return request.user.has_perm("users.can_communicate_internally")
+        return request.user.user_permissions.filter(
+            codename="can_communicate_internally",
+            content_type__app_label="users",
+        ).exists()
 
 
 class IsServiceAuthentication(permissions.BasePermission):


### PR DESCRIPTION
### What

Replaced `has_perm` with a direct query on `user_permissions` in `InternalAuthenticationPermission`, so that only users who explicitly have the `can_communicate_internally` permission assigned are allowed through.

### Why

Django's `has_perm` implicitly returns `True` for all active superusers, bypassing the actual permission check. This permission class is intended to restrict access strictly to users that received the `can_communicate_internally` permission via the OIDC claims flow — superusers should not be granted implicit access to internal communication endpoints.