### PR TITLE
feat: add parallel streaming fetch with disk-backed event spool for classification events

### DIFF
--- a/insights/metrics/conversations/reports/services.py
+++ b/insights/metrics/conversations/reports/services.py
@@ -12,6 +12,7 @@ import zipfile
 import boto3
 import uuid
 import os
+import tempfile
 
 from django.utils.crypto import get_random_string
 from django.core.mail import EmailMessage
@@ -102,6 +103,41 @@ def serialize_filters_for_json(filters: dict) -> dict:
             serialized_filters[key] = value
 
     return serialized_filters
+
+
+class _ReplayableDatalakeEventsSpool:
+    """
+    Disk-backed event spool that supports multiple iterations over the same
+    datalake fetch without keeping all events in memory.
+    """
+
+    def __init__(self, path: str):
+        self.path = path
+
+    @classmethod
+    def from_parallel_fetch(cls, service, report: Report, **kwargs):
+        fd, path = tempfile.mkstemp(suffix=".jsonl")
+        os.close(fd)
+        try:
+            with open(path, "w") as spool_file:
+                for event in service._iter_datalake_events(report, **kwargs):
+                    spool_file.write(json.dumps(event, default=str) + "\n")
+        except Exception:
+            if os.path.exists(path):
+                os.unlink(path)
+            raise
+        return cls(path)
+
+    def __iter__(self) -> Iterator[dict]:
+        with open(self.path) as spool_file:
+            for line in spool_file:
+                line = line.strip()
+                if line:
+                    yield json.loads(line)
+
+    def cleanup(self) -> None:
+        if os.path.exists(self.path):
+            os.unlink(self.path)
 
 
 class BaseConversationsReportService(ABC):
@@ -388,6 +424,82 @@ class ConversationsReportService(BaseConversationsReportService):
 
         self.cache_keys = {}
         self._use_streaming_events = False
