### PR TITLE
feat: add StreamingCSVFileProcessor for incremental CSV report generation

### DIFF
--- a/insights/metrics/conversations/reports/file_processors.py
+++ b/insights/metrics/conversations/reports/file_processors.py
@@ -231,3 +231,35 @@ class StreamingXLSXFileProcessor:
                 local_path=tmp_path,
             )
         ]
+
+
+class StreamingCSVFileProcessor:
+    """
+    CSV processor that writes each worksheet to a temp file on disk instead
+    of keeping everything in memory. Accepts generators/iterables for worksheet
+    data so rows can be written incrementally.
+    """
+
+    def write_worksheet(
+        self,
+        name: str,
+        headers: list[str],
+        rows: Iterable[dict],
+    ) -> tuple[ConversationsReportFile, int]:
+        """
+        Write a worksheet from an iterable of row dicts to a temp CSV file.
+        Returns the file reference and the number of data rows written.
+        """
+        tmp_fd, tmp_path = tempfile.mkstemp(suffix=".csv")
+        os.close(tmp_fd)
+
+        row_count = 0
+        with open(tmp_path, "w", encoding="utf-8", newline="") as csv_file:
+            writer = csv.DictWriter(csv_file, fieldnames=headers)
+            writer.writeheader()
+            for row_data in rows:
+                writer.writerow({header: row_data.get(header, "") for header in headers})
+                row_count += 1
+
+        file_name = name[: CSV_FILE_NAME_MAX_LENGTH - 4] + ".csv"
+        return ConversationsReportFile(name=file_name, local_path=tmp_path), row_count

--- a/insights/metrics/conversations/reports/services.py
+++ b/insights/metrics/conversations/reports/services.py
@@ -46,6 +46,7 @@ from insights.metrics.conversations.reports.dataclass import (
 )
 from insights.metrics.conversations.reports.file_processors import (
     get_file_processor,
+    StreamingCSVFileProcessor,
     StreamingXLSXFileProcessor,
 )
 from insights.metrics.conversations.services import ConversationsMetricsService
@@ -1082,7 +1083,7 @@ class ConversationsReportService(BaseConversationsReportService):
 
         report = self._update_report_status(report)
         use_streaming = (
-            report.format == ReportFormat.XLSX
+            report.format in (ReportFormat.XLSX, ReportFormat.CSV)
             and self._is_streaming_mode_enabled(report)
         )
 
@@ -2845,6 +2846,11 @@ class ConversationsReportService(BaseConversationsReportService):
             "Worksheet '%s' has no headers and no materialized rows" % worksheet.name
         )
 
+    def _cleanup_streaming_temp_paths(self, temp_paths: list[str]) -> None:
+        for temp_path in temp_paths:
+            if os.path.exists(temp_path):
+                os.unlink(temp_path)
+
     def _generate_streaming(
         self,
         report: Report,
@@ -2852,37 +2858,65 @@ class ConversationsReportService(BaseConversationsReportService):
         end_date: datetime,
     ) -> list[ConversationsReportFile]:
         """
-        Generate an XLSX report by streaming datalake events page by page
-        and writing worksheet rows directly to a temp file on disk.
+        Generate a report by streaming datalake events page by page and
+        writing worksheet rows directly to temp files on disk.
         """
         self._use_streaming_events = True
         self._streaming_spools = []
-        processor = StreamingXLSXFileProcessor()
-        workbook, tmp_path = processor.create_workbook(report)
+        temp_paths: list[str] = []
+        workbook = None
+        xlsx_tmp_path = None
 
         try:
             worksheets = self._get_worksheets(report, start_date, end_date)
 
-            for ws in worksheets:
-                if self._should_skip_worksheet(ws):
-                    continue
+            if report.format == ReportFormat.XLSX:
+                xlsx_processor = StreamingXLSXFileProcessor()
+                workbook, xlsx_tmp_path = xlsx_processor.create_workbook(report)
+                temp_paths.append(xlsx_tmp_path)
 
