### PR TITLE
feat: refactor conversations report generation and add unit tests

### DIFF
--- a/insights/metrics/conversations/tasks.py
+++ b/insights/metrics/conversations/tasks.py
@@ -33,6 +33,22 @@ from insights.metrics.conversations.usecases.datalake_check_project_sales_funnel
 logger = logging.getLogger(__name__)
 
 
+def _create_conversations_report_service() -> ConversationsReportService:
+    return ConversationsReportService(
+        datalake_events_client=DataLakeEventsClient(),
+        metrics_service=ConversationsMetricsService(),
+        elasticsearch_service=ConversationsElasticsearchService(
+            client=ElasticsearchClient(),
+        ),
+        cache_client=CacheClient(),
+        nexus_client=NexusClient(),
+        events_limit_per_page=settings.CONVERSATIONS_REPORT_EVENTS_LIMIT_PER_PAGE,
+        page_limit=settings.CONVERSATIONS_REPORT_PAGE_LIMIT,
+        elastic_page_size=settings.CONVERSATIONS_REPORT_ELASTIC_PAGE_SIZE,
+        elastic_page_limit=settings.CONVERSATIONS_REPORT_ELASTIC_PAGE_LIMIT,
+    )
+
+
 @app.task
 def generate_conversations_report():
     host = settings.HOSTNAME
@@ -105,19 +121,7 @@ def generate_conversations_report():
         oldest_report.config = config
 
         oldest_report.save(update_fields=["config"])
-        ConversationsReportService(
-            datalake_events_client=DataLakeEventsClient(),
-            metrics_service=ConversationsMetricsService(),
-            elasticsearch_service=ConversationsElasticsearchService(
-                client=ElasticsearchClient(),
-            ),
-            cache_client=CacheClient(),
-            nexus_client=NexusClient(),
-            events_limit_per_page=settings.CONVERSATIONS_REPORT_EVENTS_LIMIT_PER_PAGE,
-            page_limit=settings.CONVERSATIONS_REPORT_PAGE_LIMIT,
-            elastic_page_size=settings.CONVERSATIONS_REPORT_ELASTIC_PAGE_SIZE,
-            elastic_page_limit=settings.CONVERSATIONS_REPORT_ELASTIC_PAGE_LIMIT,
-        ).generate(oldest_report)
+        _create_conversations_report_service().generate(oldest_report)
     except Exception as e:
         logger.error(
             "[ generate_conversations_report task ] Error generating report %s: %s",
@@ -153,7 +157,7 @@ def timeout_reports():
         status=ReportStatus.IN_PROGRESS,
         started_at__lt=timezone.now()
         - timedelta(seconds=settings.REPORT_GENERATION_TIMEOUT),
-    )
+    ).select_related("project", "requested_by")
 
     if not in_progress_reports.exists():
         logger.info(
@@ -161,20 +165,23 @@ def timeout_reports():
         )
         return
 
+    report_count = in_progress_reports.count()
+
     logger.info(
         "[ timeout_reports task ] Found %s in progress reports",
-        in_progress_reports.count(),
+        report_count,
     )
+
+    service = _create_conversations_report_service()
 
     for report in in_progress_reports:
         report.status = ReportStatus.FAILED
         report.completed_at = timezone.now()
         report.errors = {"timeout": "Report generation timed out"}
         report.save(update_fields=["status", "completed_at", "errors"])
+        service.send_email(report, [], is_error=True)
 
-    logger.info(
-        "[ timeout_reports task ] Timed out %s reports", in_progress_reports.count()
-    )
+    logger.info("[ timeout_reports task ] Timed out %s reports", report_count)
 
 
 @app.task

--- a/insights/metrics/conversations/tasks.py
+++ b/insights/metrics/conversations/tasks.py
@@ -172,13 +172,19 @@ def timeout_reports():
         report_count,
     )
 
+    timed_out_reports = list(in_progress_reports)
+    completed_at = timezone.now()
+    timeout_errors = {"timeout": "Report generation timed out"}
+
+    for report in timed_out_reports:
+        report.status = ReportStatus.FAILED
+        report.completed_at = completed_at
+        report.errors = timeout_errors
+        report.save(update_fields=["status", "completed_at", "errors"])
+
     service = _create_conversations_report_service()
 
-    for report in in_progress_reports:
-        report.status = ReportStatus.FAILED
-        report.completed_at = timezone.now()
-        report.errors = {"timeout": "Report generation timed out"}
-        report.save(update_fields=["status", "completed_at", "errors"])
+    for report in timed_out_reports:
         service.send_email(report, [], is_error=True)
 
     logger.info("[ timeout_reports task ] Timed out %s reports", report_count)

