### PR TITLE
feat: jwt auth for vtex io endpoints

### DIFF
--- a/insights/authentication/permissions.py
+++ b/insights/authentication/permissions.py
@@ -150,7 +150,20 @@ class FeatureFlagPermission(permissions.BasePermission):
 
 
 class HasInternalAuthenticationPermission(permissions.BasePermission):
+    """
+    Grants access for App IO / inter-module JWT callers.
+
+    Prefers ``WeniAuthContext`` from ``weni_commons`` (``request.auth.is_jwt``).
+    Falls back to the legacy ``request.jwt_payload`` / ``request.project_uuid``
+    attributes set by ``JWTAuthentication``.
+    """
+
     def has_permission(self, request: Request, view: APIView) -> bool:
+        from weni_commons.auth.context import WeniAuthContext
+
+        if isinstance(request.auth, WeniAuthContext):
+            return request.auth.is_jwt
+
         jwt_payload = getattr(request, "jwt_payload", None)
         project_uuid = getattr(request, "project_uuid", None)
 

--- a/insights/authentication/tests/decorators.py
+++ b/insights/authentication/tests/decorators.py
@@ -3,10 +3,33 @@ import functools
 from django.contrib.auth.models import Permission
 from django.contrib.contenttypes.models import ContentType
 from django.contrib.auth import get_user_model
+from weni_commons.auth import TOKEN_TYPE_KEYCLOAK, WeniAuthContext
 
 from insights.projects.models import ProjectAuth
 
 User = get_user_model()
+
+
+def build_keycloak_auth_context(
+    user,
+    *,
+    project=None,
+    project_uuid=None,
+    vtex_account=None,
+    is_internal: bool = False,
+) -> WeniAuthContext:
+    """Build a Keycloak-style ``WeniAuthContext`` for ``force_authenticate``."""
+    resolved_project_uuid = project_uuid
+    if resolved_project_uuid is None and project is not None:
+        resolved_project_uuid = str(project.uuid)
+
+    return WeniAuthContext(
+        project_uuid=str(resolved_project_uuid) if resolved_project_uuid else None,
+        vtex_account=vtex_account,
+        user_email=getattr(user, "email", None),
+        is_internal=is_internal,
+        token_type=TOKEN_TYPE_KEYCLOAK,
+    )
 
 
 def with_project_auth(func):
@@ -16,6 +39,10 @@ def with_project_auth(func):
         user = self.user
 
         ProjectAuth.objects.create(project=project, user=user, role=1)
+        self.client.force_authenticate(
+            user=user,
+            token=build_keycloak_auth_context(user, project=project),
+        )
 
         return func(self, *args, **kwargs)
 
@@ -32,6 +59,14 @@ def with_internal_auth(func):
             content_type=content_type,
         )
         user.user_permissions.add(permission)
+
+        project = getattr(self, "project", None)
+        self.client.force_authenticate(
+            user=user,
+            token=build_keycloak_auth_context(
+                user, project=project, is_internal=True
+            ),
+        )
 
         return func(self, *args, **kwargs)
 

--- a/insights/authentication/tests/test_authentication.py
+++ b/insights/authentication/tests/test_authentication.py
@@ -16,7 +16,6 @@ from insights.authentication.admin_sso import (
     admin_oidc_logout,
     get_oidc_logout_url,
 )
-from insights.authentication.authentication import JWTAuthentication
 from insights.authentication.permissions import (
     FeatureFlagPermission,
     HasInternalAuthenticationPermission,
@@ -30,8 +29,10 @@ from insights.authentication.services.tests.test_jwt_service import (
     generate_public_key,
     generate_public_key_pem,
 )
+from insights.authentication.weni_auth import weni_authentication_classes
 from insights.dashboards.models import Dashboard
 from insights.projects.models import Project, ProjectAuth
+from weni_commons.auth import WeniAuthViewMixin
 
 User = get_user_model()
 
@@ -43,13 +44,21 @@ TEST_PUBLIC_KEY = generate_public_key(TEST_PRIVATE_KEY)
 TEST_PUBLIC_KEY_PEM = generate_public_key_pem(TEST_PUBLIC_KEY)
 
 
-class MockJWTAuthenticationView(APIView):
-    authentication_classes = [JWTAuthentication]
-    # Same as internal VTEX/conversations views: allow when JWT set request.jwt_payload/project_uuid
+class MockJWTAuthenticationView(WeniAuthViewMixin, APIView):
     permission_classes = [HasInternalAuthenticationPermission]
 
+    @property
+    def authentication_classes(self):
+        return weni_authentication_classes(super().authentication_classes)
+
     def get(self, request):
-        return Response({"status": "ok"}, status=status.HTTP_200_OK)
+        return Response(
+            {
+                "status": "ok",
+                "project_uuid": self.auth.project_uuid,
+            },
+            status=status.HTTP_200_OK,
+        )
 
 
 class TestJWTAuthentication(APITestCase):
@@ -63,19 +72,35 @@ class TestJWTAuthentication(APITestCase):
         project = Project.objects.create(name="Test Project")
         token = self.jwt_service.generate_jwt_token(project_uuid=project.uuid)
         url = reverse("jwt-authentication-view")
-        response = self.client.get(url, HTTP_AUTHORIZATION=f"Bearer {token}")
+        response = self.client.get(url, HTTP_X_WENI_AUTH=token)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.data, {"status": "ok"})
+        self.assertEqual(
+            response.data,
+            {"status": "ok", "project_uuid": str(project.uuid)},
+        )
 
     @override_settings(ROOT_URLCONF="insights.authentication.tests.test_urls")
     @override_settings(JWT_SECRET_KEY=TEST_PRIVATE_KEY_PEM)
     @override_settings(JWT_PUBLIC_KEY=TEST_PUBLIC_KEY_PEM)
-    def test_jwt_authentication_project_not_found(self):
-        token = self.jwt_service.generate_jwt_token(project_uuid=uuid.uuid4())
+    def test_jwt_authentication_via_bearer_header(self):
+        project = Project.objects.create(name="Test Project")
+        token = self.jwt_service.generate_jwt_token(project_uuid=project.uuid)
         url = reverse("jwt-authentication-view")
         response = self.client.get(url, HTTP_AUTHORIZATION=f"Bearer {token}")
-        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
-        self.assertEqual(response.data, {"detail": "Project not found"})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["project_uuid"], str(project.uuid))
+
+    @override_settings(ROOT_URLCONF="insights.authentication.tests.test_urls")
+    @override_settings(JWT_SECRET_KEY=TEST_PRIVATE_KEY_PEM)
+    @override_settings(JWT_PUBLIC_KEY=TEST_PUBLIC_KEY_PEM)
+    def test_jwt_authentication_unknown_project_still_authenticates(self):
+        # Tenant existence is enforced by the view/use case, not by auth.
+        unknown_uuid = uuid.uuid4()
+        token = self.jwt_service.generate_jwt_token(project_uuid=unknown_uuid)
+        url = reverse("jwt-authentication-view")
+        response = self.client.get(url, HTTP_X_WENI_AUTH=token)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["project_uuid"], str(unknown_uuid))
 
     @override_settings(ROOT_URLCONF="insights.authentication.tests.test_urls")
     def test_jwt_authentication_missing_header(self):
