### PR TITLE
feat: implement streaming XLSX report generation

### DIFF
--- a/insights/metrics/conversations/reports/dataclass.py
+++ b/insights/metrics/conversations/reports/dataclass.py
@@ -18,10 +18,14 @@ class ConversationsReportWorksheet:
 class ConversationsReportFile:
     """
     File for the conversations report.
+
+    Provide either in-memory ``content`` or an on-disk ``local_path`` for
+    streaming uploads. Only one should be set.
     """
 
     name: str
-    content: str
+    content: bytes | None = None
+    local_path: str | None = None
 
 
 @dataclass(frozen=True)

--- a/insights/metrics/conversations/reports/dataclass.py
+++ b/insights/metrics/conversations/reports/dataclass.py
@@ -1,3 +1,4 @@
+from collections.abc import Iterable
 from dataclasses import dataclass
 from uuid import UUID
 
@@ -9,7 +10,8 @@ class ConversationsReportWorksheet:
     """
 
     name: str
-    data: list[dict]
+    data: list[dict] | Iterable[dict]
+    headers: list[str] | None = None
 
 
 @dataclass(frozen=True)

--- a/insights/metrics/conversations/reports/file_processors.py
+++ b/insights/metrics/conversations/reports/file_processors.py
@@ -3,6 +3,9 @@ import io
 import csv
 import logging
 import xlsxwriter
+import tempfile
+import os
+from typing import Iterable
 
 from django.utils.translation import gettext, override
 from insights.metrics.conversations.reports.dataclass import (
@@ -163,3 +166,68 @@ def get_file_processor(format: ReportFormat) -> FileProcessor:
         raise ValueError(f"Invalid format: {format}")
 
     return FILE_PROCESSORS[format]()
+
+
+class StreamingXLSXFileProcessor:
+    """
+    XLSX processor that writes to a temp file on disk instead of keeping
+    everything in memory. Accepts generators/iterables for worksheet data
+    so rows can be written incrementally.
+    """
+
+    def __init__(self):
+        self._used_worksheet_names: set[str] = set()
+
+    def create_workbook(self, report: Report) -> tuple[xlsxwriter.Workbook, str]:
+        """
+        Create a workbook backed by a temp file. Returns (workbook, tmp_path).
+        The caller must call finalize() when done.
+        """
+        tmp_fd, tmp_path = tempfile.mkstemp(suffix=".xlsx")
+        os.close(tmp_fd)
+        workbook = xlsxwriter.Workbook(tmp_path)
+        return workbook, tmp_path
+
+    def write_worksheet(
+        self,
+        workbook: xlsxwriter.Workbook,
+        name: str,
+        headers: list[str],
+        rows: Iterable[dict],
+    ) -> int:
+        """
+        Write a worksheet from an iterable of row dicts.
+        Returns the number of data rows written.
+        """
+        worksheet_name = XLSXFileProcessor()._ensure_unique_worksheet_name(
+            name, self._used_worksheet_names
+        )
+        xlsx_worksheet = workbook.add_worksheet(worksheet_name)
+        xlsx_worksheet.write_row(0, 0, headers)
+
+        row_count = 0
+        for row_num, row_data in enumerate(rows, start=1):
+            xlsx_worksheet.write_row(row_num, 0, [row_data.get(h, "") for h in headers])
+            row_count += 1
+
+        return row_count
+
+    def finalize(
+        self, workbook: xlsxwriter.Workbook, tmp_path: str, report: Report
+    ) -> list[ConversationsReportFile]:
+        """
+        Close the workbook, read the file content, clean up, and return
+        the report file.
+        """
+        workbook.close()
+
+        with override(report.requested_by.language):
+            file_name = gettext("Conversations dashboard report")
+
+        try:
+            with open(tmp_path, "rb") as f:
+                content = f.read()
+        finally:
+            os.unlink(tmp_path)
+
+        return [ConversationsReportFile(name=f"{file_name}.xlsx", content=content)]

--- a/insights/metrics/conversations/reports/file_processors.py
+++ b/insights/metrics/conversations/reports/file_processors.py
@@ -216,18 +216,18 @@ class StreamingXLSXFileProcessor:
         self, workbook: xlsxwriter.Workbook, tmp_path: str, report: Report
     ) -> list[ConversationsReportFile]:
         """
-        Close the workbook, read the file content, clean up, and return
-        the report file.
+        Close the workbook and return a file reference backed by the temp
+        path on disk. The caller uploads or reads the file and is responsible
+        for deleting ``local_path``.
         """
         workbook.close()
 
         with override(report.requested_by.language):
             file_name = gettext("Conversations dashboard report")
 
-        try:
-            with open(tmp_path, "rb") as f:
-                content = f.read()
-        finally:
-            os.unlink(tmp_path)
-
-        return [ConversationsReportFile(name=f"{file_name}.xlsx", content=content)]
+        return [
+            ConversationsReportFile(
+                name=f"{file_name}.xlsx",
+                local_path=tmp_path,
+            )
+        ]

--- a/insights/metrics/conversations/reports/services.py
+++ b/insights/metrics/conversations/reports/services.py
@@ -1,3 +1,4 @@
+from collections.abc import Iterable, Iterator
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime
 import io
@@ -10,6 +11,7 @@ import pytz
 import zipfile
 import boto3
 import uuid
+import os
 
 from django.utils.crypto import get_random_string
 from django.core.mail import EmailMessage
@@ -385,6 +387,32 @@ class ConversationsReportService(BaseConversationsReportService):
         self.elastic_page_limit = elastic_page_limit
 
         self.cache_keys = {}
+        self._use_streaming_events = False
+
+    def _rows_with_empty_fallback(
+        self, rows: Iterable[dict], empty_row: dict
+    ) -> Iterator[dict]:
+        """
+        Yield rows from an iterable and emit a placeholder row when empty.
+        """
+        has_rows = False
+        for row in rows:
+            has_rows = True
+            yield row
+        if not has_rows:
+            yield empty_row
+
+    def _finalize_worksheet_rows(
+        self, rows: Iterable[dict], empty_row: dict
+    ) -> list[dict] | Iterator[dict]:
+        """
+        Materialize worksheet rows for the standard path or keep them as a
+        generator when streaming events to disk.
+        """
+        rows_with_fallback = self._rows_with_empty_fallback(rows, empty_row)
+        if self._use_streaming_events:
+            return rows_with_fallback
+        return list(rows_with_fallback)
 
     def _add_cache_key(self, report_uuid: UUID, cache_key: str) -> None:
         """