--- a/insights/metrics/conversations/tests/test_tasks.py
+++ b/insights/metrics/conversations/tests/test_tasks.py
@@ -1,0 +1,64 @@
+from datetime import timedelta
+from unittest.mock import patch
+
+from django.test import TestCase, override_settings
+from django.utils import timezone
+
+from insights.metrics.conversations.tasks import timeout_reports
+from insights.projects.models import Project
+from insights.reports.choices import ReportFormat, ReportSource, ReportStatus
+from insights.reports.models import Report
+from insights.users.models import User
+
+
+@override_settings(REPORT_GENERATION_TIMEOUT=3600)
+class TestTimeoutReports(TestCase):
+    def setUp(self):
+        self.project = Project.objects.create(name="Test Project")
+        self.user = User.objects.create(email="test@test.com", language="en")
+
+    def test_timeout_reports_does_nothing_when_no_stale_reports(self):
+        Report.objects.create(
+            project=self.project,
+            source=ReportSource.CONVERSATIONS_DASHBOARD,
+            source_config={},
+            filters={},
+            format=ReportFormat.CSV,
+            requested_by=self.user,
+            status=ReportStatus.IN_PROGRESS,
+            started_at=timezone.now(),
+        )
+
+        with patch(
+            "insights.metrics.conversations.tasks._create_conversations_report_service"
+        ) as mock_create_service:
+            timeout_reports()
+
+            mock_create_service.assert_not_called()
+
+    @patch(
+        "insights.metrics.conversations.tasks._create_conversations_report_service"
+    )
+    def test_timeout_reports_marks_reports_as_failed_and_sends_email(
+        self, mock_create_service
+    ):
+        mock_service = mock_create_service.return_value
+
+        report = Report.objects.create(
+            project=self.project,
+            source=ReportSource.CONVERSATIONS_DASHBOARD,
+            source_config={},
+            filters={},
+            format=ReportFormat.CSV,
+            requested_by=self.user,
+            status=ReportStatus.IN_PROGRESS,
+            started_at=timezone.now() - timedelta(hours=2),
+        )
+
+        timeout_reports()
+
+        report.refresh_from_db()
+        self.assertEqual(report.status, ReportStatus.FAILED)
+        self.assertIsNotNone(report.completed_at)
+        self.assertEqual(report.errors, {"timeout": "Report generation timed out"})
+        mock_service.send_email.assert_called_once_with(report, [], is_error=True)

--- a/insights/metrics/conversations/tests/test_tasks.py
+++ b/insights/metrics/conversations/tests/test_tasks.py
@@ -1,5 +1,6 @@
 from datetime import timedelta
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, Mock, patch
+
 from uuid import uuid4
 
 from django.test import TestCase, override_settings
@@ -185,7 +186,9 @@ class TestTimeoutReports(TestCase):
     def test_timeout_reports_marks_reports_as_failed_and_sends_email(
         self, mock_create_service
     ):
-        Report.objects.create(
+        mock_service = Mock()
+        mock_create_service.return_value = mock_service
+        report = Report.objects.create(
             project=self.project,
             source=ReportSource.CONVERSATIONS_DASHBOARD,
             source_config={},
@@ -195,8 +198,12 @@ class TestTimeoutReports(TestCase):
             status=ReportStatus.IN_PROGRESS,
             started_at=timezone.now() - timedelta(hours=2),
         )
-
         timeout_reports()
+        report.refresh_from_db()
+        self.assertEqual(report.status, ReportStatus.FAILED)
+        self.assertIsNotNone(report.completed_at)
+        self.assertEqual(report.errors, {"timeout": "Report generation timed out"})
+        mock_service.send_email.assert_called_once_with(report, [], is_error=True)
 
     @override_settings(REPORT_GENERATION_TIMEOUT=3600)
     def test_returns_early_when_no_in_progress_reports(self):

--- a/insights/metrics/conversations/tests/test_tasks.py
+++ b/insights/metrics/conversations/tests/test_tasks.py
@@ -185,9 +185,7 @@ class TestTimeoutReports(TestCase):
     def test_timeout_reports_marks_reports_as_failed_and_sends_email(
         self, mock_create_service
     ):
-        mock_service = mock_create_service.return_value
-
-        report = Report.objects.create(
+        Report.objects.create(
             project=self.project,
             source=ReportSource.CONVERSATIONS_DASHBOARD,
             source_config={},


### PR DESCRIPTION
### What

- Extracted `_create_conversations_report_service()` to centralize `ConversationsReportService` construction and reuse it in `generate_conversations_report` and `timeout_reports`.
- Updated `timeout_reports` to:
    - `select_related("project", "requested_by")` when querying in-progress reports
    - Send a failure email via `send_email(report, [], is_error=True)` for each timed-out report
    - Avoid redundant `.count()` calls by caching the report count
- Added unit tests for `timeout_reports` covering the no-op case and the timeout + email notification flow.

### Why

Users were not notified when conversation report generation timed out. This change ensures timed-out reports are marked as failed and the requester receives a failure email, while reducing duplicated service setup and adding test coverage for the timeout behavior.