### PR TITLE
feat: removing uuid from agent source

### DIFF
--- a/insights/sources/agents/query_builder.py
+++ b/insights/sources/agents/query_builder.py
@@ -17,6 +17,6 @@ class AgentSQLQueryBuilder:
     def list(self):
         if not self.is_valid:
             self.build_query()
-        query = f"SELECT pp.uuid, u.email, CONCAT(u.first_name, ' ', u.last_name) AS name FROM public.projects_projectpermission AS pp INNER JOIN public.accounts_user AS u ON u.email=pp.user_id WHERE {self.where_clause};"
+        query = f"SELECT u.email, CONCAT(u.first_name, ' ', u.last_name) AS name FROM public.projects_projectpermission AS pp INNER JOIN public.accounts_user AS u ON u.email=pp.user_id WHERE {self.where_clause};"
 
         return query, self.params


### PR DESCRIPTION
### What
removing user uuid from query builder return
### Why
avoid show the uuid that can be used as a external token