-                headers = self._resolve_worksheet_headers(ws)
-                row_count = processor.write_worksheet(
-                    workbook, ws.name, headers, ws.data
-                )
-                logger.info(
-                    "[CONVERSATIONS REPORT SERVICE] Streaming worksheet '%s' wrote %s rows for report %s",
-                    ws.name,
-                    row_count,
-                    report.uuid,
-                )
+                for ws in worksheets:
+                    if self._should_skip_worksheet(ws):
+                        continue
 
-            files = processor.finalize(workbook, tmp_path, report)
+                    headers = self._resolve_worksheet_headers(ws)
+                    row_count = xlsx_processor.write_worksheet(
+                        workbook, ws.name, headers, ws.data
+                    )
+                    logger.info(
+                        "[CONVERSATIONS REPORT SERVICE] Streaming worksheet '%s' wrote %s rows for report %s",
+                        ws.name,
+                        row_count,
+                        report.uuid,
+                    )
+
+                files = xlsx_processor.finalize(workbook, xlsx_tmp_path, report)
+            elif report.format == ReportFormat.CSV:
+                csv_processor = StreamingCSVFileProcessor()
+                files = []
+
+                for ws in worksheets:
+                    if self._should_skip_worksheet(ws):
+                        continue
+
+                    headers = self._resolve_worksheet_headers(ws)
+                    report_file, row_count = csv_processor.write_worksheet(
+                        ws.name, headers, ws.data
+                    )
+                    temp_paths.append(report_file.local_path)
+                    files.append(report_file)
+                    logger.info(
+                        "[CONVERSATIONS REPORT SERVICE] Streaming worksheet '%s' wrote %s rows for report %s",
+                        ws.name,
+                        row_count,
+                        report.uuid,
+                    )
+            else:
+                raise ValueError("Unsupported streaming format: %s" % report.format)
         except Exception:
-            workbook.close()
-            if os.path.exists(tmp_path):
-                os.unlink(tmp_path)
+            if workbook is not None:
+                workbook.close()
+            self._cleanup_streaming_temp_paths(temp_paths)
             raise
         finally:
             self._use_streaming_events = False

