### PR TITLE
feat: add pull request template for improved contribution guidelines

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,9 @@
+### What
+_Summarize what changed. Name the key components (models, endpoints, managers, use cases, serializers, etc.) and describe the behavioral impact — not just what files were touched._
+_Use a short paragraph for focused changes, or bullet points when the PR spans multiple areas._
+
+### Why
+_Explain the motivation. What problem or limitation existed before? What does this change enable, fix, or simplify for consumers of the code?_
+
+### Sequence diagram
+_Optional. Mermaid sequence diagram explaining the new feature process._


### PR DESCRIPTION
### What

Adds a pull request template to the repository under `.github/PULL_REQUEST_TEMPLATE.md`.

### Why

Without a standard template, PR descriptions were inconsistent, often missing key context about what changed and why. This template encourages contributors to clearly describe the behavioral impact of their changes and the motivation behind them, making code reviews faster and more effective.