### PR TITLE
feat: add UTC range conversion utility for project dates

### DIFF
--- a/insights/metrics/templates_and_orders/usecases/get_templates_and_orders_metrics.py
+++ b/insights/metrics/templates_and_orders/usecases/get_templates_and_orders_metrics.py
@@ -16,6 +16,7 @@ from insights.metrics.templates_and_orders.exceptions import (
     ErrorGettingOrdersMetrics,
     TemplatesNotFoundError,
 )
+from insights.metrics.vtex.date_utils import to_utc_range
 from insights.metrics.vtex.services.orders_service import OrdersService
 from insights.projects.models import Project
 
@@ -92,10 +93,11 @@ class GetTemplatesAndOrdersMetrics:
         end_date: date,
     ) -> dict:
         service = OrdersService(project)
+        start_dt, end_dt = to_utc_range(start_date, end_date, project)
 
         filters = {
-            "start_date": start_date,
-            "end_date": end_date,
+            "start_date": start_dt,
+            "end_date": end_dt,
         }
 
         try:

--- a/insights/metrics/templates_and_orders/usecases/tests/test_get_templates_and_orders_metrics.py
+++ b/insights/metrics/templates_and_orders/usecases/tests/test_get_templates_and_orders_metrics.py
@@ -1,4 +1,4 @@
-from datetime import date, datetime, timezone
+from datetime import date
 from unittest.mock import MagicMock, patch
 
 from django.test import TestCase

--- a/insights/metrics/templates_and_orders/usecases/tests/test_get_templates_and_orders_metrics.py
+++ b/insights/metrics/templates_and_orders/usecases/tests/test_get_templates_and_orders_metrics.py
@@ -1,4 +1,4 @@
-from datetime import date
+from datetime import date, datetime, timezone
 from unittest.mock import MagicMock, patch
 
 from django.test import TestCase
@@ -18,6 +18,7 @@ from insights.metrics.templates_and_orders.usecases.get_templates_and_orders_met
     GetTemplatesAndOrdersMetrics,
     MetricsLimits,
 )
+from insights.metrics.vtex.date_utils import to_utc_range
 from insights.projects.models import Project
 
 
@@ -41,6 +42,9 @@ class TestGetTemplatesAndOrdersMetrics(TestCase):
         self.end_date = date(2024, 1, 31)
         self.utm_source = "weniabandonedcart"
         self.template_name_prefix = "weni_abandoned_cart"
+        self.expected_orders_start, self.expected_orders_end = to_utc_range(
+            self.start_date, self.end_date, self.project
+        )
 
     @patch(
         "insights.metrics.templates_and_orders.usecases"
@@ -112,8 +116,8 @@ class TestGetTemplatesAndOrdersMetrics(TestCase):
         mock_orders_instance.get_metrics_from_utm_source.assert_called_once_with(
             utm_source=custom_utm,
             filters={
-                "start_date": self.start_date,
-                "end_date": self.end_date,
+                "start_date": self.expected_orders_start,
+                "end_date": self.expected_orders_end,
             },
         )
 
@@ -489,4 +493,44 @@ class TestGetTemplatesAndOrdersMetrics(TestCase):
         self.assertEqual(
             result["template_metrics"],
             {"sent": 0, "delivered": 0, "read": 0, "clicked": 0},
+        )
+
+    @patch(
+        "insights.metrics.templates_and_orders.usecases"
+        ".get_templates_and_orders_metrics.OrdersService"
+    )
+    def test_converts_order_dates_to_project_timezone_utc_range(
+        self, MockOrdersService
+    ):
+        self.project.timezone = "America/Sao_Paulo"
+        self.project.save(update_fields=["timezone"])
+
+        self.mock_get_wabas.execute.return_value = []
+        self.mock_get_metrics.execute.return_value = {
+            "sent": 0,
+            "delivered": 0,
+            "read": 0,
+            "clicked": 0,
+        }
+
+        mock_orders_instance = MockOrdersService.return_value
+        mock_orders_instance.get_metrics_from_utm_source.return_value = {
+            "revenue": {"value": 0, "currency_code": "", "increase_percentage": 0},
+            "orders_placed": {"value": 0, "increase_percentage": 0},
+        }
+
+        self.usecase.execute(
+            project=self.project,
+            start_date=date(2026, 7, 17),
+            end_date=date(2026, 7, 23),
+            utm_source=self.utm_source,
+            template_name_prefix=self.template_name_prefix,
+        )
+
+        mock_orders_instance.get_metrics_from_utm_source.assert_called_once_with(
+            utm_source=self.utm_source,
+            filters={
+                "start_date": datetime(2026, 7, 17, 3, 0, 0, tzinfo=timezone.utc),
+                "end_date": datetime(2026, 7, 24, 2, 59, 59, tzinfo=timezone.utc),
+            },
         )

--- a/insights/metrics/templates_and_orders/usecases/tests/test_get_templates_and_orders_metrics.py
+++ b/insights/metrics/templates_and_orders/usecases/tests/test_get_templates_and_orders_metrics.py
@@ -519,10 +519,16 @@ class TestGetTemplatesAndOrdersMetrics(TestCase):
             "orders_placed": {"value": 0, "increase_percentage": 0},
         }
 
