### PR TITLE
fix: update available widgets logic in ConversationsReportService

### DIFF
--- a/insights/metrics/conversations/reports/services.py
+++ b/insights/metrics/conversations/reports/services.py
@@ -30,14 +30,12 @@ from insights.metrics.conversations.exceptions import (
     SearchTermsAgentUUIDNotConfiguredError,
 )
 from insights.metrics.conversations.reports.available_widgets import (
-    get_added_to_cart_widget,
     get_crosstab_widgets,
     get_csat_ai_widget,
     get_csat_human_widget,
     get_custom_widgets,
     get_nps_ai_widget,
     get_nps_human_widget,
-    get_search_term_widget,
 )
 from insights.metrics.conversations.reports.dataclass import (
     AvailableReportWidgets,
@@ -2954,9 +2952,13 @@ class ConversationsReportService(BaseConversationsReportService):
             "CONTACTS",
         ]
 
+        if self.get_payment_agent_use_case.execute(project.uuid):
+            available_widgets.append("ADDED_TO_CART")
+
+        if self.get_concierge_agent_use_case.execute(project.uuid):
+            available_widgets.append("SEARCH_TERMS")
+
         special_widgets_get_functions = [
-            (get_added_to_cart_widget, "ADDED_TO_CART"),
-            (get_search_term_widget, "SEARCH_TERMS"),
             (get_csat_ai_widget, "CSAT_AI"),
             (get_csat_human_widget, "CSAT_HUMAN"),
             (get_nps_ai_widget, "NPS_AI"),

--- a/insights/metrics/conversations/reports/tests/test_services.py
+++ b/insights/metrics/conversations/reports/tests/test_services.py
@@ -2209,10 +2209,8 @@ class TestConversationsReportServiceAdditional(TestCase):
     @patch("insights.metrics.conversations.reports.services.get_csat_human_widget")
     @patch("insights.metrics.conversations.reports.services.get_nps_ai_widget")
     @patch("insights.metrics.conversations.reports.services.get_csat_ai_widget")
-    @patch("insights.metrics.conversations.reports.services.get_search_term_widget")
     def test_get_available_widgets_basic_only(
         self,
-        mock_get_search_term_widget,
         mock_get_csat_ai_widget,
         mock_get_nps_ai_widget,
         mock_get_csat_human_widget,
@@ -2221,7 +2219,8 @@ class TestConversationsReportServiceAdditional(TestCase):
         mock_get_crosstab_widgets,
     ):
         """Test get_available_widgets with only basic widgets (no special widgets)."""
-        mock_get_search_term_widget.return_value = False
+        self.mock_get_payment_agent_use_case.execute.return_value = None
+        self.mock_get_concierge_agent_use_case.execute.return_value = None
         mock_get_csat_ai_widget.return_value = None
         mock_get_nps_ai_widget.return_value = None
         mock_get_csat_human_widget.return_value = None
@@ -2244,7 +2243,12 @@ class TestConversationsReportServiceAdditional(TestCase):
         self.assertEqual(result.custom_widgets, [])
         self.assertEqual(result.crosstab_widgets, [])
 
-        mock_get_search_term_widget.assert_called_once_with(self.project)
+        self.mock_get_payment_agent_use_case.execute.assert_called_once_with(
+            self.project.uuid
+        )
+        self.mock_get_concierge_agent_use_case.execute.assert_called_once_with(
+            self.project.uuid
+        )
         mock_get_csat_ai_widget.assert_called_once_with(self.project)
         mock_get_nps_ai_widget.assert_called_once_with(self.project)
         mock_get_csat_human_widget.assert_called_once_with(self.project)
@@ -2258,12 +2262,8 @@ class TestConversationsReportServiceAdditional(TestCase):
     @patch("insights.metrics.conversations.reports.services.get_csat_human_widget")
     @patch("insights.metrics.conversations.reports.services.get_nps_ai_widget")
     @patch("insights.metrics.conversations.reports.services.get_csat_ai_widget")
-    @patch("insights.metrics.conversations.reports.services.get_search_term_widget")
-    @patch("insights.metrics.conversations.reports.services.get_added_to_cart_widget")
     def test_get_available_widgets_with_special_widgets(
         self,
-        mock_get_added_to_cart_widget,
-        mock_get_search_term_widget,
         mock_get_csat_ai_widget,
         mock_get_nps_ai_widget,
         mock_get_csat_human_widget,
@@ -2272,14 +2272,6 @@ class TestConversationsReportServiceAdditional(TestCase):
         mock_get_crosstab_widgets,
     ):
         """Test get_available_widgets with special widgets available."""
-        mock_added_to_cart_widget = Widget.objects.create(
-            name="Added to Cart Widget",
-            config={},
-            source="conversations.product_added_to_cart",
-            type="conversations.product_added_to_cart",
-            position=[1, 2],
-            dashboard=self.dashboard,
-        )
         mock_csat_ai_widget = Widget.objects.create(
             name="CSAT AI Widget",
             config={"datalake_config": {"agent_uuid": "test-uuid"}},
@@ -2321,8 +2313,12 @@ class TestConversationsReportServiceAdditional(TestCase):
             dashboard=self.dashboard,
         )
 
-        mock_get_added_to_cart_widget.return_value = mock_added_to_cart_widget
-        mock_get_search_term_widget.return_value = True
+        self.mock_get_payment_agent_use_case.execute.return_value = (
+            "22222222-2222-2222-2222-222222222222"
+        )
+        self.mock_get_concierge_agent_use_case.execute.return_value = (
+            "11111111-1111-1111-1111-111111111111"
+        )
         mock_get_csat_ai_widget.return_value = mock_csat_ai_widget
         mock_get_nps_ai_widget.return_value = mock_nps_ai_widget
         mock_get_csat_human_widget.return_value = mock_csat_human_widget
@@ -2350,6 +2346,12 @@ class TestConversationsReportServiceAdditional(TestCase):
         self.assertEqual(result.sections, expected_sections)
         self.assertEqual(result.custom_widgets, [])
         self.assertEqual(result.crosstab_widgets, [])
+        self.mock_get_payment_agent_use_case.execute.assert_called_once_with(
+            self.project.uuid
+        )
+        self.mock_get_concierge_agent_use_case.execute.assert_called_once_with(
+            self.project.uuid
+        )
 
     @patch("insights.metrics.conversations.reports.services.get_crosstab_widgets")
     @patch("insights.metrics.conversations.reports.services.get_custom_widgets")
@@ -2357,10 +2359,8 @@ class TestConversationsReportServiceAdditional(TestCase):
     @patch("insights.metrics.conversations.reports.services.get_csat_human_widget")
     @patch("insights.metrics.conversations.reports.services.get_nps_ai_widget")
     @patch("insights.metrics.conversations.reports.services.get_csat_ai_widget")
-    @patch("insights.metrics.conversations.reports.services.get_search_term_widget")
     def test_get_available_widgets_with_custom_widgets(
         self,
-        mock_get_search_term_widget,
         mock_get_csat_ai_widget,
         mock_get_nps_ai_widget,
         mock_get_csat_human_widget,
@@ -2369,7 +2369,10 @@ class TestConversationsReportServiceAdditional(TestCase):
         mock_get_crosstab_widgets,
     ):
         """Test get_available_widgets with custom widgets available."""
-        mock_get_search_term_widget.return_value = True
+        self.mock_get_payment_agent_use_case.execute.return_value = None
+        self.mock_get_concierge_agent_use_case.execute.return_value = (
+            "11111111-1111-1111-1111-111111111111"
+        )
         mock_get_csat_ai_widget.return_value = None
         mock_get_nps_ai_widget.return_value = None
         mock_get_csat_human_widget.return_value = None
@@ -2422,12 +2425,8 @@ class TestConversationsReportServiceAdditional(TestCase):
     @patch("insights.metrics.conversations.reports.services.get_csat_human_widget")
     @patch("insights.metrics.conversations.reports.services.get_nps_ai_widget")
     @patch("insights.metrics.conversations.reports.services.get_csat_ai_widget")
-    @patch("insights.metrics.conversations.reports.services.get_search_term_widget")
-    @patch("insights.metrics.conversations.reports.services.get_added_to_cart_widget")
     def test_get_available_widgets_combined(
         self,
-        mock_get_added_to_cart_widget,
-        mock_get_search_term_widget,
         mock_get_csat_ai_widget,
         mock_get_nps_ai_widget,
         mock_get_csat_human_widget,
@@ -2436,8 +2435,12 @@ class TestConversationsReportServiceAdditional(TestCase):
         mock_get_crosstab_widgets,
     ):
         """Test get_available_widgets with all types of widgets available."""
-        mock_get_search_term_widget.return_value = True
-        mock_get_added_to_cart_widget.return_value = None
+        self.mock_get_payment_agent_use_case.execute.return_value = (
+            "22222222-2222-2222-2222-222222222222"
+        )
+        self.mock_get_concierge_agent_use_case.execute.return_value = (
+            "11111111-1111-1111-1111-111111111111"
+        )
         mock_csat_ai_widget = Widget.objects.create(
             name="CSAT AI Widget",
             config={"datalake_config": {"agent_uuid": "test-uuid"}},
@@ -2454,16 +2457,7 @@ class TestConversationsReportServiceAdditional(TestCase):
             position=[1, 2],
             dashboard=self.dashboard,
         )
-        mock_added_to_cart_widget = Widget.objects.create(
-            name="Added to Cart Widget",
-            config={},
-            source="conversations.product_added_to_cart",
-            type="conversations.product_added_to_cart",
-            position=[1, 2],
-            dashboard=self.dashboard,
-        )
 
-        mock_get_added_to_cart_widget.return_value = mock_added_to_cart_widget
         mock_get_csat_ai_widget.return_value = mock_csat_ai_widget
         mock_get_nps_ai_widget.return_value = mock_nps_ai_widget
         mock_get_csat_human_widget.return_value = None
@@ -2506,12 +2500,8 @@ class TestConversationsReportServiceAdditional(TestCase):
     @patch("insights.metrics.conversations.reports.services.get_csat_human_widget")
     @patch("insights.metrics.conversations.reports.services.get_nps_ai_widget")
     @patch("insights.metrics.conversations.reports.services.get_csat_ai_widget")
-    @patch("insights.metrics.conversations.reports.services.get_search_term_widget")
-    @patch("insights.metrics.conversations.reports.services.get_added_to_cart_widget")
     def test_get_available_widgets_partial_special_widgets(
         self,
-        mock_get_added_to_cart_widget,
-        mock_get_search_term_widget,
         mock_get_csat_ai_widget,
         mock_get_nps_ai_widget,
         mock_get_csat_human_widget,
@@ -2520,8 +2510,10 @@ class TestConversationsReportServiceAdditional(TestCase):
         mock_get_crosstab_widgets,
     ):
         """Test get_available_widgets with only some special widgets available."""
-        mock_get_search_term_widget.return_value = True
-        mock_get_added_to_cart_widget.return_value = None
+        self.mock_get_payment_agent_use_case.execute.return_value = None
+        self.mock_get_concierge_agent_use_case.execute.return_value = (
+            "11111111-1111-1111-1111-111111111111"
+        )
         mock_csat_ai_widget = Widget.objects.create(
             name="CSAT AI Widget",
             config={"datalake_config": {"agent_uuid": "test-uuid"}},
@@ -2531,7 +2523,6 @@ class TestConversationsReportServiceAdditional(TestCase):
             dashboard=self.dashboard,
         )
 
-        mock_get_added_to_cart_widget.return_value = None
         mock_get_csat_ai_widget.return_value = mock_csat_ai_widget
         mock_get_nps_ai_widget.return_value = None
         mock_get_csat_human_widget.return_value = None
@@ -2562,10 +2553,8 @@ class TestConversationsReportServiceAdditional(TestCase):
     @patch("insights.metrics.conversations.reports.services.get_csat_human_widget")
     @patch("insights.metrics.conversations.reports.services.get_nps_ai_widget")
     @patch("insights.metrics.conversations.reports.services.get_csat_ai_widget")
-    @patch("insights.metrics.conversations.reports.services.get_search_term_widget")
     def test_get_available_widgets_with_crosstab_widgets(
         self,
-        mock_get_search_term_widget,
         mock_get_csat_ai_widget,
         mock_get_nps_ai_widget,
         mock_get_csat_human_widget,
@@ -2574,7 +2563,10 @@ class TestConversationsReportServiceAdditional(TestCase):
         mock_get_crosstab_widgets,
     ):
         """Test get_available_widgets with crosstab widgets available."""
-        mock_get_search_term_widget.return_value = True
+        self.mock_get_payment_agent_use_case.execute.return_value = None
+        self.mock_get_concierge_agent_use_case.execute.return_value = (
+            "11111111-1111-1111-1111-111111111111"
+        )
         mock_get_csat_ai_widget.return_value = None
         mock_get_nps_ai_widget.return_value = None
         mock_get_csat_human_widget.return_value = None


### PR DESCRIPTION
### What

Updates `ConversationsReportService.get_available_widgets` so `ADDED_TO_CART` and `SEARCH_TERMS` are included based on whether the project has a payment or concierge agent (via the existing use cases), instead of checking for those widgets with `get_added_to_cart_widget` / `get_search_term_widget`. Tests were updated to match.

### Why

Align available-report widgets with agent configuration, so search terms and added-to-cart options show up when the corresponding agents exist on the project, not only when those widgets are already present on the dashboard.