--- a/insights/metrics/conversations/reports/tests/test_file_processors.py
+++ b/insights/metrics/conversations/reports/tests/test_file_processors.py
@@ -6,6 +6,7 @@ from insights.metrics.conversations.reports.dataclass import (
 )
 from insights.metrics.conversations.reports.file_processors import (
     CSVFileProcessor,
+    StreamingCSVFileProcessor,
     StreamingXLSXFileProcessor,
     XLSXFileProcessor,
     get_file_processor,
@@ -204,3 +205,30 @@ class TestStreamingXLSXFileProcessor(TestCase):
         self.assertTrue(os.path.exists(tmp_path))
 
         os.unlink(tmp_path)
+
+
+class TestStreamingCSVFileProcessor(TestCase):
+    def setUp(self):
+        self.processor = StreamingCSVFileProcessor()
+
+    def test_write_worksheet_returns_local_path_without_content(self):
+        def row_generator():
+            yield {"col1": "val1", "col2": "val2"}
+
+        report_file, row_count = self.processor.write_worksheet(
+            "Valid",
+            ["col1", "col2"],
+            row_generator(),
+        )
+
+        self.assertEqual(row_count, 1)
+        self.assertEqual(report_file.name, "Valid.csv")
+        self.assertIsNone(report_file.content)
+        self.assertTrue(os.path.exists(report_file.local_path))
+
+        with open(report_file.local_path, encoding="utf-8") as csv_file:
+            content = csv_file.read()
+
+        self.assertEqual(content.splitlines(), ["col1,col2", "val1,val2"])
+
+        os.unlink(report_file.local_path)

--- a/insights/metrics/conversations/reports/tests/test_services.py
+++ b/insights/metrics/conversations/reports/tests/test_services.py
@@ -5448,6 +5448,150 @@ class TestStreamingPrefetch(TestCase):
         self.assertFalse(os.path.exists(spool_paths[0]))
         self.assertEqual(self.service._streaming_spools, [])
 
+    @patch(
+        "insights.metrics.conversations.reports.services.is_feature_active_for_attributes",
+        return_value=True,
+    )
+    @patch.object(ConversationsReportService, "_iter_datalake_events")
+    def test_generate_streaming_csv_returns_local_path_files(
+        self, mock_iter_events, mock_feature_flag
+    ):
+        mock_iter_events.return_value = iter(
+            [
+                {
+                    "contact_urn": "urn:tel:+5511111111111",
+                    "date": "2025-01-01T12:00:00.000000Z",
+                    "value": "resolved",
+                    "metadata": "{}",
+                },
+            ]
+        )
+
+        report = Report.objects.create(
+            project=self.project,
+            source=self.service.source,
+            source_config={"sections": ["RESOLUTIONS"]},
+            filters={"start": "2025-01-01", "end": "2025-01-02"},
+            format=ReportFormat.CSV,
+            requested_by=self.user,
+            status=ReportStatus.IN_PROGRESS,
+        )
+
+        files = self.service._generate_streaming(
+            report,
+            datetime(2025, 1, 1),
+            datetime(2025, 1, 2),
+        )
+
+        self.assertGreaterEqual(len(files), 1)
+        for report_file in files:
+            self.assertTrue(report_file.name.endswith(".csv"))
+            self.assertIsNone(report_file.content)
+            self.assertIsNotNone(report_file.local_path)
+            self.assertTrue(os.path.exists(report_file.local_path))
+
+        with open(files[0].local_path, encoding="utf-8") as csv_file:
+            content = csv_file.read()
+
+        self.assertIn("URN", content)
+        self.assertIn("urn:tel:+5511111111111", content)
+
+        for report_file in files:
+            if report_file.local_path and os.path.exists(report_file.local_path):
+                os.unlink(report_file.local_path)
+
+    @patch(
+        "insights.metrics.conversations.reports.services.is_feature_active_for_attributes",
+        return_value=True,
+    )
+    @patch.object(ConversationsReportService, "_iter_datalake_events")
+    def test_generate_streaming_csv_cleans_up_spool_files(
+        self, mock_iter_events, mock_feature_flag
+    ):
+        mock_iter_events.return_value = iter(
+            [
+                {
+                    "contact_urn": "urn:tel:+5511111111111",
+                    "date": "2025-01-01T12:00:00.000000Z",
+                    "value": "resolved",
+                    "metadata": "{}",
+                },
+            ]
+        )
+
+        report = Report.objects.create(
+            project=self.project,
+            source=self.service.source,
+            source_config={"sections": ["RESOLUTIONS", "CONTACTS"]},
+            filters={"start": "2025-01-01", "end": "2025-01-02"},
+            format=ReportFormat.CSV,
+            requested_by=self.user,
+            status=ReportStatus.IN_PROGRESS,
+        )
+
+        spool_paths = []
+
+        from insights.metrics.conversations.reports import services as services_module
+
+        original_spool_factory = (
+            services_module._ReplayableDatalakeEventsSpool.from_parallel_fetch
+        )
+
+        def spool_factory(service, report, **kwargs):
+            spool = original_spool_factory(service, report, **kwargs)
+            spool_paths.append(spool.path)
+            return spool
+
+        with patch.object(
+            services_module._ReplayableDatalakeEventsSpool,
+            "from_parallel_fetch",
+            side_effect=spool_factory,
+        ):
+            files = self.service._generate_streaming(
+                report,
+                datetime(2025, 1, 1),
+                datetime(2025, 1, 2),
+            )
+
+        self.assertGreaterEqual(len(files), 1)
+        self.assertEqual(len(spool_paths), 1)
+        self.assertFalse(os.path.exists(spool_paths[0]))
+        self.assertEqual(self.service._streaming_spools, [])
+
+        for report_file in files:
+            if report_file.local_path and os.path.exists(report_file.local_path):
+                os.unlink(report_file.local_path)
+
+    @patch(
+        "insights.metrics.conversations.reports.services.ConversationsReportService.send_email"
+    )
+    @patch.object(ConversationsReportService, "_generate_streaming")
+    @patch.object(
+        ConversationsReportService, "_is_streaming_mode_enabled", return_value=True
+    )
+    def test_generate_dispatches_to_streaming_for_csv(
+        self, mock_streaming_enabled, mock_generate_streaming, mock_send_email
+    ):
+        mock_generate_streaming.return_value = [
+            ConversationsReportFile(name="Resolutions.csv", local_path="/tmp/test.csv")
+        ]
+        mock_send_email.return_value = None
+
+        report = Report.objects.create(
+            project=self.project,
+            source=self.service.source,
+            source_config={"sections": ["RESOLUTIONS"]},
+            filters={"start": "2025-01-01", "end": "2025-01-02"},
+            format=ReportFormat.CSV,
+            requested_by=self.user,
+            status=ReportStatus.PENDING,
+        )
+
+        self.service.generate(report)
+
+        mock_generate_streaming.assert_called_once()
+        mock_send_email.assert_called_once()
+
 
 class TestGetDatalakeEventsInParallel(TestCase):
     def setUp(self):


### PR DESCRIPTION
### What

- Adds `StreamingCSVFileProcessor`, which writes each worksheet incrementally to a temp CSV file on disk instead of holding all rows in memory.
- Extends streaming report generation to CSV format (previously only XLSX was supported when streaming mode is enabled).
- Refactors `_generate_streaming()` to branch by format:
    - **XLSX**: single workbook via `StreamingXLSXFileProcessor` (unchanged behavior).
    - **CSV**: one temp CSV file per worksheet via `StreamingCSVFileProcessor`.
- Adds `_cleanup_streaming_temp_paths()` for consistent temp-file cleanup on error.
- Adds unit and integration tests for the new processor and CSV streaming paths.

### Why

Large CSV conversation reports previously loaded all datalake events into memory before writing output, which could cause high memory usage or failures on big date ranges. XLSX already had a streaming path that processes datalake events page by page and writes rows directly to disk. This change brings CSV to the same streaming model so both formats can handle large reports efficiently when the streaming feature flag is active.

### Sequence diagram

```mermaid
sequenceDiagram
    participant Client
    participant ReportService as ConversationsReportService
    participant FeatureFlag as Feature flag check
    participant Datalake as Datalake events
    participant CSVProcessor as StreamingCSVFileProcessor
    participant Disk as Temp files on disk
    participant Email as Email delivery

    Client->>ReportService: generate(report, format=CSV)
    ReportService->>ReportService: _update_report_status(IN_PROGRESS)
    ReportService->>FeatureFlag: _is_streaming_mode_enabled(report)
    FeatureFlag-->>ReportService: true

    ReportService->>ReportService: _generate_streaming(report, dates)
    ReportService->>ReportService: _use_streaming_events = true

    ReportService->>Datalake: _get_worksheets() (page-by-page via _iter_datalake_events)
    Datalake-->>ReportService: worksheets with row generators

    loop For each worksheet
        ReportService->>ReportService: _resolve_worksheet_headers(ws)
        ReportService->>CSVProcessor: write_worksheet(name, headers, ws.data)
        CSVProcessor->>Disk: mkstemp + write header + stream rows
        CSVProcessor-->>ReportService: ConversationsReportFile(local_path), row_count
    end

    ReportService->>ReportService: _cleanup_streaming_spools()
    ReportService-->>ReportService: list of CSV files (local_path, no content)

    alt Success
        ReportService->>Email: send_email(report, files)
        Email-->>Client: Report delivered
    else Error during generation
        ReportService->>ReportService: _cleanup_streaming_temp_paths(temp_paths)
        ReportService-->>Client: Exception raised
    end
```