### PR TITLE
chore: remove redundant capture_message on orders fetch error

### DIFF
--- a/insights/sources/orders/clients.py
+++ b/insights/sources/orders/clients.py
@@ -132,11 +132,6 @@ class VtexOrdersRestClient(VtexAuthentication):
             response = requests.get(endpoint, headers=self.headers, timeout=timeout)
 
         if not response.ok:
-            capture_message(
-                f"Error fetching orders. URL: {endpoint}. Status code: {response.status_code}. Response: {response.text}",
-                level="error",
-            )
-
             response_details = {
                 "status_code": response.status_code,
                 "text": response.text,

--- a/insights/sources/tests/orders/test_clients.py
+++ b/insights/sources/tests/orders/test_clients.py
@@ -172,8 +172,7 @@ class TestVtexOrdersRestClient(TestCase):
         # We can add more assertions about the URL and headers if needed
 
     @patch("insights.sources.orders.clients.requests.get")
-    @patch("insights.sources.orders.clients.capture_message")
-    def test_get_orders_list_direct_error(self, mock_capture_message, mock_get):
+    def test_get_orders_list_direct_error(self, mock_get):
         mock_response = MagicMock()
         mock_response.ok = False
         mock_response.status_code = 500
@@ -186,7 +185,6 @@ class TestVtexOrdersRestClient(TestCase):
 
         self.assertFalse(response.ok)
         mock_get.assert_called_once()
-        mock_capture_message.assert_called_once()
 
     @patch("insights.sources.orders.clients.requests.post")
     def test_get_orders_list_io_proxy_success(self, mock_post):
@@ -204,8 +202,7 @@ class TestVtexOrdersRestClient(TestCase):
         # We can add more assertions about the URL, headers and json body if needed
 
     @patch("insights.sources.orders.clients.requests.post")
-    @patch("insights.sources.orders.clients.capture_message")
-    def test_get_orders_list_io_proxy_error(self, mock_capture_message, mock_post):
+    def test_get_orders_list_io_proxy_error(self, mock_post):
         mock_response = MagicMock()
         mock_response.ok = False
         mock_response.status_code = 400
@@ -218,7 +215,6 @@ class TestVtexOrdersRestClient(TestCase):
 
         self.assertFalse(response.ok)
         mock_post.assert_called_once()
-        mock_capture_message.assert_called_once()
 
     def test_parse_datetime_valid(self):
         date_str_z = "2023-10-26T10:00:00+00:00"


### PR DESCRIPTION
### What
Removes the `capture_message` Sentry call from the error handling path in `get_orders_list` when a non-OK response is received from the orders endpoint.

### Why
The `capture_message` call was logging errors to Sentry at the point of a failed HTTP response, which was likely redundant or causing noise — the error details (`status_code`, `text`) are still preserved in `response_details` for downstream handling. Removing this call reduces unnecessary Sentry noise while retaining the structured error information needed for proper exception handling.