@@ -749,7 +777,9 @@ class ConversationsReportService(BaseConversationsReportService):
 
         conversation_classification_events = None
 
-        if "RESOLUTIONS" in sections or "CONTACTS" in sections:
+        if not self._use_streaming_events and (
+            "RESOLUTIONS" in sections or "CONTACTS" in sections
+        ):
             # Fetching only once for resolutions and contacts worksheets
             # instead of fetching for each worksheet
             conversation_classification_events = self.get_datalake_events(
@@ -1242,10 +1272,14 @@ class ConversationsReportService(BaseConversationsReportService):
 
         return events
 
-    def get_datalake_events(self, report: Report, **kwargs) -> list[dict]:
+    def get_datalake_events(
+        self, report: Report, **kwargs
+    ) -> list[dict] | Iterable[dict]:
         """
         Get datalake events.
         """
+        if self._use_streaming_events:
+            return self._iter_datalake_events(report, **kwargs)
         return self.get_datalake_events_in_parallel(report, **kwargs)
 
     def _iter_datalake_events(self, report: Report, **kwargs):
@@ -1290,6 +1324,12 @@ class ConversationsReportService(BaseConversationsReportService):
 
             if current_page % 10 == 0:
                 self._update_heartbeat(report)
+
+            logger.info(
+                "[CONVERSATIONS REPORT SERVICE] Retrieving datalake events for page %s for report %s (streaming)",
+                current_page,
+                report.uuid,
+            )
 
             paginated_events = self.datalake_events_client.get_events(
                 **kwargs,
@@ -1436,50 +1476,18 @@ class ConversationsReportService(BaseConversationsReportService):
 
         return data
 
-    def get_resolutions_worksheet(
+    def _iter_resolutions_rows(
         self,
+        events: Iterable[dict],
         report: Report,
-        start_date: datetime,
-        end_date: datetime,
-        conversation_classification_events: list[dict] | None = None,
-    ) -> ConversationsReportWorksheet:
-        """
-        Get the resolutions worksheet.
-        """
-        if conversation_classification_events is not None:
-            events = conversation_classification_events
-        else:
-            events = self.get_datalake_events(
-                report=report,
-                project=report.project.uuid,
-                date_start=start_date,
-                date_end=end_date,
-                event_name="weni_nexus_data",
-                key="conversation_classification",
-                table="conversation_classification",
-            )
-
-        with override(report.requested_by.language):
-            worksheet_name = gettext("Resolutions")
-
-            resolutions_label = gettext("Resolution")
-            date_label = gettext("Date")
-
-            resolved_label = gettext("AI-Assisted")
-            unresolved_label = gettext("Not assisted")
-            transferred_to_human_label = gettext("Transferred to human support")
-
-            unclassified_label = gettext("Unclassified")
-            unknown_label = gettext("Unknown")
-
-        if len(events) == 0:
-            return ConversationsReportWorksheet(
-                name=worksheet_name,
-                data=[],
-            )
-
-        data = []
-
+        resolutions_label: str,
+        date_label: str,
+        resolved_label: str,
+        unresolved_label: str,
+        transferred_to_human_label: str,
+        unclassified_label: str,
+        unknown_label: str,
+    ) -> Iterator[dict]:
         for event in events:
             metadata = event.get("metadata")
 
@@ -1515,32 +1523,82 @@ class ConversationsReportService(BaseConversationsReportService):
             else:
                 resolution_label = unknown_label
 
-            data.append(
-                {
-                    "URN": event.get("contact_urn", ""),
-                    resolutions_label: resolution_label,
-                    date_label: (
-                        self._format_date(event.get("date", ""), report)
-                        if event.get("date")
-                        else ""
-                    ),
-                }
+            yield {
+                "URN": event.get("contact_urn", ""),
+                resolutions_label: resolution_label,
+                date_label: (
+                    self._format_date(event.get("date", ""), report)
+                    if event.get("date")
+                    else ""
+                ),
+            }
+
+    def get_resolutions_worksheet(
+        self,
+        report: Report,
+        start_date: datetime,
+        end_date: datetime,
+        conversation_classification_events: list[dict] | Iterable[dict] | None = None,
+    ) -> ConversationsReportWorksheet:
+        """
+        Get the resolutions worksheet.
+        """
+        if conversation_classification_events is not None:
+            events = conversation_classification_events
+        else:
+            events = self.get_datalake_events(
+                report=report,
+                project=report.project.uuid,
+                date_start=start_date,
+                date_end=end_date,
+                event_name="weni_nexus_data",
+                key="conversation_classification",
+                table="conversation_classification",
             )
 
-        setattr(self, "_conversation_classification_events_cache", events)
+        with override(report.requested_by.language):
+            worksheet_name = gettext("Resolutions")
 
-        if len(data) == 0:
-            data = [
-                {
-                    "URN": "",
-                    resolutions_label: "",
-                    date_label: "",
-                }
-            ]
+            resolutions_label = gettext("Resolution")
+            date_label = gettext("Date")
+
+            resolved_label = gettext("AI-Assisted")
+            unresolved_label = gettext("Not assisted")
+            transferred_to_human_label = gettext("Transferred to human support")
+
+            unclassified_label = gettext("Unclassified")
+            unknown_label = gettext("Unknown")
+
+        if isinstance(events, list) and len(events) == 0:
+            return ConversationsReportWorksheet(
+                name=worksheet_name,
+                data=[],
+            )
+
+        empty_row = {
+            "URN": "",
+            resolutions_label: "",
+            date_label: "",
+        }
+        data = self._finalize_worksheet_rows(
+            self._iter_resolutions_rows(
+                events,
+                report,
+                resolutions_label,
+                date_label,
+                resolved_label,
+                unresolved_label,
+                transferred_to_human_label,
+                unclassified_label,
+                unknown_label,
+            ),
+            empty_row,
+        )
 
         return ConversationsReportWorksheet(
             name=worksheet_name,
             data=data,
+            headers=list(empty_row.keys()),
         )
 
     def _get_topics_data(self, report: Report) -> dict:
@@ -1609,6 +1667,35 @@ class ConversationsReportService(BaseConversationsReportService):
 
         return topic_name, subtopic_name
 
+    def _iter_topics_distribution_rows(
+        self,
+        events: Iterable[dict],
+        report: Report,
+        topics_data: dict,
+        topic_label: str,
+        subtopic_label: str,
+        date_label: str,
+        unclassified_label: str,
+    ) -> Iterator[dict]:
+        for event in events:
+            topic_name, subtopic_name = self._process_topic_event_data(
+                event, topics_data, unclassified_label
+            )
+
+            if not topic_name or not subtopic_name:
+                continue
+
+            yield {
+                "URN": event.get("contact_urn"),
+                topic_label: topic_name,
+                subtopic_label: subtopic_name,
+                date_label: (
+                    self._format_date(event.get("date"), report)
+                    if event.get("date")
+                    else ""
+                ),
+            }
+
     def get_topics_distribution_worksheet(
         self,
         report: Report,
@@ -1648,43 +1735,45 @@ class ConversationsReportService(BaseConversationsReportService):
             subtopic_label = gettext("Subtopic")
             unclassified_label = gettext("Unclassified")
 
-        results_data = []
-
-        for event in events:
-            topic_name, subtopic_name = self._process_topic_event_data(
-                event, topics_data, unclassified_label
-            )
-
-            if not topic_name or not subtopic_name:
-                continue
-
-            results_data.append(
-                {
-                    "URN": event.get("contact_urn"),
-                    topic_label: topic_name,
-                    subtopic_label: subtopic_name,
-                    date_label: (
-                        self._format_date(event.get("date"), report)
-                        if event.get("date")
-                        else ""
-                    ),
-                }
-            )
-
-        if len(results_data) == 0:
-            results_data = [
-                {
-                    "URN": "",
-                    topic_label: "",
-                    subtopic_label: "",
-                    date_label: "",
-                }
-            ]
+        empty_row = {
+            "URN": "",
+            topic_label: "",
+            subtopic_label: "",
+            date_label: "",
+        }
+        data = self._finalize_worksheet_rows(
+            self._iter_topics_distribution_rows(
+                events,
+                report,
+                topics_data,
+                topic_label,
+                subtopic_label,
+                date_label,
+                unclassified_label,
+            ),
+            empty_row,
+        )
 
         return ConversationsReportWorksheet(
             name=worksheet_name,
-            data=results_data,
+            data=data,
+            headers=list(empty_row.keys()),
         )
+
+    def _iter_csat_ai_rows(
+        self, events: Iterable[dict], report: Report, date_label: str, rating_label: str
+    ) -> Iterator[dict]:
+        ratings = {"1", "2", "3", "4", "5"}
+
+        for event in events:
+            if event.get("value") not in ratings:
+                continue
+
+            yield {
+                "URN": event.get("contact_urn"),
+                date_label: self._format_date(event.get("date"), report),
+                rating_label: event.get("value"),
+            }
 
     def get_csat_ai_worksheet(
         self, report: Report, start_date: datetime, end_date: datetime
@@ -1714,35 +1803,40 @@ class ConversationsReportService(BaseConversationsReportService):
             date_label = gettext("Date")
             rating_label = gettext("Rating")
 
-        data = []
+        empty_row = {
+            "URN": "",
+            date_label: "",
+            rating_label: "",
+        }
+        data = self._finalize_worksheet_rows(
+            self._iter_csat_ai_rows(events, report, date_label, rating_label),
+            empty_row,
+        )
 
-        ratings = {"1", "2", "3", "4", "5"}
+        return ConversationsReportWorksheet(
+            name=worksheet_name,
+            data=data,
+            headers=list(empty_row.keys()),
+        )
+
+    def _iter_nps_ai_rows(
+        self, events: Iterable[dict], report: Report, date_label: str, rating_label: str
+    ) -> Iterator[dict]:
+        ratings = {str(n): 0 for n in range(0, 11)}
 
         for event in events:
             if event.get("value") not in ratings:
                 continue
 
-            data.append(
-                {
-                    "URN": event.get("contact_urn"),
-                    date_label: self._format_date(event.get("date"), report),
-                    rating_label: event.get("value"),
-                }
-            )
-
-        if len(data) == 0:
-            data = [
-                {
-                    "URN": "",
-                    date_label: "",
-                    rating_label: "",
-                }
-            ]
-
-        return ConversationsReportWorksheet(
-            name=worksheet_name,
-            data=data,
-        )
+            yield {
+                "URN": event.get("contact_urn"),
+                date_label: (
+                    self._format_date(event.get("date"), report)
+                    if event.get("date")
+                    else ""
+                ),
+                rating_label: event.get("value"),
+            }
 
     def get_nps_ai_worksheet(
         self, report: Report, start_date: datetime, end_date: datetime
@@ -1773,35 +1867,17 @@ class ConversationsReportService(BaseConversationsReportService):
             date_label = gettext("Date")
             rating_label = gettext("Rating")
 
-        data = []
-        ratings = {str(n): 0 for n in range(0, 11)}
+        empty_row = {
+            "URN": "",
+            date_label: "",
+            rating_label: "",
+        }
+        data = self._finalize_worksheet_rows(
+            self._iter_nps_ai_rows(events, report, date_label, rating_label),
+            empty_row,
+        )
 
-        for event in events:
-            if event.get("value") not in ratings:
-                continue
-
-            data.append(
-                {
-                    "URN": event.get("contact_urn"),
-                    date_label: (
-                        self._format_date(event.get("date"), report)
-                        if event.get("date")
-                        else ""
-                    ),
-                    rating_label: event.get("value"),
-                }
-            )
-
-        if len(data) == 0:
-            data = [
-                {
-                    "URN": "",
-                    date_label: "",
-                    rating_label: "",
-                }
-            ]
-
-        return ConversationsReportWorksheet(name=worksheet_name, data=data)
+        return ConversationsReportWorksheet(name=worksheet_name, data=data, headers=list(empty_row.keys()))
 
     def get_csat_human_worksheet(
         self, report: Report, start_date: str, end_date: str
@@ -1944,6 +2020,20 @@ class ConversationsReportService(BaseConversationsReportService):
             data=data,
         )
 
+    def _iter_custom_widget_rows(
+        self,
+        events: Iterable[dict],
+        report: Report,
+        date_label: str,
+        value_label: str,
+    ) -> Iterator[dict]:
+        for event in events:
+            yield {
+                "URN": event.get("contact_urn"),
+                date_label: self._format_date(event.get("date"), report),
+                value_label: event.get("value"),
+            }
+
     def get_custom_widget_worksheet(
         self,
         report: Report,
@@ -1978,29 +2068,20 @@ class ConversationsReportService(BaseConversationsReportService):
             date_label = gettext("Date")
             value_label = gettext("Value")
 
-        data = []
-
-        for event in events:
-            data.append(
-                {
-                    "URN": event.get("contact_urn"),
-                    date_label: self._format_date(event.get("date"), report),
-                    value_label: event.get("value"),
-                }
-            )
-
-        if len(data) == 0:
-            data = [
-                {
-                    "URN": "",
-                    date_label: "",
-                    value_label: "",
-                }
-            ]
+        empty_row = {
+            "URN": "",
+            date_label: "",
+            value_label: "",
+        }
+        data = self._finalize_worksheet_rows(
+            self._iter_custom_widget_rows(events, report, date_label, value_label),
+            empty_row,
+        )
 
         return ConversationsReportWorksheet(
             name=worksheet_name,
             data=data,
+            headers=list(empty_row.keys()),
         )
 
     def get_crosstab_widget_worksheet(
@@ -2106,6 +2187,31 @@ class ConversationsReportService(BaseConversationsReportService):
             data=data,
         )
 
+    def _iter_tool_result_detailed_rows(
+        self,
+        events: Iterable[dict],
+        report: Report,
+        urn_label: str,
+        tool_name_label: str,
+        date_label: str,
+    ) -> Iterator[dict]:
+        for event in events:
+            metadata = event.get("metadata")
+
+            if metadata and not isinstance(metadata, dict):
+                try:
+                    metadata = json.loads(metadata)
+                except Exception:
+                    continue
+
+            tool_name = event.get("value", "")
+
+            yield {
+                urn_label: event.get("contact_urn", ""),
+                tool_name_label: tool_name,
+                date_label: self._format_date(event.get("date", ""), report),
+            }
+
     def _get_tool_result_detailed_worksheet(
         self,
         report: Report,
@@ -2127,31 +2233,19 @@ class ConversationsReportService(BaseConversationsReportService):
             tool_name_label = gettext("Tool name")
             date_label = gettext("Date")
 
-        data = []
+        empty_row = {urn_label: "", tool_name_label: "", date_label: ""}
+        data = self._finalize_worksheet_rows(
+            self._iter_tool_result_detailed_rows(
+                events, report, urn_label, tool_name_label, date_label
+            ),
+            empty_row,
+        )
 
-        for event in events:
-            metadata = event.get("metadata")
-
-            if metadata and not isinstance(metadata, dict):
-                try:
-                    metadata = json.loads(metadata)
-                except Exception:
-                    continue
-
-            tool_name = event.get("value", "")
-
-            data.append(
-                {
-                    urn_label: event.get("contact_urn", ""),
-                    tool_name_label: tool_name,
-                    date_label: self._format_date(event.get("date", ""), report),
-                }
-            )
-
-        if len(data) == 0:
-            data = [{urn_label: "", tool_name_label: "", date_label: ""}]
-
-        return ConversationsReportWorksheet(name=worksheet_name, data=data)
+        return ConversationsReportWorksheet(
+            name=worksheet_name,
+            data=data,
+            headers=list(empty_row.keys()),
+        )
 
     def get_agent_invocation_worksheet(
         self,
@@ -2204,6 +2298,40 @@ class ConversationsReportService(BaseConversationsReportService):
             data=data,
         )
 
+    def _iter_agent_invocation_detailed_rows(
+        self,
+        events: Iterable[dict],
+        report: Report,
+        agents_by_slug: dict[str, dict],
+        urn_label: str,
+        agent_name_label: str,
+        agent_uuid_label: str,
+        date_label: str,
+    ) -> Iterator[dict]:
+        for event in events:
+            metadata = event.get("metadata")
+
+            if metadata and not isinstance(metadata, dict):
+                try:
+                    metadata = json.loads(metadata)
+                except Exception:
+                    continue
+
+            agent_slug = event.get("value", "")
+            agent_data = agents_by_slug.get(agent_slug) or {}
+            agent_name = agent_data.get("name") or agent_slug
+            agent_uuid = ""
+
+            if metadata:
+                agent_uuid = metadata.get("agent_uuid", None)
+
+            yield {
+                urn_label: event.get("contact_urn", ""),
+                agent_name_label: agent_name,
+                agent_uuid_label: agent_uuid,
+                date_label: self._format_date(event.get("date", ""), report),
+            }
+
     def _get_agent_invocation_detailed_worksheet(
         self,
         report: Report,
@@ -2228,45 +2356,30 @@ class ConversationsReportService(BaseConversationsReportService):
             agent_uuid_label = gettext("Agent UUID")
             date_label = gettext("Date")
 
-        data = []
+        empty_row = {
+            urn_label: "",
+            agent_name_label: "",
+            agent_uuid_label: "",
+            date_label: "",
+        }
+        data = self._finalize_worksheet_rows(
+            self._iter_agent_invocation_detailed_rows(
+                events,
+                report,
+                agents_by_slug,
+                urn_label,
+                agent_name_label,
+                agent_uuid_label,
+                date_label,
+            ),
+            empty_row,
+        )
 
-        for event in events:
-            metadata = event.get("metadata")
-
-            if metadata and not isinstance(metadata, dict):
-                try:
-                    metadata = json.loads(metadata)
-                except Exception:
-                    continue
-
-            agent_slug = event.get("value", "")
-            agent_data = agents_by_slug.get(agent_slug) or {}
-            agent_name = agent_data.get("name") or agent_slug
-            agent_uuid = ""
-
-            if metadata:
-                agent_uuid = metadata.get("agent_uuid", None)
-
-            data.append(
-                {
-                    urn_label: event.get("contact_urn", ""),
-                    agent_name_label: agent_name,
-                    agent_uuid_label: agent_uuid,
-                    date_label: self._format_date(event.get("date", ""), report),
-                }
-            )
-
-        if len(data) == 0:
-            data = [
-                {
-                    urn_label: "",
-                    agent_name_label: "",
-                    agent_uuid_label: "",
-                    date_label: "",
-                }
-            ]
-
-        return ConversationsReportWorksheet(name=worksheet_name, data=data)
+        return ConversationsReportWorksheet(
+            name=worksheet_name,
+            data=data,
+            headers=list(empty_row.keys()),
+        )
 
     def get_contacts_summary_worksheet(
         self,
@@ -2320,7 +2433,7 @@ class ConversationsReportService(BaseConversationsReportService):
         report: Report,
         start_date: datetime,
         end_date: datetime,
-        conversation_classification_events: list[dict] | None = None,
+        conversation_classification_events: list[dict] | Iterable[dict] | None = None,
     ) -> list[ConversationsReportWorksheet]:
         try:
             attributes = {
@@ -2351,7 +2464,18 @@ class ConversationsReportService(BaseConversationsReportService):
                 )
             ]
 
-        events = conversation_classification_events or []
+        if conversation_classification_events is not None:
+            events = conversation_classification_events
+        else:
+            events = self.get_datalake_events(
+                report=report,
+                project=report.project.uuid,
+                date_start=start_date,
+                date_end=end_date,
+                event_name="weni_nexus_data",
+                key="conversation_classification",
+                table="conversation_classification",
+            )
 
         urn_counts: dict[str, int] = {}
         for event in events:
@@ -2395,6 +2519,24 @@ class ConversationsReportService(BaseConversationsReportService):
             ),
         ]
 
+    def _iter_search_terms_rows(
+        self,
+        events: Iterable[dict],
+        report: Report,
+        date_label: str,
+        terms_label: str,
+    ) -> Iterator[dict]:
+        for event in events:
+            yield {
+                "URN": event.get("contact_urn", ""),
+                date_label: (
+                    self._format_date(event.get("date"), report)
+                    if event.get("date")
+                    else ""
+                ),
+                terms_label: event.get("value", ""),
+            }
+
     def get_search_terms_worksheet(
         self,
         report: Report,
@@ -2429,32 +2571,39 @@ class ConversationsReportService(BaseConversationsReportService):
             date_label = gettext("Date")
             terms_label = gettext("Terms")
 
-        data = [
-            {
+        empty_row = {
+            "URN": "",
+            date_label: "",
+            terms_label: "",
+        }
+        data = self._finalize_worksheet_rows(
+            self._iter_search_terms_rows(events, report, date_label, terms_label),
+            empty_row,
+        )
+
+        return ConversationsReportWorksheet(
+            name=worksheet_name,
+            data=data,
+            headers=list(empty_row.keys()),
+        )
+
+    def _iter_added_to_cart_rows(
+        self,
+        events: Iterable[dict],
+        report: Report,
+        date_label: str,
+        product_label: str,
+    ) -> Iterator[dict]:
+        for event in events:
+            yield {
                 "URN": event.get("contact_urn", ""),
                 date_label: (
                     self._format_date(event.get("date"), report)
                     if event.get("date")
                     else ""
                 ),
-                terms_label: event.get("value", ""),
+                product_label: event.get("value", ""),
             }
-            for event in events
-        ]
-
-        if not data:
-            data = [
-                {
-                    "URN": "",
-                    date_label: "",
-                    terms_label: "",
-                }
-            ]
-
-        return ConversationsReportWorksheet(
-            name=worksheet_name,
-            data=data,
-        )
 
     def get_added_to_cart_worksheet(
         self,
@@ -2490,31 +2639,35 @@ class ConversationsReportService(BaseConversationsReportService):
             date_label = gettext("Date")
             product_label = gettext("Product")
 
-        data = [
-            {
-                "URN": event.get("contact_urn", ""),
-                date_label: (
-                    self._format_date(event.get("date"), report)
-                    if event.get("date")
-                    else ""
-                ),
-                product_label: event.get("value", ""),
-            }
-            for event in events
-        ]
-
-        if not data:
-            data = [
-                {
-                    "URN": "",
-                    date_label: "",
-                    product_label: "",
-                }
-            ]
+        empty_row = {
+            "URN": "",
+            date_label: "",
+            product_label: "",
+        }
+        data = self._finalize_worksheet_rows(
+            self._iter_added_to_cart_rows(events, report, date_label, product_label),
+            empty_row,
+        )
 
         return ConversationsReportWorksheet(
             name=worksheet_name,
             data=data,
+            headers=list(empty_row.keys()),
+        )
+
+    def _should_skip_worksheet(self, worksheet: ConversationsReportWorksheet) -> bool:
+        return isinstance(worksheet.data, list) and len(worksheet.data) == 0
+
+    def _resolve_worksheet_headers(
+        self, worksheet: ConversationsReportWorksheet
+    ) -> list[str]:
+        if worksheet.headers:
+            return worksheet.headers
+        if isinstance(worksheet.data, list) and worksheet.data:
+            return list(worksheet.data[0].keys())
+        raise ValueError(
+            "Worksheet '%s' has no headers and no materialized rows"
+            % worksheet.name
         )
 
     def _generate_streaming(
@@ -2522,23 +2675,23 @@ class ConversationsReportService(BaseConversationsReportService):
         report: Report,
         start_date: datetime,
         end_date: datetime,
-    ) -> list:
+    ) -> list[ConversationsReportFile]:
         """
-        Generate an XLSX report by writing to a temp file on disk instead
-        of in-memory. Reuses the same ``_get_worksheets()`` pipeline so all
-        section logic stays in one place; only the file-writing strategy
-        changes.
+        Generate an XLSX report by streaming datalake events page by page
+        and writing worksheet rows directly to a temp file on disk.
         """
-        worksheets = self._get_worksheets(report, start_date, end_date)
-
+        self._use_streaming_events = True
         processor = StreamingXLSXFileProcessor()
         workbook, tmp_path = processor.create_workbook(report)
 
         try:
+            worksheets = self._get_worksheets(report, start_date, end_date)
+
             for ws in worksheets:
-                if not ws.data:
+                if self._should_skip_worksheet(ws):
                     continue
-                headers = list(ws.data[0].keys())
+
+                headers = self._resolve_worksheet_headers(ws)
                 row_count = processor.write_worksheet(
                     workbook, ws.name, headers, ws.data
                 )
@@ -2555,6 +2708,8 @@ class ConversationsReportService(BaseConversationsReportService):
             if os.path.exists(tmp_path):
                 os.unlink(tmp_path)
             raise
+        finally:
+            self._use_streaming_events = False
 
         return files
 

--- a/insights/metrics/conversations/reports/services.py
+++ b/insights/metrics/conversations/reports/services.py
@@ -41,7 +41,10 @@ from insights.metrics.conversations.reports.dataclass import (
     ConversationsReportFile,
     ConversationsReportWorksheet,
 )
-from insights.metrics.conversations.reports.file_processors import get_file_processor
+from insights.metrics.conversations.reports.file_processors import (
+    get_file_processor,
+    StreamingXLSXFileProcessor,
+)
 from insights.metrics.conversations.services import ConversationsMetricsService
 from insights.reports.models import Report
 from insights.reports.choices import ReportStatus, ReportFormat, ReportSource
@@ -408,6 +411,25 @@ class ConversationsReportService(BaseConversationsReportService):
         except Exception as e:
             logger.error(
                 "[CONVERSATIONS REPORT SERVICE] Feature flag check failed: %s", e
+            )
+            capture_exception(e)
+            return False
+
+    def _is_streaming_mode_enabled(self, report: Report) -> bool:
+        attributes = {
+            "projectUUID": str(report.project.uuid),
+        }
+        if report.requested_by:
+            attributes["userEmail"] = report.requested_by.email
+        try:
+            return is_feature_active_for_attributes(
+                settings.CONVERSATIONS_REPORT_STREAMING_MODE_FEATURE_FLAG_KEY,
+                attributes=attributes,
+            )
+        except Exception as e:
+            logger.error(
+                "[CONVERSATIONS REPORT SERVICE] Streaming mode feature flag check failed: %s",
+                e,
             )
             capture_exception(e)
             return False
@@ -863,7 +885,16 @@ class ConversationsReportService(BaseConversationsReportService):
         )
 
         report = self._update_report_status(report)
-        file_processor = get_file_processor(report.format)
+        use_streaming = (
+            report.format == ReportFormat.XLSX
+            and self._is_streaming_mode_enabled(report)
+        )
+
+        if use_streaming:
+            logger.info(
+                "[CONVERSATIONS REPORT SERVICE] Using streaming mode for report %s",
+                report.uuid,
+            )
 
         try:
             start_date, end_date = self._validate_dates(report)
@@ -880,8 +911,12 @@ class ConversationsReportService(BaseConversationsReportService):
                 end_date,
             )
 
-            worksheets = self._get_worksheets(report, start_date, end_date)
-            files = file_processor.process(report=report, worksheets=worksheets)
+            if use_streaming:
+                files = self._generate_streaming(report, start_date, end_date)
+            else:
+                file_processor = get_file_processor(report.format)
+                worksheets = self._get_worksheets(report, start_date, end_date)
+                files = file_processor.process(report=report, worksheets=worksheets)
 
         except Exception as e:
             logger.error(
@@ -1212,6 +1247,63 @@ class ConversationsReportService(BaseConversationsReportService):
         Get datalake events.
         """
         return self.get_datalake_events_in_parallel(report, **kwargs)
+
+    def _iter_datalake_events(self, report: Report, **kwargs):
+        """
+        Generator that yields datalake events page by page without
+        accumulating all results in memory. Used by the streaming
+        report generation path.
+        """
+        limit = self.events_limit_per_page
+        offset = 0
+        current_page = 1
+        page_limit = self.page_limit
+
+        date_start = kwargs.get("date_start")
+        date_end = kwargs.get("date_end")
+
+        if date_start and isinstance(date_start, datetime):
+            kwargs["date_start"] = date_start.isoformat()
+
+        if date_end and isinstance(date_end, datetime):
+            kwargs["date_end"] = date_end.isoformat()
+
+        while True:
+            if current_page >= page_limit:
+                logger.error(
+                    "[CONVERSATIONS REPORT SERVICE] Report %s has more than %s pages (streaming). "
+                    "Finishing datalake events retrieval",
+                    report.uuid,
+                    page_limit,
+                )
+                raise ValueError("Report has more than %s pages" % page_limit)
+
+            report.refresh_from_db(fields=["status"])
+
+            if report.status != ReportStatus.IN_PROGRESS:
+                logger.info(
+                    "[CONVERSATIONS REPORT SERVICE] Report %s is not in progress (streaming). "
+                    "Finishing datalake events retrieval",
+                    report.uuid,
+                )
+                raise ValueError("Report %s is not in progress" % report.uuid)
+
+            if current_page % 10 == 0:
+                self._update_heartbeat(report)
+
+            paginated_events = self.datalake_events_client.get_events(
+                **kwargs,
+                limit=limit,
+                offset=offset,
+            )
+
+            if len(paginated_events) == 0 or paginated_events == [{}]:
+                break
+
+            yield from paginated_events
+
+            offset += limit
+            current_page += 1
 
     def _format_date(self, original_date: str | int, report: Report) -> str:
         """
@@ -2424,6 +2516,47 @@ class ConversationsReportService(BaseConversationsReportService):
             name=worksheet_name,
             data=data,
         )
+
+    def _generate_streaming(
+        self,
+        report: Report,
+        start_date: datetime,
+        end_date: datetime,
+    ) -> list:
+        """
+        Generate an XLSX report by writing to a temp file on disk instead
+        of in-memory. Reuses the same ``_get_worksheets()`` pipeline so all
+        section logic stays in one place; only the file-writing strategy
+        changes.
+        """
+        worksheets = self._get_worksheets(report, start_date, end_date)
+
+        processor = StreamingXLSXFileProcessor()
+        workbook, tmp_path = processor.create_workbook(report)
+
+        try:
+            for ws in worksheets:
+                if not ws.data:
+                    continue
+                headers = list(ws.data[0].keys())
+                row_count = processor.write_worksheet(
+                    workbook, ws.name, headers, ws.data
+                )
+                logger.info(
+                    "[CONVERSATIONS REPORT SERVICE] Streaming worksheet '%s' wrote %s rows for report %s",
+                    ws.name,
+                    row_count,
+                    report.uuid,
+                )
+
+            files = processor.finalize(workbook, tmp_path, report)
+        except Exception:
+            workbook.close()
+            if os.path.exists(tmp_path):
+                os.unlink(tmp_path)
+            raise
+
+        return files
 
     def get_available_widgets(self, project: Project) -> AvailableReportWidgets:
         """

--- a/insights/metrics/conversations/reports/services.py
+++ b/insights/metrics/conversations/reports/services.py
@@ -506,6 +506,26 @@ class ConversationsReportService(BaseConversationsReportService):
 
             del self.cache_keys[report_uuid]
 
+    def _read_report_file_bytes(self, file: ConversationsReportFile) -> bytes:
+        """
+        Read report file bytes from memory or disk.
+        """
+        if file.content is not None:
+            return file.content
+
+        if file.local_path:
+            with open(file.local_path, "rb") as report_file:
+                return report_file.read()
+
+        raise ValueError("Report file has no content or local_path")
+
+    def _cleanup_report_file(self, file: ConversationsReportFile) -> None:
+        """
+        Remove a temp file created during streaming report generation.
+        """
+        if file.local_path and os.path.exists(file.local_path):
+            os.unlink(file.local_path)
+
     def zip_files(
         self, files: list[ConversationsReportFile]
     ) -> ConversationsReportFile:
@@ -537,7 +557,8 @@ class ConversationsReportService(BaseConversationsReportService):
                             raise ValueError("Failed to generate a unique name")
 
                     names_used.add(name)
-                    zip_file.writestr(name, file.content)
+                    zip_file.writestr(name, self._read_report_file_bytes(file))
+                    self._cleanup_report_file(file)
 
             zip_content = zip_buffer.getvalue()
 
@@ -553,14 +574,25 @@ class ConversationsReportService(BaseConversationsReportService):
         extension = file.name.split(".")[-1]
         obj_key = f"reports/conversations/{str(uuid.uuid4())}.{extension}"
 
-        # Wrap content in BytesIO to make it file-like
-        file_obj = io.BytesIO(file.content)
-
-        s3.upload_fileobj(
-            file_obj,
-            settings.S3_BUCKET_NAME,
-            obj_key,
-        )
+        try:
+            if file.local_path:
+                with open(file.local_path, "rb") as report_file:
+                    s3.upload_fileobj(
+                        report_file,
+                        settings.S3_BUCKET_NAME,
+                        obj_key,
+                    )
+            elif file.content is not None:
+                file_obj = io.BytesIO(file.content)
+                s3.upload_fileobj(
+                    file_obj,
+                    settings.S3_BUCKET_NAME,
+                    obj_key,
+                )
+            else:
+                raise ValueError("Report file has no content or local_path")
+        finally:
+            self._cleanup_report_file(file)
 
         return obj_key
 
@@ -630,11 +662,14 @@ class ConversationsReportService(BaseConversationsReportService):
                 email.content_subtype = "html"
 
                 if reports_file and not settings.USE_S3:
-                    email.attach(
-                        reports_file.name,
-                        reports_file.content,
-                        "application/zip",
-                    )
+                    try:
+                        email.attach(
+                            reports_file.name,
+                            self._read_report_file_bytes(reports_file),
+                            "application/zip",
+                        )
+                    finally:
+                        self._cleanup_report_file(reports_file)
 
                 email.send(fail_silently=False)
         except Exception as e:

--- a/insights/metrics/conversations/reports/tests/test_file_processors.py
+++ b/insights/metrics/conversations/reports/tests/test_file_processors.py
@@ -1,10 +1,12 @@
 from django.test import TestCase
+import os
 
 from insights.metrics.conversations.reports.dataclass import (
     ConversationsReportWorksheet,
 )
 from insights.metrics.conversations.reports.file_processors import (
     CSVFileProcessor,
+    StreamingXLSXFileProcessor,
     XLSXFileProcessor,
     get_file_processor,
 )
@@ -166,3 +168,39 @@ class TestGetFileProcessor(TestCase):
 
         processor = get_file_processor(ReportFormat.XLSX)
         self.assertIsInstance(processor, XLSXFileProcessor)
+
+
+class TestStreamingXLSXFileProcessor(TestCase):
+    def setUp(self):
+        self.processor = StreamingXLSXFileProcessor()
+        self.project = Project.objects.create(name="Test")
+        self.user = User.objects.create(email="test@test.com", language="en")
+        self.source = "test_source"
+
+    def test_finalize_returns_local_path_without_reading_content(self):
+        report = Report.objects.create(
+            project=self.project,
+            source=self.source,
+            source_config={},
+            filters={},
+            format=ReportFormat.XLSX,
+            requested_by=self.user,
+        )
+
+        workbook, tmp_path = self.processor.create_workbook(report)
+        self.processor.write_worksheet(
+            workbook,
+            "Valid",
+            ["col1"],
+            [{"col1": "val1"}],
+        )
+
+        files = self.processor.finalize(workbook, tmp_path, report)
+
+        self.assertEqual(len(files), 1)
+        self.assertTrue(files[0].name.endswith(".xlsx"))
+        self.assertIsNone(files[0].content)
+        self.assertEqual(files[0].local_path, tmp_path)
+        self.assertTrue(os.path.exists(tmp_path))
+
+        os.unlink(tmp_path)

--- a/insights/metrics/conversations/reports/tests/test_services.py
+++ b/insights/metrics/conversations/reports/tests/test_services.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 import json
+import os
 from unittest.mock import MagicMock, patch
 import uuid
 
@@ -2826,6 +2827,26 @@ class TestConversationsReportServiceAdditional(TestCase):
         self.assertIn("reports/conversations/", obj_key)
         self.assertIn(".csv", obj_key)
         mock_s3_client.upload_fileobj.assert_called_once()
+
+    @patch("boto3.client")
+    def test_upload_file_to_s3_from_local_path(self, mock_boto3_client):
+        """Test upload_file_to_s3 streams from disk without loading into memory."""
+        import tempfile
+
+        mock_s3_client = MagicMock()
+        mock_boto3_client.return_value = mock_s3_client
+
+        with tempfile.NamedTemporaryFile(suffix=".xlsx", delete=False) as tmp_file:
+            tmp_file.write(b"xlsx content")
+            tmp_path = tmp_file.name
+
+        file = ConversationsReportFile(name="report.xlsx", local_path=tmp_path)
+        obj_key = self.service.upload_file_to_s3(file)
+
+        self.assertIn("reports/conversations/", obj_key)
+        self.assertIn(".xlsx", obj_key)
+        mock_s3_client.upload_fileobj.assert_called_once()
+        self.assertFalse(os.path.exists(tmp_path))
 
     @patch("boto3.client")
     def test_get_presigned_url(self, mock_boto3_client):

--- a/insights/settings.py
+++ b/insights/settings.py
@@ -468,6 +468,10 @@ CONVERSATIONS_REPORT_STATUS_CACHE_KEY = env.str(
     "CONVERSATIONS_REPORT_STATUS_CACHE_KEY",
     default="conversations_report_status:{project_uuid}",
 )
+CONVERSATIONS_REPORT_STREAMING_MODE_FEATURE_FLAG_KEY = env.str(
+    "CONVERSATIONS_REPORT_STREAMING_MODE_FEATURE_FLAG_KEY",
+    default="insightsConversationsReportStreamingMode",
+)
 
 # Conversations dashboard
 


### PR DESCRIPTION
### What

Adds an opt-in streaming path for conversations dashboard XLSX report generation, controlled by the `insightsConversationsReportStreamingMode` feature flag.

- Introduces `StreamingXLSXFileProcessor`, which writes worksheets incrementally to a temp file on disk instead of building the full workbook in memory.
- Extends `ConversationsReportFile` to support either in-memory `content` or on-disk `local_path`, and `ConversationsReportWorksheet` to accept `Iterable[dict]` rows plus explicit `headers`.
- Refactors datalake-driven worksheets (resolutions, topics, CSAT/NPS, custom widgets, tool/agent invocations, search terms, added-to-cart, etc.) to use row iterators (`_iter_*_rows`) that yield rows one at a time.
- Adds `_iter_datalake_events` to fetch datalake events page by page without accumulating all pages in memory when streaming is active.
- Updates S3 upload, ZIP bundling, and email attachment flows to read from disk when `local_path` is set and to clean up temp files after use.
- Adds `CONVERSATIONS_REPORT_STREAMING_MODE_FEATURE_FLAG_KEY` setting and tests for the streaming processor and S3 upload from disk.

### Why

Large conversations reports were loading all datalake events and the full XLSX into memory, causing high memory usage and OOM risk on big date ranges or high-volume projects. Streaming lets rows be fetched and written incrementally to a temp file and uploaded to S3 without holding the entire dataset in RAM, while the feature flag allows a gradual, per-project rollout with a safe fallback to the existing in-memory path.

### Sequence diagram

```mermaid
sequenceDiagram
    participant Task as Report Task
    participant Service as ConversationsReportService
    participant FF as Feature Flag
    participant DL as Datalake Events Client
    participant Proc as StreamingXLSXFileProcessor
    participant Disk as Temp File
    participant S3 as S3

    Task->>Service: generate_report(report)

    Service->>FF: is_streaming_mode_enabled(report)
    FF-->>Service: true (XLSX + flag on)

    Service->>Service: _use_streaming_events = true
    Service->>Proc: create_workbook(report)
    Proc->>Disk: mkstemp(.xlsx)
    Proc-->>Service: workbook, tmp_path

    Service->>Service: _get_worksheets(report, dates)

    loop Each worksheet section
        Service->>DL: get_events(limit, offset) [page by page]
        DL-->>Service: paginated events
        Service->>Service: _iter_*_rows(events) yields rows
        Service->>Proc: write_worksheet(name, headers, row_iterable)
        Proc->>Disk: write rows incrementally
    end

    Service->>Proc: finalize(workbook, tmp_path, report)
    Proc->>Disk: workbook.close()
    Proc-->>Service: ConversationsReportFile(local_path=tmp_path)

    Service->>Service: _use_streaming_events = false

    alt USE_S3 enabled
        Service->>S3: upload_fileobj(open(local_path))
        S3-->>Service: obj_key
    else Email attachment (no S3)
        Service->>Service: attach(_read_report_file_bytes)
    end

    Service->>Disk: _cleanup_report_file (unlink temp file)
    Service-->>Task: report completed
```