+        start_date = date(2026, 7, 17)
+        end_date = date(2026, 7, 23)
+        expected_start, expected_end = to_utc_range(
+            start_date, end_date, self.project
+        )
+
         self.usecase.execute(
             project=self.project,
-            start_date=date(2026, 7, 17),
-            end_date=date(2026, 7, 23),
+            start_date=start_date,
+            end_date=end_date,
             utm_source=self.utm_source,
             template_name_prefix=self.template_name_prefix,
         )
@@ -530,7 +536,7 @@ class TestGetTemplatesAndOrdersMetrics(TestCase):
         mock_orders_instance.get_metrics_from_utm_source.assert_called_once_with(
             utm_source=self.utm_source,
             filters={
-                "start_date": datetime(2026, 7, 17, 3, 0, 0, tzinfo=timezone.utc),
-                "end_date": datetime(2026, 7, 24, 2, 59, 59, tzinfo=timezone.utc),
+                "start_date": expected_start,
+                "end_date": expected_end,
             },
         )

--- a/insights/metrics/vtex/date_utils.py
+++ b/insights/metrics/vtex/date_utils.py
@@ -1,0 +1,22 @@
+from datetime import date, datetime, time, timezone
+from zoneinfo import ZoneInfo
+
+from insights.projects.models import Project
+
+
+def to_utc_range(
+    start_date: date, end_date: date, project: Project
+) -> tuple[datetime, datetime]:
+    """
+    Convert calendar dates to a UTC datetime range using the project's timezone.
+
+    Start is local midnight; end is local 23:59:59. Both are returned in UTC so
+    VTEX authorizedDate filters include the full local days selected by the user.
+    """
+    project_tz = ZoneInfo(project.timezone) if project.timezone else ZoneInfo("UTC")
+    start_local = datetime.combine(start_date, time.min, tzinfo=project_tz)
+    end_local = datetime.combine(end_date, time(23, 59, 59), tzinfo=project_tz)
+    return (
+        start_local.astimezone(timezone.utc),
+        end_local.astimezone(timezone.utc),
+    )

--- a/insights/metrics/vtex/date_utils.py
+++ b/insights/metrics/vtex/date_utils.py
@@ -3,6 +3,8 @@ from zoneinfo import ZoneInfo
 
 from insights.projects.models import Project
 
