### PR TITLE
feat: add SEARCH_TERMS and ADDED_TO_CART widgets to available widgets list

### DIFF
--- a/insights/metrics/conversations/enums.py
+++ b/insights/metrics/conversations/enums.py
@@ -48,6 +48,8 @@ class AvailableWidgets(TextChoices):
     """
 
     SALES_FUNNEL = "SALES_FUNNEL"
+    SEARCH_TERMS = "SEARCH_TERMS"
+    ADDED_TO_CART = "ADDED_TO_CART"
 
 
 class AbsoluteNumbersMetricsType(TextChoices):

--- a/insights/metrics/conversations/mock/services.py
+++ b/insights/metrics/conversations/mock/services.py
@@ -23,6 +23,7 @@ from insights.metrics.conversations.dataclass import (
     UniqueContactsMetricsData,
 )
 from insights.metrics.conversations.enums import (
+    AvailableWidgets,
     AvailableWidgetsListType,
     ConversationType,
     CsatMetricsType,
@@ -288,7 +289,13 @@ class MockConversationsMetricsService(BaseConversationsMetricsService):
     def get_available_widgets(
         self, project_uuid: UUID, widget_type: AvailableWidgetsListType | None = None
     ) -> AvailableWidgetsList:
-        return []
+        return AvailableWidgetsList(
+            available_widgets=[
+                AvailableWidgets.SALES_FUNNEL,
+                AvailableWidgets.SEARCH_TERMS,
+                AvailableWidgets.ADDED_TO_CART,
+            ]
+        )
 
     def get_contacts_metrics(
         self,

--- a/insights/metrics/conversations/services.py
+++ b/insights/metrics/conversations/services.py
@@ -1022,6 +1022,12 @@ class ConversationsMetricsService(
         if self.check_if_sales_funnel_data_exists(project_uuid):
             available_widgets.append(AvailableWidgets.SALES_FUNNEL)
 
+        if self.get_concierge_agent_use_case.execute(project_uuid):
+            available_widgets.append(AvailableWidgets.SEARCH_TERMS)
+
+        if self.get_payment_agent_use_case.execute(project_uuid):
+            available_widgets.append(AvailableWidgets.ADDED_TO_CART)
+
         return available_widgets
 
     def get_available_widgets(

--- a/insights/metrics/conversations/tests/test_services.py
+++ b/insights/metrics/conversations/tests/test_services.py
@@ -886,15 +886,25 @@ class TestConversationsMetricsService(TestCase):
 
     def test_get_available_widgets(self):
         self.mock_check_sales_funnel_use_case.execute.return_value = True
+        self.mock_get_concierge_agent_use_case.execute.return_value = None
+        self.mock_get_payment_agent_use_case.execute.return_value = None
         available_widgets = self.service.get_available_widgets(self.project.uuid)
 
         self.assertIsInstance(available_widgets, AvailableWidgetsList)
         self.assertEqual(
             available_widgets.available_widgets, [AvailableWidgets.SALES_FUNNEL]
         )
+        self.mock_get_concierge_agent_use_case.execute.assert_called_once_with(
+            self.project.uuid
+        )
+        self.mock_get_payment_agent_use_case.execute.assert_called_once_with(
+            self.project.uuid
+        )
 
     def test_get_available_widgets_with_native_type(self):
         self.mock_check_sales_funnel_use_case.execute.return_value = True
+        self.mock_get_concierge_agent_use_case.execute.return_value = None
+        self.mock_get_payment_agent_use_case.execute.return_value = None
         available_widgets = self.service.get_available_widgets(
             self.project.uuid, AvailableWidgetsListType.NATIVE
         )
@@ -910,6 +920,78 @@ class TestConversationsMetricsService(TestCase):
         )
 
         self.assertIsInstance(available_widgets, AvailableWidgetsList)
+        self.assertEqual(available_widgets.available_widgets, [])
+        self.mock_get_concierge_agent_use_case.execute.assert_not_called()
+        self.mock_get_payment_agent_use_case.execute.assert_not_called()
+
+    def test_get_available_widgets_with_search_terms_and_added_to_cart(self):
+        self.mock_check_sales_funnel_use_case.execute.return_value = True
+        self.mock_get_concierge_agent_use_case.execute.return_value = (
+            "11111111-1111-1111-1111-111111111111"
+        )
+        self.mock_get_payment_agent_use_case.execute.return_value = (
+            "22222222-2222-2222-2222-222222222222"
+        )
+
+        available_widgets = self.service.get_available_widgets(self.project.uuid)
+
+        self.assertEqual(
+            available_widgets.available_widgets,
+            [
+                AvailableWidgets.SALES_FUNNEL,
+                AvailableWidgets.SEARCH_TERMS,
+                AvailableWidgets.ADDED_TO_CART,
+            ],
+        )
+        self.mock_get_concierge_agent_use_case.execute.assert_called_once_with(
+            self.project.uuid
+        )
+        self.mock_get_payment_agent_use_case.execute.assert_called_once_with(
+            self.project.uuid
+        )
+
+    def test_get_available_widgets_with_only_search_terms(self):
+        self.mock_check_sales_funnel_use_case.execute.return_value = False
+        self.mock_get_concierge_agent_use_case.execute.return_value = (
+            "11111111-1111-1111-1111-111111111111"
+        )
+        self.mock_get_payment_agent_use_case.execute.return_value = None
+
+        with patch(
+            "insights.metrics.conversations.tasks.check_project_sales_funnel_on_datalake"
+        ):
+            available_widgets = self.service.get_available_widgets(self.project.uuid)
+
+        self.assertEqual(
+            available_widgets.available_widgets, [AvailableWidgets.SEARCH_TERMS]
+        )
+
+    def test_get_available_widgets_with_only_added_to_cart(self):
+        self.mock_check_sales_funnel_use_case.execute.return_value = False
+        self.mock_get_concierge_agent_use_case.execute.return_value = None
+        self.mock_get_payment_agent_use_case.execute.return_value = (
+            "22222222-2222-2222-2222-222222222222"
+        )
+
+        with patch(
+            "insights.metrics.conversations.tasks.check_project_sales_funnel_on_datalake"
+        ):
+            available_widgets = self.service.get_available_widgets(self.project.uuid)
+
+        self.assertEqual(
+            available_widgets.available_widgets, [AvailableWidgets.ADDED_TO_CART]
+        )
+
+    def test_get_available_widgets_without_agent_widgets(self):
+        self.mock_check_sales_funnel_use_case.execute.return_value = False
+        self.mock_get_concierge_agent_use_case.execute.return_value = None
+        self.mock_get_payment_agent_use_case.execute.return_value = None
+
+        with patch(
+            "insights.metrics.conversations.tasks.check_project_sales_funnel_on_datalake"
+        ):
+            available_widgets = self.service.get_available_widgets(self.project.uuid)
+
         self.assertEqual(available_widgets.available_widgets, [])
 
     def test_get_crosstab_data_when_widget_type_is_invalid(self):


### PR DESCRIPTION
### What
Two new widget types — `SEARCH_TERMS` and `ADDED_TO_CART` — have been added to the `AvailableWidgets` enum. The `_get_native_available_widgets` method in the conversations service now conditionally includes these widgets based on whether a concierge agent or a payment agent exists for the given project, using `get_concierge_agent_use_case` and `get_payment_agent_use_case` respectively.

### Why
Previously, the available widgets list only surfaced the `SALES_FUNNEL` widget for native widget types. Projects using concierge or payment agents had no dedicated widgets to expose search term analytics or cart addition data. This change enables those projects to surface the relevant widgets dynamically, giving consumers of the API visibility into agent-specific commerce metrics.

### Sequence diagram
```mermaid
sequenceDiagram
    participant Client
    participant Service
    participant ConciergeUseCase
    participant PaymentUseCase

    Client->>Service: get_available_widgets(project_uuid)
    Service->>Service: check_if_sales_funnel_data_exists(project_uuid)
    Service->>ConciergeUseCase: execute(project_uuid)
    ConciergeUseCase-->>Service: concierge_agent_uuid or None
    Service->>PaymentUseCase: execute(project_uuid)
    PaymentUseCase-->>Service: payment_agent_uuid or None
    Service-->>Client: AvailableWidgetsList([SALES_FUNNEL?, SEARCH_TERMS?, ADDED_TO_CART?])
```