@@ -84,6 +109,7 @@ class TestJWTAuthentication(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
 
     @override_settings(ROOT_URLCONF="insights.authentication.tests.test_urls")
+    @override_settings(JWT_PUBLIC_KEY=TEST_PUBLIC_KEY_PEM)
     def test_jwt_authentication_invalid_header(self):
         url = reverse("jwt-authentication-view")
         response = self.client.get(url, HTTP_AUTHORIZATION="Bearer invalid-token")

--- a/insights/authentication/weni_auth.py
+++ b/insights/authentication/weni_auth.py
@@ -1,0 +1,42 @@
+"""Helpers for WeniAuthentication / WeniAuthViewMixin consumers."""
+
+from typing import Mapping, MutableMapping, Sequence
+
+from rest_framework.request import Request
+from weni_commons.auth import WeniAuthentication, get_auth_context
+
+
+def weni_authentication_classes(
+    base_classes: Sequence | None = None,
+) -> list:
+    """
+    Prepend ``WeniAuthentication`` so JWT is tried before OIDC/Token defaults.
+
+    Passing ``base_classes`` keeps existing authenticators. When omitted, returns
+    only WeniAuthentication.
+    """
+    classes = list(base_classes) if base_classes is not None else []
+    if WeniAuthentication not in classes:
+        classes.insert(0, WeniAuthentication)
+    return classes
+
+
+def query_params_with_auth_project_uuid(
+    request: Request,
+    data: Mapping | None = None,
+    *,
+    project_key: str = "project_uuid",
+) -> MutableMapping:
+    """
+    Return a mutable copy of query/body data with tenant forced from auth.
+
+    JWT callers carry an immutable ``project_uuid`` in the token. Overwriting
+    the request value prevents path/query spoofing. Keycloak callers get the
+    same key from the standardized resolver, so the value is consistent.
+    """
+    source = data if data is not None else request.query_params
+    mutable = source.copy()
+    auth = get_auth_context(request)
+    if auth is not None and auth.has_project_uuid:
+        mutable[project_key] = str(auth.project_uuid)
+    return mutable

--- a/insights/internals/api/projects/tests/test_update_vtex_account_view.py
+++ b/insights/internals/api/projects/tests/test_update_vtex_account_view.py
@@ -37,7 +37,10 @@ class TestUpdateProjectVTEXAccountViewAsAnonymousUser(
     def test_cannot_update_vtex_account_when_unauthenticated(self):
         response = self.update_vtex_account(self.project.uuid, {"vtex_account": "xyz"})
 
-        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+        self.assertIn(
+            response.status_code,
+            (status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN),
+        )
 
 
 class TestUpdateProjectVTEXAccountViewAsAuthenticatedUser(
@@ -129,7 +132,10 @@ class TestUpdateProjectVTEXAccountViewWithJWTAuthentication(
 
         response = self.update_vtex_account(self.project.uuid, {"vtex_account": "xyz"})
 
-        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+        self.assertIn(
+            response.status_code,
+            (status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN),
+        )
 
     def test_cannot_update_vtex_account_with_invalid_body_via_jwt(self):
         response = self.update_vtex_account(self.project.uuid, {})
@@ -138,6 +144,25 @@ class TestUpdateProjectVTEXAccountViewWithJWTAuthentication(
         self.assertEqual(response.data["vtex_account"][0].code, "required")
 
     def test_cannot_update_vtex_account_when_project_does_not_exist_via_jwt(self):
-        response = self.update_vtex_account(uuid4(), {"vtex_account": "xyz"})
+        # Tenant comes from the JWT claim, not from the path.
+        missing_project_uuid = uuid4()
+        token = JWTService().generate_jwt_token(missing_project_uuid)
+        self.client.credentials(HTTP_AUTHORIZATION=f"Bearer {token}")
+
+        response = self.update_vtex_account(
+            missing_project_uuid, {"vtex_account": "xyz"}
+        )
 
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_path_project_uuid_cannot_override_jwt_tenant(self):
+        other_project = Project.objects.create(name="Other", vtex_account="other")
+        response = self.update_vtex_account(
+            other_project.uuid, {"vtex_account": "xyz"}
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.project.refresh_from_db()
+        other_project.refresh_from_db()
+        self.assertEqual(self.project.vtex_account, "xyz")
+        self.assertEqual(other_project.vtex_account, "other")

--- a/insights/internals/api/projects/tests/test_update_vtex_account_view.py
+++ b/insights/internals/api/projects/tests/test_update_vtex_account_view.py
@@ -37,10 +37,7 @@ class TestUpdateProjectVTEXAccountViewAsAnonymousUser(
     def test_cannot_update_vtex_account_when_unauthenticated(self):
         response = self.update_vtex_account(self.project.uuid, {"vtex_account": "xyz"})
 
-        self.assertIn(
-            response.status_code,
-            (status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN),
-        )
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
 
 
 class TestUpdateProjectVTEXAccountViewAsAuthenticatedUser(
@@ -132,10 +129,7 @@ class TestUpdateProjectVTEXAccountViewWithJWTAuthentication(
 
         response = self.update_vtex_account(self.project.uuid, {"vtex_account": "xyz"})
 
-        self.assertIn(
-            response.status_code,
-            (status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN),
-        )
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
 
     def test_cannot_update_vtex_account_with_invalid_body_via_jwt(self):
         response = self.update_vtex_account(self.project.uuid, {})

--- a/insights/internals/api/projects/views.py
+++ b/insights/internals/api/projects/views.py
@@ -3,12 +3,13 @@ from rest_framework import status, views
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.request import Request
 from rest_framework.response import Response
+from weni_commons.auth import WeniAuthViewMixin
 
-from insights.authentication.authentication import JWTAuthentication
 from insights.authentication.permissions import (
     HasInternalAuthenticationPermission,
     InternalAuthenticationPermission,
 )
+from insights.authentication.weni_auth import weni_authentication_classes
 from insights.projects.models import Project
 from insights.projects.usecases.update_vtex_account import UpdateProjectVTEXAccount
 
@@ -18,7 +19,7 @@ from .serializers import (
 )
 
 
-class UpdateProjectVTEXAccountView(views.APIView):
+class UpdateProjectVTEXAccountView(WeniAuthViewMixin, views.APIView):
     permission_classes = [
         HasInternalAuthenticationPermission
         | (IsAuthenticated & InternalAuthenticationPermission)
@@ -26,20 +27,17 @@ class UpdateProjectVTEXAccountView(views.APIView):
 
     @property
     def authentication_classes(self):
-        # Try JWT first so Bearer JWT tokens are accepted before OIDC (which would raise on invalid OIDC token)
-        classes = list(super().authentication_classes)
-        if JWTAuthentication not in classes:
-            classes.insert(0, JWTAuthentication)
-        return classes
+        return weni_authentication_classes(super().authentication_classes)
 
     def patch(self, request: Request, project_uuid: str) -> Response:
         serializer = UpdateProjectVTEXAccountRequestSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
 
-        project = get_object_or_404(Project, uuid=project_uuid)
+        # Tenant comes from auth context (JWT claim or Keycloak resolver), never
+        # from a client-controlled path segment alone.
+        project = get_object_or_404(Project, uuid=self.auth.project_uuid)
 
-        user = getattr(request, "user", None)
-        user_email = user.email if user is not None and user.is_authenticated else None
+        user_email = self.user_email
 
         project, projects_unlinked = UpdateProjectVTEXAccount().execute(
             project=project,

--- a/insights/metrics/conversations/api/v1/tests/test_views.py
+++ b/insights/metrics/conversations/api/v1/tests/test_views.py
@@ -250,7 +250,10 @@ class TestConversationsMetricsViewSetAsAnonymousUser(
     def test_cannot_get_totals_when_not_authenticated(self):
         response = self.get_totals({})
 
-        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+        self.assertIn(
+            response.status_code,
+            (status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN),
+        )
 
     def test_cannot_get_csat_metrics_when_unauthenticated(self):
         response = self.get_csat_metrics({})
@@ -1717,7 +1720,10 @@ class TestConversationsMetricsViewSetWithJWTAuthentication(
             }
         )
 
-        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+        self.assertIn(
+            response.status_code,
+            (status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN),
+        )
 
 
 @override_settings(JWT_SECRET_KEY=JWT_PRIVATE_KEY_PEM)
@@ -1784,4 +1790,7 @@ class TestInternalConversationsMetricsViewSetWithJWTAuthentication(
             }
         )
 
-        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+        self.assertIn(
+            response.status_code,
+            (status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN),
+        )

--- a/insights/metrics/conversations/api/v1/tests/test_views.py
+++ b/insights/metrics/conversations/api/v1/tests/test_views.py
@@ -1,6 +1,7 @@
 import uuid
 from unittest.mock import MagicMock, patch
 
+from django.test import override_settings
 from django.urls import reverse
 from rest_framework.test import APITestCase
 from rest_framework.response import Response
@@ -8,6 +9,7 @@ from rest_framework import status
 import json
 
 from insights.authentication.authentication import User
+from insights.authentication.services.jwt_service import JWTService
 from insights.authentication.services.tests.test_jwt_service import (
     generate_private_key,
     generate_private_key_pem,
@@ -1671,3 +1673,115 @@ class TestConversationsMetricsViewSetAsInternalUser(
         )
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+
+@override_settings(JWT_SECRET_KEY=JWT_PRIVATE_KEY_PEM)
+@override_settings(JWT_PUBLIC_KEY=JWT_PUBLIC_KEY_PEM)
+class TestConversationsMetricsViewSetWithJWTAuthentication(
+    BaseTestConversationsMetricsViewSet
+):
+    def setUp(self):
+        self.project = Project.objects.create(name="Test Project")
+        token = JWTService().generate_jwt_token(self.project.uuid)
+        self.client.credentials(HTTP_AUTHORIZATION=f"Bearer {token}")
+
+    @patch(
+        "insights.metrics.conversations.services.ConversationsMetricsService.get_totals"
+    )
+    def test_get_totals_with_jwt(self, mock_get_totals):
+        mock_get_totals.return_value = ConversationsTotalsMetrics(
+            total_conversations=ConversationsTotalsMetric(value=10, percentage=100),
+            resolved=ConversationsTotalsMetric(value=6, percentage=60),
+            unresolved=ConversationsTotalsMetric(value=4, percentage=40),
+            transferred_to_human=ConversationsTotalsMetric(value=0, percentage=0),
+        )
+
+        response = self.get_totals(
+            {
+                "project_uuid": self.project.uuid,
+                "start_date": "2025-01-01",
+                "end_date": "2025-01-01",
+            }
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_get_totals_with_invalid_token(self):
+        self.client.credentials(HTTP_AUTHORIZATION="Bearer invalid_token")
+
+        response = self.get_totals(
+            {
+                "project_uuid": self.project.uuid,
+                "start_date": "2025-01-01",
+                "end_date": "2025-01-01",
+            }
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+
+@override_settings(JWT_SECRET_KEY=JWT_PRIVATE_KEY_PEM)
+@override_settings(JWT_PUBLIC_KEY=JWT_PUBLIC_KEY_PEM)
+class TestInternalConversationsMetricsViewSetWithJWTAuthentication(
+    BaseTestInternalConversationsMetricsViewSet
+):
+    def setUp(self):
+        self.project = Project.objects.create(name="Test Project")
+        token = JWTService().generate_jwt_token(self.project.uuid)
+        self.client.credentials(HTTP_AUTHORIZATION=f"Bearer {token}")
+
+    def test_cannot_get_project_ai_csat_metrics_without_required_fields(self):
+        response = self.get_project_ai_csat_metrics({})
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.data["start_date"][0].code, "required")
+        self.assertEqual(response.data["end_date"][0].code, "required")
+
+    @patch(
+        "insights.metrics.conversations.services.ConversationsMetricsService.get_csat_metrics"
+    )
+    def test_get_project_ai_csat_metrics_with_jwt(self, mock_get_csat_metrics):
+        mock_get_csat_metrics.return_value = {
+            "results": [
+                {
+                    "label": "1",
+                    "value": 100,
+                    "full_value": 100,
+                }
+            ],
+        }
+
+        Widget.objects.create(
+            name="Test Widget",
+            dashboard=Dashboard.objects.create(
+                project=self.project, name="Test Dashboard"
+            ),
+            source="conversations.csat",
+            type="conversations.csat",
+            position=[1, 2],
+            config={"datalake_config": {"agent_uuid": str(uuid.uuid4())}},
+        )
+
+        response = self.get_project_ai_csat_metrics(
+            {
+                "start_date": "2024-01-01",
+                "end_date": "2024-01-31",
+            }
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["results"][0]["label"], "1")
+        self.assertEqual(response.data["results"][0]["value"], 100)
+
+    def test_get_project_ai_csat_metrics_with_invalid_token(self):
+        self.client.credentials(HTTP_AUTHORIZATION="Bearer invalid_token")
+
+        response = self.get_project_ai_csat_metrics(
+            {
+                "project_uuid": self.project.uuid,
+                "start_date": "2024-01-01",
+                "end_date": "2024-01-31",
+            }
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)

--- a/insights/metrics/conversations/api/v1/tests/test_views.py
+++ b/insights/metrics/conversations/api/v1/tests/test_views.py
@@ -250,10 +250,7 @@ class TestConversationsMetricsViewSetAsAnonymousUser(
     def test_cannot_get_totals_when_not_authenticated(self):
         response = self.get_totals({})
 
-        self.assertIn(
-            response.status_code,
-            (status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN),
-        )
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
 
     def test_cannot_get_csat_metrics_when_unauthenticated(self):
         response = self.get_csat_metrics({})
@@ -1720,10 +1717,7 @@ class TestConversationsMetricsViewSetWithJWTAuthentication(
             }
         )
 
-        self.assertIn(
-            response.status_code,
-            (status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN),
-        )
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
 
 
 @override_settings(JWT_SECRET_KEY=JWT_PRIVATE_KEY_PEM)
@@ -1790,7 +1784,4 @@ class TestInternalConversationsMetricsViewSetWithJWTAuthentication(
             }
         )
 
-        self.assertIn(
-            response.status_code,
-            (status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN),
-        )
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)

--- a/insights/metrics/conversations/api/v1/tests/test_views.py
+++ b/insights/metrics/conversations/api/v1/tests/test_views.py
@@ -1601,7 +1601,8 @@ class TestInternalConversationsMetricsViewSetWithInternalAuthentication(
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertEqual(response.data["start_date"][0].code, "required")
         self.assertEqual(response.data["end_date"][0].code, "required")
-        self.assertEqual(response.data["project_uuid"][0].code, "required")
+        # project_uuid comes from auth context, not from the query string
+        self.assertNotIn("project_uuid", response.data)
 
     @with_internal_auth
     @patch(

--- a/insights/metrics/conversations/api/v1/views.py
+++ b/insights/metrics/conversations/api/v1/views.py
@@ -8,11 +8,16 @@ from rest_framework.response import Response
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.exceptions import PermissionDenied
 
-from insights.authentication.authentication import JWTAuthentication
+from weni_commons.auth import WeniAuthViewMixin
+
 from insights.authentication.permissions import (
     HasInternalAuthenticationPermission,
     InternalAuthenticationPermission,
     ProjectAuthQueryParamPermission,
+)
+from insights.authentication.weni_auth import (
+    query_params_with_auth_project_uuid,
+    weni_authentication_classes,
 )
 from insights.metrics.conversations.api.permissions import WidgetQueryParamPermission
 from insights.metrics.conversations.api.decorators import force_use_real_service
@@ -58,7 +63,7 @@ from insights.metrics.conversations.api.v1.serializers import (
 from insights.metrics.conversations.services import (
     ConversationsMetricsService,
 )
-from insights.projects.models import ProjectAuth
+from insights.projects.models import Project, ProjectAuth
 from insights.widgets.permissions import CanViewWidgetQueryParamPermission
 from insights.metrics.conversations.api.mixins import ConversationsMetricsResponseMixin
 
@@ -73,6 +78,7 @@ if TYPE_CHECKING:
 
 
 class ConversationsMetricsViewSet(
+    WeniAuthViewMixin,
     ConversationsMetricsServiceResolverMixin,
     ConversationsMetricsResponseMixin,
     GenericViewSet,
@@ -85,11 +91,7 @@ class ConversationsMetricsViewSet(
 
     @property
     def authentication_classes(self):
-        # Try JWT first so Bearer JWT tokens are accepted before OIDC
-        classes = list(super().authentication_classes)
-        if JWTAuthentication not in classes:
-            classes.insert(0, JWTAuthentication)
-        return classes
+        return weni_authentication_classes(super().authentication_classes)
 
     @action(
         detail=False,
@@ -360,15 +362,12 @@ class ConversationsMetricsViewSet(
         """
 
         query_params_serializer = ConversationTotalsMetricsQueryParamsSerializer(
-            data=request.query_params,
+            data=query_params_with_auth_project_uuid(request),
         )
         query_params_serializer.is_valid(raise_exception=True)
 
-        if not (project_uuid := getattr(request, "project_uuid", None)):
-            project_uuid = query_params_serializer.validated_data["project_uuid"]
-
         totals = self.service.get_totals(
-            project_uuid=project_uuid,
+            project_uuid=self.auth.project_uuid,
             start_date=query_params_serializer.validated_data["start_date"].isoformat(),
             end_date=query_params_serializer.validated_data["end_date"].isoformat(),
         )
@@ -625,7 +624,7 @@ class ConversationsMetricsViewSet(
         return Response(metrics, status=status.HTTP_200_OK)
 
 
-class InternalConversationsMetricsViewSet(GenericViewSet):
+class InternalConversationsMetricsViewSet(WeniAuthViewMixin, GenericViewSet):
     """
     ViewSet to get conversations metrics
     """
@@ -638,11 +637,7 @@ class InternalConversationsMetricsViewSet(GenericViewSet):
 
     @property
     def authentication_classes(self):
-        # Try JWT first so Bearer JWT tokens are accepted before OIDC
-        classes = list(super().authentication_classes)
-        if JWTAuthentication not in classes:
-            classes.insert(0, JWTAuthentication)
-        return classes
+        return weni_authentication_classes(super().authentication_classes)
 
     @action(
         detail=False,
@@ -654,20 +649,18 @@ class InternalConversationsMetricsViewSet(GenericViewSet):
         """
         Get project AI CSAT metrics. Validates input, delegates to use case, returns response.
         """
+        project = Project.objects.filter(uuid=self.auth.project_uuid).first()
         query_params = InternalCsatMetricsQueryParamsSerializer(
             data=request.query_params,
-            context={"project": getattr(request, "project", None)},
+            context={"project": project},
         )
         query_params.is_valid(raise_exception=True)
-
-        if not (project_uuid := getattr(request, "project_uuid", None)):
-            project_uuid = query_params.validated_data.get("project_uuid")
 
         start_date = query_params.validated_data["start_date"]
         end_date = query_params.validated_data["end_date"]
 
         metrics = GetProjectAiCsatMetricsUseCase().execute(
-            project_uuid=project_uuid,
+            project_uuid=self.auth.project_uuid,
             start_date=start_date,
             end_date=end_date,
         )

--- a/insights/metrics/conversations/api/v1/views.py
+++ b/insights/metrics/conversations/api/v1/views.py
@@ -8,7 +8,9 @@ from rest_framework.response import Response
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.exceptions import PermissionDenied
 
+from insights.authentication.authentication import JWTAuthentication
 from insights.authentication.permissions import (
+    HasInternalAuthenticationPermission,
     InternalAuthenticationPermission,
     ProjectAuthQueryParamPermission,
 )
@@ -80,6 +82,14 @@ class ConversationsMetricsViewSet(
     """
 
     permission_classes = [IsAuthenticated, ProjectAuthQueryParamPermission]
+
+    @property
+    def authentication_classes(self):
+        # Try JWT first so Bearer JWT tokens are accepted before OIDC
+        classes = list(super().authentication_classes)
+        if JWTAuthentication not in classes:
+            classes.insert(0, JWTAuthentication)
+        return classes
 
     @action(
         detail=False,
@@ -337,8 +347,11 @@ class ConversationsMetricsViewSet(
         methods=["get"],
         serializer_class=ConversationTotalsMetricsSerializer,
         permission_classes=[
-            IsAuthenticated,
-            (ProjectAuthQueryParamPermission | InternalAuthenticationPermission),
+            HasInternalAuthenticationPermission
+            | (
+                IsAuthenticated
+                & (ProjectAuthQueryParamPermission | InternalAuthenticationPermission)
+            ),
         ],
     )
     def totals(self, request: "Request", *args, **kwargs) -> Response:
@@ -351,8 +364,11 @@ class ConversationsMetricsViewSet(
         )
         query_params_serializer.is_valid(raise_exception=True)
 
+        if not (project_uuid := getattr(request, "project_uuid", None)):
+            project_uuid = query_params_serializer.validated_data["project_uuid"]
+
         totals = self.service.get_totals(
-            project_uuid=query_params_serializer.validated_data["project_uuid"],
+            project_uuid=project_uuid,
             start_date=query_params_serializer.validated_data["start_date"].isoformat(),
             end_date=query_params_serializer.validated_data["end_date"].isoformat(),
         )
@@ -615,7 +631,18 @@ class InternalConversationsMetricsViewSet(GenericViewSet):
     """
 
     service = ConversationsMetricsService()
-    permission_classes = [IsAuthenticated, InternalAuthenticationPermission]
+    permission_classes = [
+        HasInternalAuthenticationPermission
+        | (IsAuthenticated & InternalAuthenticationPermission)
+    ]
+
+    @property
+    def authentication_classes(self):
+        # Try JWT first so Bearer JWT tokens are accepted before OIDC
+        classes = list(super().authentication_classes)
+        if JWTAuthentication not in classes:
+            classes.insert(0, JWTAuthentication)
+        return classes
 
     @action(
         detail=False,

--- a/insights/metrics/meta/tests/test_message_templates_view.py
+++ b/insights/metrics/meta/tests/test_message_templates_view.py
@@ -1044,4 +1044,7 @@ class TestMetaMessageTemplatesViewWithJWTAuthentication(
             }
         )
 
-        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+        self.assertIn(
+            response.status_code,
+            (status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN),
+        )

--- a/insights/metrics/meta/tests/test_message_templates_view.py
+++ b/insights/metrics/meta/tests/test_message_templates_view.py
@@ -4,6 +4,7 @@ from urllib.parse import urlencode
 
 from django.conf import settings
 from django.core.cache import cache
+from django.test import override_settings
 from django.utils import timezone
 from django.utils.timezone import timedelta
 import responses
@@ -12,6 +13,12 @@ from rest_framework.test import APITestCase
 from rest_framework.response import Response
 
 from insights.authentication.authentication import User
+from insights.authentication.services.jwt_service import JWTService
+from insights.authentication.services.tests.test_jwt_service import (
+    generate_private_key,
+    generate_private_key_pem,
+    generate_public_key_pem,
+)
 from insights.authentication.tests.decorators import (
     with_project_auth,
 )
@@ -36,6 +43,10 @@ from insights.metrics.meta.tests.mock import (
     MOCK_TEMPLATE_DAILY_ANALYTICS,
     MOCK_TEMPLATES_LIST_BODY,
 )
+
+JWT_PRIVATE_KEY = generate_private_key()
+JWT_PRIVATE_KEY_PEM = generate_private_key_pem(JWT_PRIVATE_KEY)
+JWT_PUBLIC_KEY_PEM = generate_public_key_pem(JWT_PRIVATE_KEY.public_key())
 
 
 class BaseTestMetaMessageTemplatesView(APITestCase):
@@ -984,3 +995,53 @@ class TestMetaMessageTemplatesViewAsAuthenticatedUser(BaseTestMetaMessageTemplat
             response.data,
             {"templates": {"SERVICE": 10, "MARKETING": 20}},
         )
+
+
+@override_settings(JWT_SECRET_KEY=JWT_PRIVATE_KEY_PEM)
+@override_settings(JWT_PUBLIC_KEY=JWT_PUBLIC_KEY_PEM)
+class TestMetaMessageTemplatesViewWithJWTAuthentication(
+    BaseTestMetaMessageTemplatesView
+):
+    def setUp(self):
+        self.project = Project.objects.create(name="Test Project")
+        token = JWTService().generate_jwt_token(self.project.uuid)
+        self.client.credentials(HTTP_AUTHORIZATION=f"Bearer {token}")
+
+    @patch(
+        "insights.metrics.meta.clients.MetaGraphAPIClient.get_conversations_by_category"
+    )
+    def test_get_conversations_by_category_with_jwt(
+        self, mock_get_conversations_by_category
+    ):
+        mock_get_conversations_by_category.return_value = (
+            MOCK_CONVERSATIONS_BY_CATEGORY_RESPONSE_BODY
+        )
+
+        response = self.get_conversations_by_category(
+            {
+                "project": self.project.uuid,
+                "waba_id": "1234567890987654",
+                "start_date": "2024-01-01",
+                "end_date": "2024-01-31",
+            }
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(
+            response.data,
+            {"templates": {"SERVICE": 10, "MARKETING": 20}},
+        )
+
+    def test_get_conversations_by_category_with_invalid_token(self):
+        self.client.credentials(HTTP_AUTHORIZATION="Bearer invalid_token")
+
+        response = self.get_conversations_by_category(
+            {
+                "project": self.project.uuid,
+                "waba_id": "1234567890987654",
+                "start_date": "2024-01-01",
+                "end_date": "2024-01-31",
+            }
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)

--- a/insights/metrics/meta/tests/test_message_templates_view.py
+++ b/insights/metrics/meta/tests/test_message_templates_view.py
@@ -1044,7 +1044,4 @@ class TestMetaMessageTemplatesViewWithJWTAuthentication(
             }
         )
 
-        self.assertIn(
-            response.status_code,
-            (status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN),
-        )
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)

--- a/insights/metrics/meta/views.py
+++ b/insights/metrics/meta/views.py
@@ -11,11 +11,16 @@ from rest_framework.exceptions import ValidationError
 from rest_framework.viewsets import GenericViewSet
 from sentry_sdk import capture_exception
 
-from insights.authentication.authentication import JWTAuthentication
+from weni_commons.auth import WeniAuthViewMixin
+
 from insights.authentication.permissions import (
     HasInternalAuthenticationPermission,
     InternalAuthenticationPermission,
     ProjectAuthQueryParamPermission,
+)
+from insights.authentication.weni_auth import (
+    query_params_with_auth_project_uuid,
+    weni_authentication_classes,
 )
 from insights.metrics.meta.choices import (
     WhatsAppMessageTemplatesCategories,
@@ -60,7 +65,7 @@ from insights.sources.integrations.clients import WeniIntegrationsClient
 logger = logging.getLogger(__name__)
 
 
-class WhatsAppMessageTemplatesView(GenericViewSet):
+class WhatsAppMessageTemplatesView(WeniAuthViewMixin, GenericViewSet):
     service = MetaMessageTemplatesService()
     permission_classes = [
         IsAuthenticated,
@@ -70,11 +75,7 @@ class WhatsAppMessageTemplatesView(GenericViewSet):
 
     @property
     def authentication_classes(self):
-        # Try JWT first so Bearer JWT tokens are accepted before OIDC
-        classes = list(super().authentication_classes)
-        if JWTAuthentication not in classes:
-            classes.insert(0, JWTAuthentication)
-        return classes
+        return weni_authentication_classes(super().authentication_classes)
 
     @property
     def project_uuid_field(self):
@@ -329,8 +330,9 @@ class WhatsAppMessageTemplatesView(GenericViewSet):
         ],
     )
     def get_conversations_by_category(self, request: Request) -> Response:
+        # Force tenant from auth so query ``project`` cannot override JWT claims.
         serializer = ConversationsByCategoryQueryParamsSerializer(
-            data=request.query_params
+            data=query_params_with_auth_project_uuid(request, project_key="project")
         )
         serializer.is_valid(raise_exception=True)
 

--- a/insights/metrics/meta/views.py
+++ b/insights/metrics/meta/views.py
@@ -11,7 +11,9 @@ from rest_framework.exceptions import ValidationError
 from rest_framework.viewsets import GenericViewSet
 from sentry_sdk import capture_exception
 
+from insights.authentication.authentication import JWTAuthentication
 from insights.authentication.permissions import (
+    HasInternalAuthenticationPermission,
     InternalAuthenticationPermission,
     ProjectAuthQueryParamPermission,
 )
@@ -65,6 +67,14 @@ class WhatsAppMessageTemplatesView(GenericViewSet):
         ProjectAuthQueryParamPermission,
         ProjectDashboardWABAPermission,
     ]
+
+    @property
+    def authentication_classes(self):
+        # Try JWT first so Bearer JWT tokens are accepted before OIDC
+        classes = list(super().authentication_classes)
+        if JWTAuthentication not in classes:
+            classes.insert(0, JWTAuthentication)
+        return classes
 
     @property
     def project_uuid_field(self):
@@ -308,10 +318,13 @@ class WhatsAppMessageTemplatesView(GenericViewSet):
         url_name="conversations-by-category",
         url_path="conversations-by-category",
         permission_classes=[
-            IsAuthenticated,
-            (
-                (ProjectAuthQueryParamPermission & ProjectDashboardWABAPermission)
-                | InternalAuthenticationPermission
+            HasInternalAuthenticationPermission
+            | (
+                IsAuthenticated
+                & (
+                    (ProjectAuthQueryParamPermission & ProjectDashboardWABAPermission)
+                    | InternalAuthenticationPermission
+                )
             ),
         ],
     )

--- a/insights/metrics/skills/tests/test_views.py
+++ b/insights/metrics/skills/tests/test_views.py
@@ -36,7 +36,12 @@ class TestSkillsMetricsViewAsAnonymousUser(BaseTestSkillsMetrisView):
     def test_cannot_get_metrics_for_skill_when_unauthenticated(self):
         response = self.get_metrics_for_skill({})
 
-        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+        # WeniAuthentication currently has no authenticate_header → DRF returns 403.
+        # If commons adds it, this may become 401 again.
+        self.assertIn(
+            response.status_code,
+            (status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN),
+        )
 
 
 class TestSkillsMetricsViewAsAuthenticatedUser(BaseTestSkillsMetrisView):
@@ -203,4 +208,7 @@ class TestSkillsMetricsViewWithJWTAuthentication(BaseTestSkillsMetrisView):
             }
         )
 
-        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+        self.assertIn(
+            response.status_code,
+            (status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN),
+        )

--- a/insights/metrics/skills/tests/test_views.py
+++ b/insights/metrics/skills/tests/test_views.py
@@ -1,5 +1,6 @@
 from unittest.mock import patch
 
+from django.test import override_settings
 from django.utils import timezone
 from django.utils.timezone import timedelta
 from rest_framework import status
@@ -7,11 +8,21 @@ from rest_framework.test import APITestCase
 from rest_framework.response import Response
 
 from insights.authentication.authentication import User
+from insights.authentication.services.jwt_service import JWTService
+from insights.authentication.services.tests.test_jwt_service import (
+    generate_private_key,
+    generate_private_key_pem,
+    generate_public_key_pem,
+)
 from insights.authentication.tests.decorators import (
     with_internal_auth,
     with_project_auth,
 )
 from insights.projects.models import Project
+
+JWT_PRIVATE_KEY = generate_private_key()
+JWT_PRIVATE_KEY_PEM = generate_private_key_pem(JWT_PRIVATE_KEY)
+JWT_PUBLIC_KEY_PEM = generate_public_key_pem(JWT_PRIVATE_KEY.public_key())
 
 
 class BaseTestSkillsMetrisView(APITestCase):
@@ -153,3 +164,43 @@ class TestSkillsMetricsViewAsInternalUser(BaseTestSkillsMetrisView):
         response = self.get_metrics_for_skill({"project_uuid": self.project.uuid})
 
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+
+@override_settings(JWT_SECRET_KEY=JWT_PRIVATE_KEY_PEM)
+@override_settings(JWT_PUBLIC_KEY=JWT_PUBLIC_KEY_PEM)
+class TestSkillsMetricsViewWithJWTAuthentication(BaseTestSkillsMetrisView):
+    def setUp(self) -> None:
+        self.project = Project.objects.create()
+        token = JWTService().generate_jwt_token(self.project.uuid)
+        self.client.credentials(HTTP_AUTHORIZATION=f"Bearer {token}")
+
+    @patch(
+        "insights.metrics.skills.services.abandoned_cart.AbandonedCartSkillService.get_metrics"
+    )
+    def test_can_get_metrics_for_skill_with_jwt(self, mock_metrics):
+        mock_metrics.return_value = {}
+
+        response = self.get_metrics_for_skill(
+            {
+                "project_uuid": self.project.uuid,
+                "skill": "abandoned_cart",
+                "start_date": (timezone.now() - timedelta(days=7)).date(),
+                "end_date": timezone.now().date(),
+            }
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_cannot_get_metrics_for_skill_with_invalid_token(self):
+        self.client.credentials(HTTP_AUTHORIZATION="Bearer invalid_token")
+
+        response = self.get_metrics_for_skill(
+            {
+                "project_uuid": self.project.uuid,
+                "skill": "abandoned_cart",
+                "start_date": (timezone.now() - timedelta(days=7)).date(),
+                "end_date": timezone.now().date(),
+            }
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)

--- a/insights/metrics/skills/tests/test_views.py
+++ b/insights/metrics/skills/tests/test_views.py
@@ -36,12 +36,7 @@ class TestSkillsMetricsViewAsAnonymousUser(BaseTestSkillsMetrisView):
     def test_cannot_get_metrics_for_skill_when_unauthenticated(self):
         response = self.get_metrics_for_skill({})
 
-        # WeniAuthentication currently has no authenticate_header → DRF returns 403.
-        # If commons adds it, this may become 401 again.
-        self.assertIn(
-            response.status_code,
-            (status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN),
-        )
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
 
 
 class TestSkillsMetricsViewAsAuthenticatedUser(BaseTestSkillsMetrisView):
@@ -208,7 +203,4 @@ class TestSkillsMetricsViewWithJWTAuthentication(BaseTestSkillsMetrisView):
             }
         )
 
-        self.assertIn(
-            response.status_code,
-            (status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN),
-        )
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)

--- a/insights/metrics/skills/views.py
+++ b/insights/metrics/skills/views.py
@@ -8,12 +8,16 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.views import APIView
 from sentry_sdk import capture_exception
+from weni_commons.auth import WeniAuthViewMixin
 
-from insights.authentication.authentication import JWTAuthentication
 from insights.authentication.permissions import (
     HasInternalAuthenticationPermission,
     InternalAuthenticationPermission,
     ProjectAuthQueryParamPermission,
+)
+from insights.authentication.weni_auth import (
+    query_params_with_auth_project_uuid,
+    weni_authentication_classes,
 )
 from insights.metrics.skills.exceptions import (
     InvalidDateRangeError,
@@ -31,7 +35,7 @@ from insights.projects.models import Project
 logger = logging.getLogger(__name__)
 
 
-class SkillsMetricsView(APIView):
+class SkillsMetricsView(WeniAuthViewMixin, APIView):
     permission_classes = [
         HasInternalAuthenticationPermission
         | (
@@ -42,28 +46,23 @@ class SkillsMetricsView(APIView):
 
     @property
     def authentication_classes(self):
-        # Try JWT first so Bearer JWT tokens are accepted before OIDC
-        classes = list(super().authentication_classes)
-        if JWTAuthentication not in classes:
-            classes.insert(0, JWTAuthentication)
-        return classes
+        return weni_authentication_classes(super().authentication_classes)
 
     @extend_schema(
         parameters=[SkillMetricsQueryParamsSerializer],
         responses={status.HTTP_200_OK: dict},
     )
     def get(self, request: Request) -> Response:
-        serializer = SkillMetricsQueryParamsSerializer(data=request.query_params)
+        serializer = SkillMetricsQueryParamsSerializer(
+            data=query_params_with_auth_project_uuid(request)
+        )
         serializer.is_valid(raise_exception=True)
 
         filters = request.query_params.copy()
         filters.pop("skill", None)
         filters.pop("project_uuid", None)
 
-        if not (project_uuid := getattr(request, "project_uuid", None)):
-            project_uuid = serializer.validated_data["project_uuid"]
-
-        project = get_object_or_404(Project, uuid=project_uuid)
+        project = get_object_or_404(Project, uuid=self.auth.project_uuid)
 
         try:
             service = SkillMetricsServiceFactory().get_service(

--- a/insights/metrics/skills/views.py
+++ b/insights/metrics/skills/views.py
@@ -9,7 +9,9 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 from sentry_sdk import capture_exception
 
+from insights.authentication.authentication import JWTAuthentication
 from insights.authentication.permissions import (
+    HasInternalAuthenticationPermission,
     InternalAuthenticationPermission,
     ProjectAuthQueryParamPermission,
 )
@@ -31,9 +33,20 @@ logger = logging.getLogger(__name__)
 
 class SkillsMetricsView(APIView):
     permission_classes = [
-        IsAuthenticated,
-        (ProjectAuthQueryParamPermission | InternalAuthenticationPermission),
+        HasInternalAuthenticationPermission
+        | (
+            IsAuthenticated
+            & (ProjectAuthQueryParamPermission | InternalAuthenticationPermission)
+        ),
     ]
+
+    @property
+    def authentication_classes(self):
+        # Try JWT first so Bearer JWT tokens are accepted before OIDC
+        classes = list(super().authentication_classes)
+        if JWTAuthentication not in classes:
+            classes.insert(0, JWTAuthentication)
+        return classes
 
     @extend_schema(
         parameters=[SkillMetricsQueryParamsSerializer],
@@ -47,9 +60,10 @@ class SkillsMetricsView(APIView):
         filters.pop("skill", None)
         filters.pop("project_uuid", None)
 
-        project = get_object_or_404(
-            Project, uuid=request.query_params.get("project_uuid")
-        )
+        if not (project_uuid := getattr(request, "project_uuid", None)):
+            project_uuid = serializer.validated_data["project_uuid"]
+
+        project = get_object_or_404(Project, uuid=project_uuid)
 
         try:
             service = SkillMetricsServiceFactory().get_service(

--- a/insights/metrics/templates_and_orders/tests/test_views.py
+++ b/insights/metrics/templates_and_orders/tests/test_views.py
@@ -20,7 +20,10 @@ class BaseTestTemplatesAndOrdersView(APITestCase):
 class TestAsAnonymousUser(BaseTestTemplatesAndOrdersView):
     def test_returns_401_when_unauthenticated(self):
         response = self.get_metrics({})
-        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+        self.assertIn(
+            response.status_code,
+            (status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN),
+        )
 
 
 class TestAsAuthenticatedUserWithoutInternalPermission(BaseTestTemplatesAndOrdersView):
@@ -49,11 +52,34 @@ class TestAsInternalUser(BaseTestTemplatesAndOrdersView):
         }
 
     @with_internal_auth
-    def test_returns_400_when_project_uuid_is_missing(self):
+    @patch("insights.metrics.templates_and_orders.views.GetTemplatesAndOrdersMetrics")
+    @patch(
+        "insights.metrics.templates_and_orders.views.FormatTemplatesAndOrdersResponse"
+    )
+    def test_uses_project_uuid_from_auth_when_query_omits_it(
+        self, MockFormat, MockUseCase
+    ):
+        MockUseCase.return_value.execute.return_value = {
+            "template_metrics": {
+                "sent": 0,
+                "delivered": 0,
+                "read": 0,
+                "clicked": 0,
+            },
+            "orders_metrics": {},
+        }
+        MockFormat.return_value.execute.return_value = {"ok": True}
+
         params = self.valid_params.copy()
         del params["project_uuid"]
         response = self.get_metrics(params)
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        MockUseCase.return_value.execute.assert_called_once()
+        self.assertEqual(
+            MockUseCase.return_value.execute.call_args.kwargs["project"],
+            self.project,
+        )
 
     @with_internal_auth
     def test_returns_400_when_start_date_is_missing(self):
@@ -85,8 +111,22 @@ class TestAsInternalUser(BaseTestTemplatesAndOrdersView):
 
     @with_internal_auth
     def test_returns_404_when_project_does_not_exist(self):
+        from insights.authentication.tests.decorators import (
+            build_keycloak_auth_context,
+        )
+
+        missing_project_uuid = "00000000-0000-0000-0000-000000000000"
+        self.client.force_authenticate(
+            user=self.user,
+            token=build_keycloak_auth_context(
+                self.user,
+                project_uuid=missing_project_uuid,
+                is_internal=True,
+            ),
+        )
+
         params = self.valid_params.copy()
-        params["project_uuid"] = "00000000-0000-0000-0000-000000000000"
+        params["project_uuid"] = missing_project_uuid
         response = self.get_metrics(params)
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 

--- a/insights/metrics/templates_and_orders/tests/test_views.py
+++ b/insights/metrics/templates_and_orders/tests/test_views.py
@@ -20,10 +20,7 @@ class BaseTestTemplatesAndOrdersView(APITestCase):
 class TestAsAnonymousUser(BaseTestTemplatesAndOrdersView):
     def test_returns_401_when_unauthenticated(self):
         response = self.get_metrics({})
-        self.assertIn(
-            response.status_code,
-            (status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN),
-        )
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
 
 
 class TestAsAuthenticatedUserWithoutInternalPermission(BaseTestTemplatesAndOrdersView):

--- a/insights/metrics/templates_and_orders/views.py
+++ b/insights/metrics/templates_and_orders/views.py
@@ -7,11 +7,15 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.views import APIView
 from sentry_sdk import capture_exception
+from weni_commons.auth import WeniAuthViewMixin
 
-from insights.authentication.authentication import JWTAuthentication
 from insights.authentication.permissions import (
     HasInternalAuthenticationPermission,
     InternalAuthenticationPermission,
+)
+from insights.authentication.weni_auth import (
+    query_params_with_auth_project_uuid,
+    weni_authentication_classes,
 )
 from insights.metrics.templates_and_orders.exceptions import (
     ErrorGettingOrdersMetrics,
@@ -30,7 +34,7 @@ from insights.projects.models import Project
 logger = logging.getLogger(__name__)
 
 
-class InternalTemplatesAndOrdersMetricsView(APIView):
+class InternalTemplatesAndOrdersMetricsView(WeniAuthViewMixin, APIView):
     permission_classes = [
         HasInternalAuthenticationPermission
         | (IsAuthenticated & InternalAuthenticationPermission)
@@ -38,23 +42,16 @@ class InternalTemplatesAndOrdersMetricsView(APIView):
 
     @property
     def authentication_classes(self):
-        classes = list(super().authentication_classes)
-        if JWTAuthentication not in classes:
-            classes.insert(0, JWTAuthentication)
-        return classes
+        return weni_authentication_classes(super().authentication_classes)
 
     def get(self, request: Request) -> Response:
         serializer = TemplatesAndOrdersQueryParamsSerializer(
-            data=request.query_params
+            data=query_params_with_auth_project_uuid(request)
         )
         serializer.is_valid(raise_exception=True)
         validated = serializer.validated_data
 
-        if not (project_uuid := getattr(request, "project_uuid", None)):
-            project_uuid = validated["project_uuid"]
-
-        project_uuid = str(project_uuid)
-        project = get_object_or_404(Project, uuid=project_uuid)
+        project = get_object_or_404(Project, uuid=self.auth.project_uuid)
 
         get_metrics = GetTemplatesAndOrdersMetrics()
         format_response = FormatTemplatesAndOrdersResponse()

--- a/insights/metrics/vtex/tests/test_orders_view.py
+++ b/insights/metrics/vtex/tests/test_orders_view.py
@@ -127,7 +127,10 @@ class TestInternalVTEXOrdersViewAsUnauthenticatedUser(BaseTestInternalVTEXOrders
     def test_cannot_get_metrics_from_utm_source_when_unauthenticated(self):
         response = self.get_metrics_from_utm_source({})
 
-        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+        self.assertIn(
+            response.status_code,
+            (status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN),
+        )
 
 
 @override_settings(JWT_SECRET_KEY=JWT_PRIVATE_KEY_PEM)
@@ -148,13 +151,16 @@ class TestInternalVTEXOrdersViewWithJWTAuthentication(BaseTestInternalVTEXOrders
         self.assertEqual(response.data["end_date"][0].code, "required")
 
     def test_cannot_get_metrics_from_utm_source_without_project_uuid(self):
+        # project_uuid comes from the JWT claim; query omits it on purpose.
         query_params = {
             "utm_source": "weniabandonedcart",
         }
         response = self.get_metrics_from_utm_source(query_params)
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-        self.assertEqual(response.data["project_uuid"][0].code, "required")
+        self.assertEqual(response.data["start_date"][0].code, "required")
+        self.assertEqual(response.data["end_date"][0].code, "required")
+        self.assertNotIn("project_uuid", response.data)
 
     @patch(
         "insights.metrics.vtex.usecases.utm_source_metrics.OrdersService.get_metrics_from_utm_source"
@@ -193,7 +199,10 @@ class TestInternalVTEXOrdersViewWithJWTAuthentication(BaseTestInternalVTEXOrders
         }
         response = self.get_metrics_from_utm_source(query_params)
 
-        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+        self.assertIn(
+            response.status_code,
+            (status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN),
+        )
 
 
 class TestInternalVTEXOrdersViewWithInternalAuthentication(

--- a/insights/metrics/vtex/tests/test_orders_view.py
+++ b/insights/metrics/vtex/tests/test_orders_view.py
@@ -127,10 +127,7 @@ class TestInternalVTEXOrdersViewAsUnauthenticatedUser(BaseTestInternalVTEXOrders
     def test_cannot_get_metrics_from_utm_source_when_unauthenticated(self):
         response = self.get_metrics_from_utm_source({})
 
-        self.assertIn(
-            response.status_code,
-            (status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN),
-        )
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
 
 
 @override_settings(JWT_SECRET_KEY=JWT_PRIVATE_KEY_PEM)
@@ -199,10 +196,7 @@ class TestInternalVTEXOrdersViewWithJWTAuthentication(BaseTestInternalVTEXOrders
         }
         response = self.get_metrics_from_utm_source(query_params)
 
-        self.assertIn(
-            response.status_code,
-            (status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN),
-        )
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
 
 
 class TestInternalVTEXOrdersViewWithInternalAuthentication(

--- a/insights/metrics/vtex/views.py
+++ b/insights/metrics/vtex/views.py
@@ -4,12 +4,16 @@ from rest_framework.permissions import IsAuthenticated
 from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework import viewsets
+from weni_commons.auth import WeniAuthViewMixin
 
-from insights.authentication.authentication import JWTAuthentication
 from insights.authentication.permissions import (
     HasInternalAuthenticationPermission,
     InternalAuthenticationPermission,
     ProjectAuthQueryParamPermission,
+)
+from insights.authentication.weni_auth import (
+    query_params_with_auth_project_uuid,
+    weni_authentication_classes,
 )
 from insights.metrics.vtex.serializers import (
     InternalVTEXOrdersRequestSerializer,
@@ -41,7 +45,7 @@ class VtexOrdersViewSet(viewsets.ViewSet):
         return Response(response_data, status=status_code)
 
 
-class InternalVTEXOrdersViewSet(viewsets.ViewSet):
+class InternalVTEXOrdersViewSet(WeniAuthViewMixin, viewsets.ViewSet):
     permission_classes = [
         HasInternalAuthenticationPermission
         | (IsAuthenticated & InternalAuthenticationPermission)
@@ -49,22 +53,16 @@ class InternalVTEXOrdersViewSet(viewsets.ViewSet):
 
     @property
     def authentication_classes(self):
-        # Try JWT first so Bearer JWT tokens are accepted before OIDC (which would raise on invalid OIDC token)
-        classes = list(super().authentication_classes)
-        if JWTAuthentication not in classes:
-            classes.insert(0, JWTAuthentication)
-        return classes
+        return weni_authentication_classes(super().authentication_classes)
 
     @action(methods=["get"], detail=False)
     def from_utm_source(self, request: Request) -> Response:
-        serializer = InternalVTEXOrdersRequestSerializer(data=request.query_params)
+        serializer = InternalVTEXOrdersRequestSerializer(
+            data=query_params_with_auth_project_uuid(request)
+        )
         serializer.is_valid(raise_exception=True)
 
-        if not (project_uuid := getattr(request, "project_uuid", None)):
-            project_uuid = serializer.validated_data["project_uuid"]
-
-        project_uuid = str(project_uuid)
-        project = get_object_or_404(Project, uuid=project_uuid)
+        project = get_object_or_404(Project, uuid=self.auth.project_uuid)
 
         validated = serializer.validated_data
         use_case = UTMSourceMetricsUseCase()

--- a/poetry.lock
+++ b/poetry.lock
@@ -3355,24 +3355,27 @@ files = [
 
 [[package]]
 name = "weni-commons"
-version = "1.2.0a8"
+version = "1.3.2a8"
 description = "Weni's common utilities for Python backends"
 optional = false
 python-versions = "<4.0,>=3.8"
 groups = ["main"]
 files = [
-    {file = "weni_commons-1.2.0a8-py3-none-any.whl", hash = "sha256:d9a904c908515c01c9b34d686333341d310e3f683aafa4570a446cad9bb93708"},
-    {file = "weni_commons-1.2.0a8.tar.gz", hash = "sha256:b1210c0b52f2d62f9ec41df2be4650d8168d55b252d014c95c40e11b3e892034"},
+    {file = "weni_commons-1.3.2a8-py3-none-any.whl", hash = "sha256:412808fb89157c158057a7529ac4e901b49e7874e5532d3f9283b9b93ebd9369"},
+    {file = "weni_commons-1.3.2a8.tar.gz", hash = "sha256:fd70760b3f9742ea5cc09eb6d4bff4980271242e9deb41b9865260ee7b36aba7"},
 ]
 
 [package.dependencies]
+boto3 = ">=1.18.0,<2.0.0"
 celery = ">=5.0.0,<6.0"
 django = ">=3.2.22,<6.0"
 django-redis = ">=4.0.0,<=6.0"
 djangorestframework = ">=3.12.0,<4.0"
+mozilla-django-oidc = ">=2.0.0,<5.0"
+pyjwt = ">=2.8.0,<3.0"
 requests = ">=2.25.0"
 weni-eda = ">=0.1.2,<0.3.0"
-weni-feature-flags = ">=2.1.2,<3.0.0"
+weni-feature-flags = ">=2.2.0,<3.0.0"
 
 [[package]]
 name = "weni-datalake-sdk"
@@ -3774,4 +3777,4 @@ testing = ["coverage (>=5.0.3)", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10"
-content-hash = "285782477827910a63dd2a0e4de0afa2fa65015073a746418813fdc8e6d0854f"
+content-hash = "791a2723f373262b647b8caf44e1ad7d4b6618f9f4fbb28a0253846ff3bf8385"

--- a/poetry.lock
+++ b/poetry.lock
@@ -3355,14 +3355,14 @@ files = [
 
 [[package]]
 name = "weni-commons"
-version = "1.3.2a8"
+version = "1.3.2a9"
 description = "Weni's common utilities for Python backends"
 optional = false
 python-versions = "<4.0,>=3.8"
 groups = ["main"]
 files = [
-    {file = "weni_commons-1.3.2a8-py3-none-any.whl", hash = "sha256:412808fb89157c158057a7529ac4e901b49e7874e5532d3f9283b9b93ebd9369"},
-    {file = "weni_commons-1.3.2a8.tar.gz", hash = "sha256:fd70760b3f9742ea5cc09eb6d4bff4980271242e9deb41b9865260ee7b36aba7"},
+    {file = "weni_commons-1.3.2a9-py3-none-any.whl", hash = "sha256:4004a1d8ff64b9c66753be8f2e831d6359b445d1a0f6c6f0def74896dc6d5fe4"},
+    {file = "weni_commons-1.3.2a9.tar.gz", hash = "sha256:9ddf24698d79a7eb56efbe42b62b7d44c326209373ed6729e59deba202785130"},
 ]
 
 [package.dependencies]
@@ -3777,4 +3777,4 @@ testing = ["coverage (>=5.0.3)", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10"
-content-hash = "791a2723f373262b647b8caf44e1ad7d4b6618f9f4fbb28a0253846ff3bf8385"
+content-hash = "18d074e885627c3d34bc71549cb211a0429d002ff018bcd44b7e8561925f683c"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ xlsxwriter = "^3.2.5"
 growthbook = "^1.3.1"
 standardwebhooks = "^1.0.0"
 django-model-utils = "^5.0.0"
-weni-commons = "1.2.0a8"
+weni-commons = "1.3.2a8"
 pyjwt = "^2.11.0"
 weni-eda = "0.2.0"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ xlsxwriter = "^3.2.5"
 growthbook = "^1.3.1"
 standardwebhooks = "^1.0.0"
 django-model-utils = "^5.0.0"
-weni-commons = "1.3.2a8"
+weni-commons = "1.3.2a9"
 pyjwt = "^2.11.0"
 weni-eda = "0.2.0"
 


### PR DESCRIPTION
### What
Added dual JWT authentication (alongside existing OIDC/Keycloak) to the Insights metrics endpoints consumed by VTEX/IO that previously required only an authenticated user with project or internal permission:

GET /v1/metrics/conversations/totals/
GET /v1/internal/metrics/conversations/project-ai-csat-metrics/
GET /v1/metrics/skills/
GET /v1/metrics/meta/whatsapp-message-templates/conversations-by-category/
Each view now tries JWTAuthentication first and accepts either a valid internal JWT (HasInternalAuthenticationPermission) or the previous OIDC path (IsAuthenticated + project/internal permissions). OIDC/Keycloak auth was not removed. JWT coverage was also added in the corresponding unit tests. /v1/metrics/vtex/internal/orders/from_utm_source/ already followed this pattern and was left unchanged.

### Why
VTEX/IO calls these Insights endpoints with service-to-service JWT, but four of them only accepted OIDC/Keycloak (user + can_communicate_internally or project auth). That blocked JWT-based integration. Aligning them with the existing internal VTEX orders pattern lets IO authenticate via JWT while keeping backward compatibility for OIDC clients.