+        self._streaming_spools: list[_ReplayableDatalakeEventsSpool] = []
+
+    def _normalize_datalake_kwargs(self, kwargs: dict) -> None:
+        """
+        Convert datetime filters to ISO strings for datalake API calls.
+        """
+        date_start = kwargs.get("date_start")
+        date_end = kwargs.get("date_end")
+
+        if date_start and isinstance(date_start, datetime):
+            kwargs["date_start"] = date_start.isoformat()
+
+        if date_end and isinstance(date_end, datetime):
+            kwargs["date_end"] = date_end.isoformat()
+
+    def _fetch_page_indices(
+        self,
+        report: Report,
+        page_indices: range,
+        **kwargs,
+    ) -> list[list[dict] | None]:
+        """
+        Fetch the given page indices in parallel, preserving order.
+        """
+        page_indices_list = list(page_indices)
+        if not page_indices_list:
+            return []
+
+        limit = self.events_limit_per_page
+        self._normalize_datalake_kwargs(kwargs)
+        max_workers = min(
+            len(page_indices_list), settings.REPORT_PARALLEL_FETCH_MAX_WORKERS
+        )
+
+        def fetch_page(page_index: int) -> list[dict]:
+            offset = page_index * limit
+            return self.datalake_events_client.get_events(
+                **kwargs,
+                limit=limit,
+                offset=offset,
+            )
+
+        results: list[list[dict] | None] = [None] * len(page_indices_list)
+        index_to_position = {
+            page_index: position
+            for position, page_index in enumerate(page_indices_list)
+        }
+
+        with ThreadPoolExecutor(max_workers=max_workers) as executor:
+            future_to_index = {
+                executor.submit(fetch_page, page_index): page_index
+                for page_index in page_indices_list
+            }
+
+            for future in as_completed(future_to_index):
+                page_index = future_to_index[future]
+                try:
+                    page_events = future.result()
+                except Exception as e:
+                    logger.error(
+                        "[CONVERSATIONS REPORT SERVICE] Failed to fetch page %s for report %s. Error: %s",
+                        page_index,
+                        report.uuid,
+                        e,
+                    )
+                    raise
+
+                if page_events and page_events != [{}]:
+                    results[index_to_position[page_index]] = page_events
+
+        return results
+
+    def _cleanup_streaming_spools(self) -> None:
+        for spool in self._streaming_spools:
+            spool.cleanup()
+        self._streaming_spools = []
 
     def _rows_with_empty_fallback(
         self, rows: Iterable[dict], empty_row: dict
@@ -812,20 +924,39 @@ class ConversationsReportService(BaseConversationsReportService):
 
         conversation_classification_events = None
 
-        if not self._use_streaming_events and (
+        needs_classification = (
             "RESOLUTIONS" in sections or "CONTACTS" in sections
-        ):
-            # Fetching only once for resolutions and contacts worksheets
-            # instead of fetching for each worksheet
-            conversation_classification_events = self.get_datalake_events(
-                report=report,
-                project=report.project.uuid,
-                date_start=start_date,
-                date_end=end_date,
-                event_name="weni_nexus_data",
-                key="conversation_classification",
-                table="conversation_classification",
-            )
+        )
+
+        if needs_classification:
+            classification_fetch_kwargs = {
+                "project": report.project.uuid,
+                "date_start": start_date,
+                "date_end": end_date,
+                "event_name": "weni_nexus_data",
+                "key": "conversation_classification",
+                "table": "conversation_classification",
+            }
+
+            if self._use_streaming_events:
+                if "RESOLUTIONS" in sections and "CONTACTS" in sections:
+                    spool = _ReplayableDatalakeEventsSpool.from_parallel_fetch(
+                        self,
+                        report,
+                        **classification_fetch_kwargs,
+                    )
+                    self._streaming_spools.append(spool)
+                    conversation_classification_events = spool
+                else:
+                    conversation_classification_events = self.get_datalake_events(
+                        report=report,
+                        **classification_fetch_kwargs,
+                    )
+            else:
+                conversation_classification_events = self.get_datalake_events(
+                    report=report,
+                    **classification_fetch_kwargs,
+                )
 
         worksheets_mapping = {
             "RESOLUTIONS": (
@@ -1087,14 +1218,7 @@ class ConversationsReportService(BaseConversationsReportService):
         """
         Get events count.
         """
-        date_start = kwargs.get("date_start")
-        date_end = kwargs.get("date_end")
-
-        if date_start and isinstance(date_start, datetime):
-            kwargs["date_start"] = date_start.isoformat()
-
-        if date_end and isinstance(date_end, datetime):
-            kwargs["date_end"] = date_end.isoformat()
+        self._normalize_datalake_kwargs(kwargs)
 
         result = self.datalake_events_client.get_events_count(**kwargs)
 
@@ -1130,14 +1254,7 @@ class ConversationsReportService(BaseConversationsReportService):
         current_page = 1
         page_limit = self.page_limit
 
-        date_start = kwargs.get("date_start")
-        date_end = kwargs.get("date_end")
-
-        if date_start and isinstance(date_start, datetime):
-            kwargs["date_start"] = date_start.isoformat()
-
-        if date_end and isinstance(date_end, datetime):
-            kwargs["date_end"] = date_end.isoformat()
+        self._normalize_datalake_kwargs(kwargs)
 
         while True:
             if current_page >= page_limit:
@@ -1211,15 +1328,6 @@ class ConversationsReportService(BaseConversationsReportService):
             )
             raise ValueError("Report %s is not in progress" % report.uuid)
 
-        date_start = kwargs.get("date_start")
-        date_end = kwargs.get("date_end")
-
-        if date_start and isinstance(date_start, datetime):
-            kwargs["date_start"] = date_start.isoformat()
-
-        if date_end and isinstance(date_end, datetime):
-            kwargs["date_end"] = date_end.isoformat()
-
         max_workers = min(total_pages, settings.REPORT_PARALLEL_FETCH_MAX_WORKERS)
 
         logger.info(
@@ -1229,40 +1337,9 @@ class ConversationsReportService(BaseConversationsReportService):
             report.uuid,
         )
 
-        def fetch_page(page_index: int) -> list[dict]:
-            offset = page_index * limit
-            return self.datalake_events_client.get_events(
-                **kwargs,
-                limit=limit,
-                offset=offset,
-            )
+        results = self._fetch_page_indices(report, range(total_pages), **kwargs)
 
-        results: list[list[dict] | None] = [None] * total_pages
-
-        with ThreadPoolExecutor(max_workers=max_workers) as executor:
-            future_to_index = {
-                executor.submit(fetch_page, i): i for i in range(total_pages)
-            }
-
-            for future in as_completed(future_to_index):
-                page_index = future_to_index[future]
-                try:
-                    page_events = future.result()
-                except Exception as e:
-                    logger.error(
-                        "[CONVERSATIONS REPORT SERVICE] Failed to fetch page %s for report %s. Error: %s",
-                        page_index,
-                        report.uuid,
-                        e,
-                    )
-                    raise
-
-                if page_events and page_events != [{}]:
-                    results[page_index] = page_events
-
-        events = [event for page in results if page is not None for event in page]
-
-        return events
+        return [event for page in results if page is not None for event in page]
 
     def get_datalake_events_in_parallel(self, report: Report, **kwargs) -> list[dict]:
         """
@@ -1317,25 +1394,17 @@ class ConversationsReportService(BaseConversationsReportService):
             return self._iter_datalake_events(report, **kwargs)
         return self.get_datalake_events_in_parallel(report, **kwargs)
 
-    def _iter_datalake_events(self, report: Report, **kwargs):
+    def _iter_datalake_events_sequential(self, report: Report, **kwargs):
         """
-        Generator that yields datalake events page by page without
-        accumulating all results in memory. Used by the streaming
-        report generation path.
+        Generator that yields datalake events one page at a time.
+        Used as a fallback when the count query fails.
         """
         limit = self.events_limit_per_page
         offset = 0
         current_page = 1
         page_limit = self.page_limit
 
-        date_start = kwargs.get("date_start")
-        date_end = kwargs.get("date_end")
-
-        if date_start and isinstance(date_start, datetime):
-            kwargs["date_start"] = date_start.isoformat()
-
-        if date_end and isinstance(date_end, datetime):
-            kwargs["date_end"] = date_end.isoformat()
+        self._normalize_datalake_kwargs(kwargs)
 
         while True:
             if current_page >= page_limit:
@@ -1376,6 +1445,79 @@ class ConversationsReportService(BaseConversationsReportService):
 
             offset += limit
             current_page += 1
+
+    def _iter_datalake_events(self, report: Report, **kwargs):
+        """
+        Generator that yields datalake events page by page without
+        accumulating all results in memory. Used by the streaming
+        report generation path.
+        """
+        try:
+            total_count = self.get_events_count(**kwargs)
+        except Exception as e:
+            logger.warning(
+                "[CONVERSATIONS REPORT SERVICE] Failed to get events count for report %s, falling back to sequential streaming. Error: %s",
+                report.uuid,
+                e,
+            )
+            yield from self._iter_datalake_events_sequential(report, **kwargs)
+            return
+
+        if total_count == 0:
+            return
+
+        limit = self.events_limit_per_page
+        page_limit = self.page_limit
+        total_pages = math.ceil(total_count / limit)
+
+        if total_pages >= page_limit:
+            logger.error(
+                "[CONVERSATIONS REPORT SERVICE] Report %s has more than %s pages (streaming). "
+                "Finishing datalake events retrieval",
+                report.uuid,
+                page_limit,
+            )
+            raise ValueError("Report has more than %s pages" % page_limit)
+
+        report.refresh_from_db(fields=["status"])
+
+        if report.status != ReportStatus.IN_PROGRESS:
+            logger.info(
+                "[CONVERSATIONS REPORT SERVICE] Report %s is not in progress (streaming). "
+                "Finishing datalake events retrieval",
+                report.uuid,
+            )
+            raise ValueError("Report %s is not in progress" % report.uuid)
+
+        max_workers = settings.REPORT_PARALLEL_FETCH_MAX_WORKERS
+
+        for batch_start in range(0, total_pages, max_workers):
+            batch_end = min(batch_start + max_workers, total_pages)
+
+            logger.info(
+                "[CONVERSATIONS REPORT SERVICE] Fetching pages %s-%s in parallel (streaming) for report %s",
+                batch_start + 1,
+                batch_end,
+                report.uuid,
+            )
+
+            batch_results = self._fetch_page_indices(
+                report, range(batch_start, batch_end), **kwargs
+            )
+
+            report.refresh_from_db(fields=["status"])
+
+            if report.status != ReportStatus.IN_PROGRESS:
+                logger.info(
+                    "[CONVERSATIONS REPORT SERVICE] Report %s is not in progress (streaming). "
+                    "Finishing datalake events retrieval",
+                    report.uuid,
+                )
+                raise ValueError("Report %s is not in progress" % report.uuid)
+
+            for page_events in batch_results:
+                if page_events:
+                    yield from page_events
 
     def _format_date(self, original_date: str | int, report: Report) -> str:
         """
@@ -2714,6 +2856,7 @@ class ConversationsReportService(BaseConversationsReportService):
         and writing worksheet rows directly to a temp file on disk.
         """
         self._use_streaming_events = True
+        self._streaming_spools = []
         processor = StreamingXLSXFileProcessor()
         workbook, tmp_path = processor.create_workbook(report)
 
@@ -2743,6 +2886,7 @@ class ConversationsReportService(BaseConversationsReportService):
             raise
         finally:
             self._use_streaming_events = False
+            self._cleanup_streaming_spools()
 
         return files
 

--- a/insights/metrics/conversations/reports/services.py
+++ b/insights/metrics/conversations/reports/services.py
@@ -1357,9 +1357,6 @@ class ConversationsReportService(BaseConversationsReportService):
                 )
                 raise ValueError("Report %s is not in progress" % report.uuid)
 
-            if current_page % 10 == 0:
-                self._update_heartbeat(report)
-
             logger.info(
                 "[CONVERSATIONS REPORT SERVICE] Retrieving datalake events for page %s for report %s (streaming)",
                 current_page,
@@ -1912,7 +1909,9 @@ class ConversationsReportService(BaseConversationsReportService):
             empty_row,
         )
 
-        return ConversationsReportWorksheet(name=worksheet_name, data=data, headers=list(empty_row.keys()))
+        return ConversationsReportWorksheet(
+            name=worksheet_name, data=data, headers=list(empty_row.keys())
+        )
 
     def get_csat_human_worksheet(
         self, report: Report, start_date: str, end_date: str
@@ -2701,8 +2700,7 @@ class ConversationsReportService(BaseConversationsReportService):
         if isinstance(worksheet.data, list) and worksheet.data:
             return list(worksheet.data[0].keys())
         raise ValueError(
-            "Worksheet '%s' has no headers and no materialized rows"
-            % worksheet.name
+            "Worksheet '%s' has no headers and no materialized rows" % worksheet.name
         )
 
     def _generate_streaming(

--- a/insights/metrics/conversations/reports/tests/test_services.py
+++ b/insights/metrics/conversations/reports/tests/test_services.py
@@ -5448,6 +5448,8 @@ class TestStreamingPrefetch(TestCase):
         self.assertFalse(os.path.exists(spool_paths[0]))
         self.assertEqual(self.service._streaming_spools, [])
 
+
+class TestGetDatalakeEventsInParallel(TestCase):
     def setUp(self):
         self.service = ConversationsReportService(
             elasticsearch_service=ConversationsElasticsearchService(

--- a/insights/metrics/conversations/reports/tests/test_services.py
+++ b/insights/metrics/conversations/reports/tests/test_services.py
@@ -5304,9 +5304,9 @@ class TestIterDatalakeEventsStreaming(TestCase):
 
         def refresh_side_effect(*args, **kwargs):
             refresh_count["value"] += 1
+            original_refresh(*args, **kwargs)
             if refresh_count["value"] > 2:
                 report.status = ReportStatus.FAILED
-            return original_refresh(*args, **kwargs)
 
         with patch.object(report, "refresh_from_db", side_effect=refresh_side_effect):
             with self.assertRaises(ValueError):

--- a/insights/metrics/conversations/reports/tests/test_services.py
+++ b/insights/metrics/conversations/reports/tests/test_services.py
@@ -5127,8 +5127,327 @@ class TestGetDatalakeEventsDispatch(TestCase):
         mock_parallel_method.assert_called_once_with(report, key="example")
         self.assertEqual(result, [{"id": "1"}])
 
+    @patch.object(ConversationsReportService, "_iter_datalake_events")
+    def test_dispatches_to_streaming_iterator(self, mock_iter_method):
+        mock_iter_method.return_value = iter([{"id": "1"}])
 
-class TestGetDatalakeEventsInParallel(TestCase):
+        report = Report.objects.create(
+            project=self.project,
+            source=self.service.source,
+            source_config={},
+            filters={},
+            format=ReportFormat.XLSX,
+            requested_by=self.user,
+            status=ReportStatus.IN_PROGRESS,
+        )
+
+        self.service._use_streaming_events = True
+        result = self.service.get_datalake_events(report, key="example")
+
+        mock_iter_method.assert_called_once_with(report, key="example")
+        self.assertEqual(list(result), [{"id": "1"}])
+
+
+class TestIterDatalakeEventsStreaming(TestCase):
+    def setUp(self):
+        self.service = ConversationsReportService(
+            elasticsearch_service=ConversationsElasticsearchService(
+                client=MockElasticsearchClient(),
+            ),
+            events_limit_per_page=5,
+            page_limit=20,
+            datalake_events_client=MockDataLakeEventsClient(),
+            metrics_service=ConversationsMetricsService(
+                datalake_service=MagicMock(spec=BaseConversationsMetricsService),
+                nexus_conversations_client=MagicMock(spec=NexusConversationsAPIClient),
+                cache_client=MockCacheClient(),
+                flowruns_query_executor=MockFlowRunsQueryExecutor(),
+            ),
+            cache_client=MockCacheClient(),
+            nexus_client=MockNexusClient(),
+        )
+        self.project = Project.objects.create(name="Test")
+        self.user = User.objects.create(email="test@test.com", language="en")
+
+    def _create_report(self):
+        return Report.objects.create(
+            project=self.project,
+            source=self.service.source,
+            source_config={},
+            filters={},
+            format=ReportFormat.XLSX,
+            requested_by=self.user,
+            status=ReportStatus.IN_PROGRESS,
+        )
+
+    @patch(
+        "insights.sources.dl_events.tests.mock_client.MockDataLakeEventsClient.get_events"
+    )
+    @patch(
+        "insights.sources.dl_events.tests.mock_client.MockDataLakeEventsClient.get_events_count"
+    )
+    @override_settings(REPORT_PARALLEL_FETCH_MAX_WORKERS=5)
+    def test_streaming_parallel_preserves_page_order(
+        self, mock_get_count, mock_get_events
+    ):
+        mock_get_count.return_value = [{"count": 15}]
+
+        page_1 = [{"id": "1"}, {"id": "2"}, {"id": "3"}, {"id": "4"}, {"id": "5"}]
+        page_2 = [{"id": "6"}, {"id": "7"}, {"id": "8"}, {"id": "9"}, {"id": "10"}]
+        page_3 = [{"id": "11"}, {"id": "12"}, {"id": "13"}, {"id": "14"}, {"id": "15"}]
+
+        def get_events_side_effect(**kwargs):
+            offset = kwargs.get("offset", 0)
+            if offset == 0:
+                return page_1
+            if offset == 5:
+                return page_2
+            if offset == 10:
+                return page_3
+            return []
+
+        mock_get_events.side_effect = get_events_side_effect
+
+        report = self._create_report()
+        events = list(self.service._iter_datalake_events(report, key="example"))
+
+        self.assertEqual(events, page_1 + page_2 + page_3)
+        self.assertEqual(mock_get_events.call_count, 3)
+
+    @patch(
+        "insights.sources.dl_events.tests.mock_client.MockDataLakeEventsClient.get_events_count"
+    )
+    @override_settings(REPORT_PARALLEL_FETCH_MAX_WORKERS=5)
+    def test_streaming_parallel_fetches_in_batches(self, mock_get_count):
+        mock_get_count.return_value = [{"count": 60}]
+
+        batch_calls = []
+
+        def fetch_side_effect(report, page_indices, **kwargs):
+            batch_calls.append(list(page_indices))
+            return [
+                [{"id": f"page-{page_index}-event"}]
+                for page_index in page_indices
+            ]
+
+        report = self._create_report()
+
+        with patch.object(
+            self.service, "_fetch_page_indices", side_effect=fetch_side_effect
+        ):
+            list(self.service._iter_datalake_events(report, key="example"))
+
+        self.assertEqual(
+            batch_calls,
+            [
+                [0, 1, 2, 3, 4],
+                [5, 6, 7, 8, 9],
+                [10, 11],
+            ],
+        )
+
+    @patch.object(ConversationsReportService, "_iter_datalake_events_sequential")
+    @patch(
+        "insights.sources.dl_events.tests.mock_client.MockDataLakeEventsClient.get_events_count"
+    )
+    def test_streaming_falls_back_to_sequential_on_count_error(
+        self, mock_get_count, mock_sequential
+    ):
+        mock_get_count.side_effect = Exception("count failed")
+        mock_sequential.return_value = iter([{"id": "1"}])
+
+        report = self._create_report()
+        events = list(self.service._iter_datalake_events(report, key="example"))
+
+        mock_sequential.assert_called_once_with(report, key="example")
+        self.assertEqual(events, [{"id": "1"}])
+
+    @patch(
+        "insights.sources.dl_events.tests.mock_client.MockDataLakeEventsClient.get_events_count"
+    )
+    def test_streaming_parallel_returns_empty_when_count_is_zero(
+        self, mock_get_count
+    ):
+        mock_get_count.return_value = [{"count": 0}]
+
+        report = self._create_report()
+        events = list(self.service._iter_datalake_events(report, key="example"))
+
+        self.assertEqual(events, [])
+
+    @patch(
+        "insights.sources.dl_events.tests.mock_client.MockDataLakeEventsClient.get_events_count"
+    )
+    def test_streaming_parallel_raises_when_page_limit_exceeded(
+        self, mock_get_count
+    ):
+        self.service.page_limit = 5
+        mock_get_count.return_value = [{"count": 30}]
+
+        report = self._create_report()
+
+        with self.assertRaises(ValueError):
+            list(self.service._iter_datalake_events(report, key="example"))
+
+    @patch(
+        "insights.sources.dl_events.tests.mock_client.MockDataLakeEventsClient.get_events_count"
+    )
+    @override_settings(REPORT_PARALLEL_FETCH_MAX_WORKERS=5)
+    def test_streaming_parallel_raises_when_report_cancelled_between_batches(
+        self, mock_get_count
+    ):
+        mock_get_count.return_value = [{"count": 60}]
+
+        report = self._create_report()
+        original_refresh = report.refresh_from_db
+        refresh_count = {"value": 0}
+
+        def refresh_side_effect(*args, **kwargs):
+            refresh_count["value"] += 1
+            if refresh_count["value"] > 2:
+                report.status = ReportStatus.FAILED
+            return original_refresh(*args, **kwargs)
+
+        with patch.object(report, "refresh_from_db", side_effect=refresh_side_effect):
+            with self.assertRaises(ValueError):
+                list(self.service._iter_datalake_events(report, key="example"))
+
+
+class TestStreamingPrefetch(TestCase):
+    def setUp(self):
+        self.service = ConversationsReportService(
+            elasticsearch_service=ConversationsElasticsearchService(
+                client=MockElasticsearchClient(),
+            ),
+            events_limit_per_page=5,
+            page_limit=5,
+            datalake_events_client=MockDataLakeEventsClient(),
+            metrics_service=ConversationsMetricsService(
+                datalake_service=MagicMock(spec=BaseConversationsMetricsService),
+                nexus_conversations_client=MagicMock(spec=NexusConversationsAPIClient),
+                cache_client=MockCacheClient(),
+                flowruns_query_executor=MockFlowRunsQueryExecutor(),
+            ),
+            cache_client=MockCacheClient(),
+            nexus_client=MockNexusClient(),
+        )
+        self.project = Project.objects.create(name="Test")
+        self.user = User.objects.create(email="test@test.com", language="en")
+
+    @patch(
+        "insights.metrics.conversations.reports.services.is_feature_active_for_attributes",
+        return_value=True,
+    )
+    @patch.object(ConversationsReportService, "_iter_datalake_events")
+    def test_get_worksheets_streaming_prefetches_once_for_resolutions_and_contacts(
+        self, mock_iter_events, mock_feature_flag
+    ):
+        mock_events = [
+            {
+                "contact_urn": "urn:tel:+5511111111111",
+                "date": "2025-01-01T12:00:00.000000Z",
+                "value": "resolved",
+                "metadata": "{}",
+            },
+            {
+                "contact_urn": "urn:tel:+5522222222222",
+                "date": "2025-01-01T12:00:00.000000Z",
+                "value": "unresolved",
+                "metadata": "{}",
+            },
+        ]
+        mock_iter_events.return_value = iter(mock_events)
+
+        report = Report.objects.create(
+            project=self.project,
+            source=self.service.source,
+            source_config={"sections": ["RESOLUTIONS", "CONTACTS"]},
+            filters={"start": "2025-01-01", "end": "2025-01-02"},
+            format=ReportFormat.XLSX,
+            requested_by=self.user,
+            status=ReportStatus.IN_PROGRESS,
+        )
+
+        self.service._use_streaming_events = True
+        start_date = datetime(2025, 1, 1)
+        end_date = datetime(2025, 1, 2)
+
+        worksheets = self.service._get_worksheets(report, start_date, end_date)
+
+        mock_iter_events.assert_called_once()
+        self.assertTrue(len(worksheets) >= 3)
+        self.assertEqual(len(self.service._streaming_spools), 1)
+
+        resolutions_ws = next(ws for ws in worksheets if ws.name == "Resolutions")
+        self.assertEqual(len(list(resolutions_ws.data)), 2)
+
+        unique_ws = next(ws for ws in worksheets if ws.name == "Unique contacts")
+        unique_urns = [row["URN"] for row in unique_ws.data]
+        self.assertEqual(len(unique_urns), 2)
+
+        spool_path = self.service._streaming_spools[0].path
+        self.service._cleanup_streaming_spools()
+        self.assertEqual(self.service._streaming_spools, [])
+        self.assertFalse(os.path.exists(spool_path))
+
+    @patch(
+        "insights.metrics.conversations.reports.services.is_feature_active_for_attributes",
+        return_value=True,
+    )
+    @patch.object(ConversationsReportService, "_iter_datalake_events")
+    def test_generate_streaming_cleans_up_spool_files(
+        self, mock_iter_events, mock_feature_flag
+    ):
+        mock_iter_events.return_value = iter(
+            [
+                {
+                    "contact_urn": "urn:tel:+5511111111111",
+                    "date": "2025-01-01T12:00:00.000000Z",
+                    "value": "resolved",
+                    "metadata": "{}",
+                },
+            ]
+        )
+
+        report = Report.objects.create(
+            project=self.project,
+            source=self.service.source,
+            source_config={"sections": ["RESOLUTIONS", "CONTACTS"]},
+            filters={"start": "2025-01-01", "end": "2025-01-02"},
+            format=ReportFormat.XLSX,
+            requested_by=self.user,
+            status=ReportStatus.IN_PROGRESS,
+        )
+
+        spool_paths = []
+
+        from insights.metrics.conversations.reports import services as services_module
+
+        original_spool_factory = (
+            services_module._ReplayableDatalakeEventsSpool.from_parallel_fetch
+        )
+
+        def spool_factory(service, report, **kwargs):
+            spool = original_spool_factory(service, report, **kwargs)
+            spool_paths.append(spool.path)
+            return spool
+
+        with patch.object(
+            services_module._ReplayableDatalakeEventsSpool,
+            "from_parallel_fetch",
+            side_effect=spool_factory,
+        ):
+            files = self.service._generate_streaming(
+                report,
+                datetime(2025, 1, 1),
+                datetime(2025, 1, 2),
+            )
+
+        self.assertEqual(len(files), 1)
+        self.assertEqual(len(spool_paths), 1)
+        self.assertFalse(os.path.exists(spool_paths[0]))
+        self.assertEqual(self.service._streaming_spools, [])
+
     def setUp(self):
         self.service = ConversationsReportService(
             elasticsearch_service=ConversationsElasticsearchService(


### PR DESCRIPTION
### What

- Adds parallel datalake event fetching to the streaming report path (`_iter_datalake_events`), fetching pages in batches sized by `REPORT_PARALLEL_FETCH_MAX_WORKERS` while preserving page order and honoring cancellation/page-limit checks between batches.
- Introduces `_ReplayableDatalakeEventsSpool`, a disk-backed JSONL spool that lets streaming reports fetch `conversation_classification` events once and replay them for both **Resolutions** and **Unique contacts** worksheets without holding the full dataset in memory.
- Refactors shared datalake fetch logic: `_normalize_datalake_kwargs`, `_fetch_page_indices`, and spool cleanup (`_cleanup_streaming_spools`) are reused by both the parallel and streaming code paths.
- Adds unit tests covering streaming dispatch, parallel iteration (ordering, batching, fallbacks, limits, cancellation), spool prefetch/cleanup, and parallel page fetching.

### Why

Streaming report generation was fetching datalake events sequentially, which made large reports slow. When both Resolutions and Contacts are included, the same classification data is needed twice—parallel fetch improves throughput, and the replayable spool avoids duplicate API calls without loading everything into memory.