+END_OF_DAY_TIME = time(23, 59, 59)
+
 
 def to_utc_range(
     start_date: date, end_date: date, project: Project
@@ -15,7 +17,7 @@ def to_utc_range(
     """
     project_tz = ZoneInfo(project.timezone) if project.timezone else ZoneInfo("UTC")
     start_local = datetime.combine(start_date, time.min, tzinfo=project_tz)
-    end_local = datetime.combine(end_date, time(23, 59, 59), tzinfo=project_tz)
+    end_local = datetime.combine(end_date, END_OF_DAY_TIME, tzinfo=project_tz)
     return (
         start_local.astimezone(timezone.utc),
         end_local.astimezone(timezone.utc),

--- a/insights/metrics/vtex/tests/test_date_utils.py
+++ b/insights/metrics/vtex/tests/test_date_utils.py
@@ -1,0 +1,47 @@
+from datetime import date, datetime, timezone
+
+from django.test import TestCase
+
+from insights.metrics.vtex.date_utils import to_utc_range
+from insights.projects.models import Project
+
+
+class TestToUtcRange(TestCase):
+    def test_converts_date_range_to_utc_using_project_timezone(self):
+        project = Project.objects.create(
+            name="Test Project",
+            timezone="America/Sao_Paulo",
+        )
+
+        start, end = to_utc_range(
+            date(2023, 9, 1),
+            date(2023, 9, 4),
+            project,
+        )
+
+        self.assertEqual(
+            start,
+            datetime(2023, 9, 1, 3, 0, 0, tzinfo=timezone.utc),
+        )
+        self.assertEqual(
+            end,
+            datetime(2023, 9, 5, 2, 59, 59, tzinfo=timezone.utc),
+        )
+
+    def test_defaults_to_utc_when_project_timezone_is_empty(self):
+        project = Project.objects.create(name="Test Project", timezone=None)
+
+        start, end = to_utc_range(
+            date(2023, 9, 1),
+            date(2023, 9, 2),
+            project,
+        )
+
+        self.assertEqual(
+            start,
+            datetime(2023, 9, 1, 0, 0, 0, tzinfo=timezone.utc),
+        )
+        self.assertEqual(
+            end,
+            datetime(2023, 9, 2, 23, 59, 59, tzinfo=timezone.utc),
+        )

--- a/insights/metrics/vtex/tests/test_date_utils.py
+++ b/insights/metrics/vtex/tests/test_date_utils.py
@@ -1,8 +1,9 @@
-from datetime import date, datetime, timezone
+from datetime import date, datetime, time, timezone
+from zoneinfo import ZoneInfo
 
 from django.test import TestCase
 
-from insights.metrics.vtex.date_utils import to_utc_range
+from insights.metrics.vtex.date_utils import END_OF_DAY_TIME, to_utc_range
 from insights.projects.models import Project
 
 
@@ -12,36 +13,31 @@ class TestToUtcRange(TestCase):
             name="Test Project",
             timezone="America/Sao_Paulo",
         )
+        start_date = date(2023, 9, 1)
+        end_date = date(2023, 9, 4)
+        project_tz = ZoneInfo(project.timezone)
 
-        start, end = to_utc_range(
-            date(2023, 9, 1),
-            date(2023, 9, 4),
-            project,
-        )
+        start, end = to_utc_range(start_date, end_date, project)
 
-        self.assertEqual(
-            start,
-            datetime(2023, 9, 1, 3, 0, 0, tzinfo=timezone.utc),
-        )
-        self.assertEqual(
-            end,
-            datetime(2023, 9, 5, 2, 59, 59, tzinfo=timezone.utc),
-        )
+        self.assertEqual(start.tzinfo, timezone.utc)
+        self.assertEqual(end.tzinfo, timezone.utc)
+        self.assertEqual(start.astimezone(project_tz).date(), start_date)
+        self.assertEqual(start.astimezone(project_tz).time(), time.min)
+        self.assertEqual(end.astimezone(project_tz).date(), end_date)
+        self.assertEqual(end.astimezone(project_tz).time(), END_OF_DAY_TIME)
 
     def test_defaults_to_utc_when_project_timezone_is_empty(self):
         project = Project.objects.create(name="Test Project", timezone=None)
+        start_date = date(2023, 9, 1)
+        end_date = date(2023, 9, 2)
 
-        start, end = to_utc_range(
-            date(2023, 9, 1),
-            date(2023, 9, 2),
-            project,
-        )
+        start, end = to_utc_range(start_date, end_date, project)
 
         self.assertEqual(
             start,
-            datetime(2023, 9, 1, 0, 0, 0, tzinfo=timezone.utc),
+            datetime.combine(start_date, time.min, tzinfo=timezone.utc),
         )
         self.assertEqual(
             end,
-            datetime(2023, 9, 2, 23, 59, 59, tzinfo=timezone.utc),
+            datetime.combine(end_date, END_OF_DAY_TIME, tzinfo=timezone.utc),
         )

--- a/insights/metrics/vtex/tests/test_usecases.py
+++ b/insights/metrics/vtex/tests/test_usecases.py
@@ -1,9 +1,11 @@
-from datetime import date, datetime, timezone
+from datetime import date, datetime, time, timezone
 from unittest.mock import patch
+from zoneinfo import ZoneInfo
 
 from django.test import TestCase
 from rest_framework import status
 
+from insights.metrics.vtex.date_utils import END_OF_DAY_TIME, to_utc_range
 from insights.metrics.vtex.usecases.utm_source_metrics import UTMSourceMetricsUseCase
 from insights.projects.models import Project
 from insights.sources.vtexcredentials.exceptions import VtexCredentialsNotFound
@@ -18,38 +20,33 @@ class TestUTMSourceMetricsUseCaseToUtcRange(TestCase):
             name="Test Project",
             timezone="America/Sao_Paulo",
         )
+        start_date = date(2023, 9, 1)
+        end_date = date(2023, 9, 4)
+        project_tz = ZoneInfo(project.timezone)
 
-        start, end = self.use_case.to_utc_range(
-            date(2023, 9, 1),
-            date(2023, 9, 4),
-            project,
-        )
+        start, end = self.use_case.to_utc_range(start_date, end_date, project)
 
-        self.assertEqual(
-            start,
-            datetime(2023, 9, 1, 3, 0, 0, tzinfo=timezone.utc),
-        )
-        self.assertEqual(
-            end,
-            datetime(2023, 9, 5, 2, 59, 59, tzinfo=timezone.utc),
-        )
+        self.assertEqual(start.tzinfo, timezone.utc)
+        self.assertEqual(end.tzinfo, timezone.utc)
+        self.assertEqual(start.astimezone(project_tz).date(), start_date)
+        self.assertEqual(start.astimezone(project_tz).time(), time.min)
+        self.assertEqual(end.astimezone(project_tz).date(), end_date)
+        self.assertEqual(end.astimezone(project_tz).time(), END_OF_DAY_TIME)
 
     def test_defaults_to_utc_when_project_timezone_is_empty(self):
         project = Project.objects.create(name="Test Project", timezone=None)
+        start_date = date(2023, 9, 1)
+        end_date = date(2023, 9, 2)
 
-        start, end = self.use_case.to_utc_range(
-            date(2023, 9, 1),
-            date(2023, 9, 2),
-            project,
-        )
+        start, end = self.use_case.to_utc_range(start_date, end_date, project)
 
         self.assertEqual(
             start,
-            datetime(2023, 9, 1, 0, 0, 0, tzinfo=timezone.utc),
+            datetime.combine(start_date, time.min, tzinfo=timezone.utc),
         )
         self.assertEqual(
             end,
-            datetime(2023, 9, 2, 23, 59, 59, tzinfo=timezone.utc),
+            datetime.combine(end_date, END_OF_DAY_TIME, tzinfo=timezone.utc),
         )
 
 
@@ -87,14 +84,13 @@ class TestUTMSourceMetricsUseCaseExecute(TestCase):
         utm_arg, filters = call_kwargs[0]
         self.assertEqual(utm_arg, "weniabandonedcart")
         self.assertEqual(filters["project_uuid"], str(self.project.uuid))
-        self.assertEqual(
-            filters["start_date"],
-            datetime(2023, 9, 1, 0, 0, 0, tzinfo=timezone.utc),
+        expected_start, expected_end = to_utc_range(
+            date(2023, 9, 1),
+            date(2023, 9, 2),
+            self.project,
         )
-        self.assertEqual(
-            filters["end_date"],
-            datetime(2023, 9, 2, 23, 59, 59, tzinfo=timezone.utc),
-        )
+        self.assertEqual(filters["start_date"], expected_start)
+        self.assertEqual(filters["end_date"], expected_end)
 
     def test_returns_401_when_vtex_credentials_not_found(self, mock_orders_service_cls):
         mock_orders_service_cls.return_value.get_metrics_from_utm_source.side_effect = (

--- a/insights/metrics/vtex/usecases/utm_source_metrics.py
+++ b/insights/metrics/vtex/usecases/utm_source_metrics.py
@@ -1,10 +1,10 @@
 import logging
-from datetime import date, datetime, time, timezone
-from zoneinfo import ZoneInfo
+from datetime import date, datetime
 
 from rest_framework import status
 from sentry_sdk import capture_exception
 
+from insights.metrics.vtex.date_utils import to_utc_range
 from insights.metrics.vtex.services.orders_service import OrdersService
 from insights.projects.models import Project
 from insights.sources.vtexcredentials.exceptions import VtexCredentialsNotFound
@@ -18,23 +18,10 @@ class UTMSourceMetricsUseCase:
     Use case to get metrics from UTM source
     """
 
-    def _convert_dates(
-        self, start_date: date, end_date: date, project_tz: ZoneInfo
-    ) -> tuple[datetime, datetime]:
-        start_local = datetime.combine(start_date, time.min, tzinfo=project_tz)
-        end_local = datetime.combine(
-            end_date, time(23, 59, 59), tzinfo=project_tz
-        )
-        return (
-            start_local.astimezone(timezone.utc),
-            end_local.astimezone(timezone.utc),
-        )
-
     def to_utc_range(
         self, start_date: date, end_date: date, project: Project
     ) -> tuple[datetime, datetime]:
-        project_tz = ZoneInfo(project.timezone) if project.timezone else ZoneInfo("UTC")
-        return self._convert_dates(start_date, end_date, project_tz)
+        return to_utc_range(start_date, end_date, project)
 
     def execute(
         self, project: Project, utm_source: str, start_date: date, end_date: date


### PR DESCRIPTION
### What
- Extracted the date-to-UTC conversion logic into a standalone `to_utc_range` utility function in `insights/metrics/vtex/date_utils.py`.
- `UTMSourceMetricsUseCase.to_utc_range` now delegates to this shared utility instead of implementing the conversion inline.
- `GetTemplatesAndOrdersMetrics._get_orders_metrics` now converts the incoming `start_date`/`end_date` to a UTC-aware datetime range via `to_utc_range` before passing them as filters to `OrdersService`.

### Why
Previously, the templates-and-orders metrics flow passed raw `date` objects directly to `OrdersService`, ignoring the project's timezone. This meant VTEX `authorizedDate` filters were not anchored to the correct local day boundaries, potentially excluding or including orders that fall outside the user-selected range. By converting calendar dates to UTC datetimes using the project's configured timezone (defaulting to UTC when none is set), the filters now correctly span local midnight to 23:59:59 for the selected days. Extracting the logic into a shared utility also eliminates the duplicate implementation that previously existed inside `UTMSourceMetricsUseCase`.