### PR TITLE
fix: creation of dashs with same waba

### DIFF
--- a/insights/metrics/meta/tests/test_usecases.py
+++ b/insights/metrics/meta/tests/test_usecases.py
@@ -113,6 +113,10 @@ class TestSaveWhatsappIntegrationUseCase(TestCase):
 
     def test_creates_migration_data_when_old_waba_id_is_provided(self):
         old_waba_id = "old_waba_999"
+        old_phone = {
+            "id": "different-phone-id",
+            "display_phone_number": "+55 11 11111 1111",
+        }
         existing = Dashboard.objects.create(
             project=self.project,
             name="Old Waba Dashboard",
@@ -120,10 +124,7 @@ class TestSaveWhatsappIntegrationUseCase(TestCase):
                 "is_whatsapp_integration": True,
                 "app_uuid": str(uuid.uuid4()),
                 "waba_id": old_waba_id,
-                "phone_number": {
-                    "id": "different-phone-id",
-                    "display_phone_number": "+55 11 11111 1111",
-                },
+                "phone_number": old_phone,
             },
         )
 
@@ -136,6 +137,7 @@ class TestSaveWhatsappIntegrationUseCase(TestCase):
         )
 
         self.assertNotEqual(dashboard.pk, existing.pk)
+        self.assertEqual(dashboard.config["phone_number"], old_phone)
         self.assertIn("migration_data", dashboard.config)
         self.assertEqual(dashboard.config["migration_data"]["waba_id"], old_waba_id)
         self.assertIn("migrated_at", dashboard.config["migration_data"])
@@ -146,6 +148,105 @@ class TestSaveWhatsappIntegrationUseCase(TestCase):
 
         soft_deleted = Dashboard.all_objects.get(pk=existing.pk)
         self.assertTrue(soft_deleted.is_deleted)
+
+    def test_migrates_all_dashboards_with_same_old_waba_id(self):
+        old_waba_id = "old_waba_multi"
+        phone_a = {
+            "id": "phone-a",
+            "display_phone_number": "+55 11 5116-1712",
+        }
+        phone_b = {
+            "id": "phone-b",
+            "display_phone_number": "+55 11 3164-0630",
+        }
+        dash_a = Dashboard.objects.create(
+            project=self.project,
+            name="Meta A",
+            config={
+                "is_whatsapp_integration": True,
+                "app_uuid": str(uuid.uuid4()),
+                "waba_id": old_waba_id,
+                "is_mm_lite_active": True,
+                "phone_number": phone_a,
+            },
+        )
+        dash_b = Dashboard.objects.create(
+            project=self.project,
+            name="Meta B",
+            config={
+                "is_whatsapp_integration": True,
+                "app_uuid": str(uuid.uuid4()),
+                "waba_id": old_waba_id,
+                "phone_number": phone_b,
+            },
+        )
+
+        returned = SaveWhatsappIntegrationUseCase().execute(
+            project=self.project,
+            app_uuid=self.app_uuid,
+            waba_id=self.waba_id,
+            phone_number=phone_a,
+            old_waba_id=old_waba_id,
+        )
+
+        active = list(
+            Dashboard.objects.filter(
+                project=self.project,
+                config__is_whatsapp_integration=True,
+                config__waba_id=self.waba_id,
+            )
+        )
+        self.assertEqual(len(active), 2)
+        self.assertEqual(
+            {(d.config["phone_number"]["id"]) for d in active},
+            {"phone-a", "phone-b"},
+        )
+        for dashboard in active:
+            self.assertEqual(dashboard.config["migration_data"]["waba_id"], old_waba_id)
+            self.assertIn("migrated_at", dashboard.config["migration_data"])
+            self.assertEqual(dashboard.config["app_uuid"], str(self.app_uuid))
+
+        self.assertEqual(returned.config["phone_number"]["id"], "phone-a")
+        self.assertTrue(Dashboard.all_objects.get(pk=dash_a.pk).is_deleted)
+        self.assertTrue(Dashboard.all_objects.get(pk=dash_b.pk).is_deleted)
+        self.assertTrue(
+            Dashboard.objects.get(
+                project=self.project,
+                config__phone_number__id="phone-a",
+            ).config["is_mm_lite_active"]
+        )
+
+    def test_upsert_by_phone_does_not_delete_other_numbers_on_same_waba(self):
+        other_phone = {
+            "id": "other-phone",
+            "display_phone_number": "+55 11 2222-2222",
+        }
+        other = Dashboard.objects.create(
+            project=self.project,
+            name="Other Number",
+            config={
+                "is_whatsapp_integration": True,
+                "app_uuid": str(uuid.uuid4()),
+                "waba_id": self.waba_id,
+                "phone_number": other_phone,
+            },
+        )
+
+        SaveWhatsappIntegrationUseCase().execute(
+            project=self.project,
+            app_uuid=self.app_uuid,
+            waba_id=self.waba_id,
+            phone_number=self.phone_number,
+        )
+
+        other.refresh_from_db()
+        self.assertFalse(other.is_deleted)
+        self.assertEqual(
+            Dashboard.objects.filter(
+                project=self.project, config__is_whatsapp_integration=True
+            ).count(),
+            2,
+        )
 
     def test_does_not_update_dashboard_from_a_different_project(self):
         other_project = Project.objects.create(name="Other Project")

--- a/insights/metrics/meta/tests/test_whatsapp_integration_webhook.py
+++ b/insights/metrics/meta/tests/test_whatsapp_integration_webhook.py
@@ -139,16 +139,17 @@ class TestWhatsAppIntegrationWebhookAsAuthenticatedUser(
     def test_receive_integration_with_old_waba_id_saves_migration_data(self):
         project = Project.objects.create()
         old_waba_id = "old_waba_123"
+        old_phone = {
+            "id": "111111111111111",
+            "display_phone_number": "+55 11 11111 1111",
+        }
         Dashboard.objects.create(
             project=project,
             config={
                 "is_whatsapp_integration": True,
                 "waba_id": old_waba_id,
                 "app_uuid": str(uuid.uuid4()),
-                "phone_number": {
-                    "id": "111111111111111",
-                    "display_phone_number": "+55 11 11111 1111",
-                },
+                "phone_number": old_phone,
             },
         )
 
@@ -171,8 +172,61 @@ class TestWhatsAppIntegrationWebhookAsAuthenticatedUser(
             project=project, config__is_whatsapp_integration=True
         ).get()
         self.assertEqual(dashboard.config["waba_id"], payload["waba_id"])
+        self.assertEqual(dashboard.config["phone_number"], old_phone)
         self.assertEqual(dashboard.config["migration_data"]["waba_id"], old_waba_id)
         self.assertIn("migrated_at", dashboard.config["migration_data"])
+        self.assertFalse(
+            Dashboard.objects.filter(config__waba_id=old_waba_id).exists()
+        )
+
+    @with_internal_auth
+    def test_receive_integration_migrates_all_dashboards_with_same_old_waba(self):
+        project = Project.objects.create()
+        old_waba_id = "old_waba_multi"
+        phone_a = {
+            "id": "phone-a",
+            "display_phone_number": "+55 11 5116-1712",
+        }
+        phone_b = {
+            "id": "phone-b",
+            "display_phone_number": "+55 11 3164-0630",
+        }
+        for phone in (phone_a, phone_b):
+            Dashboard.objects.create(
+                project=project,
+                config={
+                    "is_whatsapp_integration": True,
+                    "waba_id": old_waba_id,
+                    "app_uuid": str(uuid.uuid4()),
+                    "phone_number": phone,
+                },
+            )
+
+        payload = {
+            "project_uuid": project.uuid,
+            "app_uuid": str(uuid.uuid4()),
+            "waba_id": "new_waba_multi",
+            "old_waba_id": old_waba_id,
+            "phone_number": phone_a,
+        }
+
+        response = self.receive_integration_data(payload)
+
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+
+        active = Dashboard.objects.filter(
+            project=project, config__is_whatsapp_integration=True
+        )
+        self.assertEqual(active.count(), 2)
+        self.assertEqual(
+            {(d.config.get("phone_number") or {}).get("id") for d in active},
+            {"phone-a", "phone-b"},
+        )
+        for dashboard in active:
+            self.assertEqual(dashboard.config["waba_id"], payload["waba_id"])
+            self.assertEqual(
+                dashboard.config["migration_data"]["waba_id"], old_waba_id
+            )
         self.assertFalse(
             Dashboard.objects.filter(config__waba_id=old_waba_id).exists()
         )

--- a/insights/metrics/meta/usecases/save_whatsapp_integration.py
+++ b/insights/metrics/meta/usecases/save_whatsapp_integration.py
@@ -1,8 +1,8 @@
 import uuid
+from copy import deepcopy
 from datetime import timezone as dt_timezone
 from typing import TypedDict
 
-from django.db.models import Q
 from django.utils import timezone
 
 from insights.dashboards.models import Dashboard
@@ -21,8 +21,17 @@ class SaveWhatsappIntegrationUseCase:
     If a matching dashboard already exists, it is soft-deleted and a new one is
     created (instead of updating in place). Existing config keys are preserved
     and only the integration fields (and optional migration_data) are merged.
+
+    When old_waba_id is provided, every active WhatsApp dashboard in the project
+    (and main project copy, if any) with that waba_id is migrated 1:1 — soft-deleted
+    and recreated with the new waba_id and migration_data — so multiple phone
+    numbers under the same WABA are all preserved.
+
+    Without old_waba_id, matching is by phone_number.id only, so other numbers
+    on the same WABA are left untouched.
+
     When the project belongs to an organization that has a main project, a copy
-    of the dashboard is also created in the main project.
+    of each created dashboard is also created in the main project.
     """
 
     def execute(
@@ -33,14 +42,210 @@ class SaveWhatsappIntegrationUseCase:
         phone_number: WhatsappPhoneNumber,
         old_waba_id: str | None = None,
     ) -> Dashboard:
-        existing = self._find_existing(
+        if old_waba_id:
+            return self._migrate_waba(
+                project=project,
+                app_uuid=app_uuid,
+                waba_id=waba_id,
+                phone_number=phone_number,
+                old_waba_id=old_waba_id,
+            )
+
+        return self._upsert_by_phone(
             project=project,
+            app_uuid=app_uuid,
             waba_id=waba_id,
-            phone_number_id=phone_number["id"],
-            old_waba_id=old_waba_id,
+            phone_number=phone_number,
+            migration_data=None,
         )
 
-        config = dict(existing.config) if existing and existing.config else {}
+    def _migrate_waba(
+        self,
+        *,
+        project: Project,
+        app_uuid: uuid.UUID,
+        waba_id: str,
+        phone_number: WhatsappPhoneNumber,
+        old_waba_id: str,
+    ) -> Dashboard:
+        migrated_at = timezone.now().astimezone(dt_timezone.utc).isoformat()
+        migration_data = {
+            "waba_id": old_waba_id,
+            "migrated_at": migrated_at,
+        }
+
+        old_dashboards = list(
+            Dashboard.objects.filter(
+                project=project,
+                config__is_whatsapp_integration=True,
+                config__waba_id=old_waba_id,
+            )
+        )
+
+        created: list[Dashboard] = []
+        for old in old_dashboards:
+            created.append(
+                self._recreate_dashboard(
+                    project=project,
+                    source=old,
+                    app_uuid=app_uuid,
+                    waba_id=waba_id,
+                    phone_number=(old.config or {}).get("phone_number")
+                    or phone_number,
+                    migration_data=migration_data,
+                    name_prefix="Meta",
+                )
+            )
+
+        self._migrate_main_project_copies(
+            source_project=project,
+            app_uuid=app_uuid,
+            waba_id=waba_id,
+            old_waba_id=old_waba_id,
+            migration_data=migration_data,
+            created_dashboards=created,
+        )
+
+        if not created:
+            return self._upsert_by_phone(
+                project=project,
+                app_uuid=app_uuid,
+                waba_id=waba_id,
+                phone_number=phone_number,
+                migration_data=migration_data,
+            )
+
+        for dashboard in created:
+            config_phone = (dashboard.config or {}).get("phone_number") or {}
+            if config_phone.get("id") == phone_number["id"]:
+                return dashboard
+
+        return created[0]
+
+    def _upsert_by_phone(
+        self,
+        *,
+        project: Project,
+        app_uuid: uuid.UUID,
+        waba_id: str,
+        phone_number: WhatsappPhoneNumber,
+        migration_data: dict | None,
+    ) -> Dashboard:
+        existing = (
+            Dashboard.objects.filter(
+                project=project,
+                config__is_whatsapp_integration=True,
+                config__phone_number__id=phone_number["id"],
+            ).first()
+        )
+
+        dashboard = self._recreate_dashboard(
+            project=project,
+            source=existing,
+            app_uuid=app_uuid,
+            waba_id=waba_id,
+            phone_number=phone_number,
+            migration_data=migration_data,
+            name_prefix="Meta",
+        )
+
+        main_project = self._get_main_project(project)
+        if main_project and main_project.pk != project.pk:
+            main_existing = (
+                Dashboard.objects.filter(
+                    project=main_project,
+                    config__is_whatsapp_integration=True,
+                    config__phone_number__id=phone_number["id"],
+                ).first()
+            )
+            self._recreate_dashboard(
+                project=main_project,
+                source=main_existing,
+                app_uuid=app_uuid,
+                waba_id=waba_id,
+                phone_number=phone_number,
+                migration_data=migration_data,
+                name_prefix=project.name,
+                config_override=dict(dashboard.config),
+            )
+
+        return dashboard
+
+    def _migrate_main_project_copies(
+        self,
+        *,
+        source_project: Project,
+        app_uuid: uuid.UUID,
+        waba_id: str,
+        old_waba_id: str,
+        migration_data: dict,
+        created_dashboards: list[Dashboard],
+    ) -> None:
+        main_project = self._get_main_project(source_project)
+        if not main_project or main_project.pk == source_project.pk:
+            return
+
+        main_old_dashboards = list(
+            Dashboard.objects.filter(
+                project=main_project,
+                config__is_whatsapp_integration=True,
+                config__waba_id=old_waba_id,
+            )
+        )
+
+        if main_old_dashboards:
+            for old in main_old_dashboards:
+                self._recreate_dashboard(
+                    project=main_project,
+                    source=old,
+                    app_uuid=app_uuid,
+                    waba_id=waba_id,
+                    phone_number=(old.config or {}).get("phone_number") or {},
+                    migration_data=migration_data,
+                    name_prefix=source_project.name,
+                )
+            return
+
+        for dashboard in created_dashboards:
+            phone = (dashboard.config or {}).get("phone_number") or {}
+            phone_id = phone.get("id")
+            main_existing = None
+            if phone_id:
+                main_existing = (
+                    Dashboard.objects.filter(
+                        project=main_project,
+                        config__is_whatsapp_integration=True,
+                        config__phone_number__id=phone_id,
+                    ).first()
+                )
+            self._recreate_dashboard(
+                project=main_project,
+                source=main_existing,
+                app_uuid=app_uuid,
+                waba_id=waba_id,
+                phone_number=phone,
+                migration_data=migration_data,
+                name_prefix=source_project.name,
+                config_override=dict(dashboard.config),
+            )
+
+    def _recreate_dashboard(
+        self,
+        *,
+        project: Project,
+        source: Dashboard | None,
+        app_uuid: uuid.UUID,
+        waba_id: str,
+        phone_number: WhatsappPhoneNumber | dict,
+        migration_data: dict | None,
+        name_prefix: str,
+        config_override: dict | None = None,
+    ) -> Dashboard:
+        if config_override is not None:
+            config = deepcopy(config_override)
+        else:
+            config = deepcopy(source.config) if source and source.config else {}
+
         config.update(
             {
                 "is_whatsapp_integration": True,
@@ -49,103 +254,28 @@ class SaveWhatsappIntegrationUseCase:
                 "phone_number": phone_number,
             }
         )
+        if migration_data is not None:
+            config["migration_data"] = migration_data
 
-        if old_waba_id:
-            config["migration_data"] = {
-                "waba_id": old_waba_id,
-                "migrated_at": timezone.now()
-                .astimezone(dt_timezone.utc)
-                .isoformat(),
-            }
+        if source is not None:
+            source.delete()
 
-        self._soft_delete_existing(
-            project=project,
-            waba_id=waba_id,
-            phone_number_id=phone_number["id"],
-            old_waba_id=old_waba_id,
-        )
+        display = (
+            phone_number.get("display_phone_number")
+            if isinstance(phone_number, dict)
+            else None
+        ) or "unknown"
 
-        name = f"Meta {phone_number['display_phone_number']}"
-        dashboard = Dashboard.objects.create(
+        return Dashboard.objects.create(
             project=project,
             config=config,
-            name=name,
+            name=f"{name_prefix} {display}",
         )
 
-        main_project = Project.objects.filter(
+    def _get_main_project(self, project: Project) -> Project | None:
+        if not project.org_uuid:
+            return None
+        return Project.objects.filter(
             org_uuid=project.org_uuid,
             config__is_main_project=True,
         ).first()
-
-        if main_project and main_project.pk != project.pk:
-            self._soft_delete_existing(
-                project=main_project,
-                waba_id=waba_id,
-                phone_number_id=phone_number["id"],
-                old_waba_id=old_waba_id,
-            )
-
-            copy_name = f"{project.name} {phone_number['display_phone_number']}"
-            Dashboard.objects.create(
-                project=main_project,
-                config=config,
-                name=copy_name,
-            )
-
-        return dashboard
-
-    def _matching_filter(
-        self,
-        waba_id: str,
-        phone_number_id: str,
-        old_waba_id: str | None = None,
-    ) -> Q:
-        matching = Q(config__phone_number__id=phone_number_id) | Q(
-            config__waba_id=waba_id
-        )
-        if old_waba_id:
-            matching |= Q(config__waba_id=old_waba_id)
-        return matching
-
-    def _find_existing(
-        self,
-        project: Project,
-        waba_id: str,
-        phone_number_id: str,
-        old_waba_id: str | None = None,
-    ) -> Dashboard | None:
-        return (
-            Dashboard.objects.filter(
-                project=project,
-                config__is_whatsapp_integration=True,
-            )
-            .filter(
-                self._matching_filter(
-                    waba_id=waba_id,
-                    phone_number_id=phone_number_id,
-                    old_waba_id=old_waba_id,
-                )
-            )
-            .first()
-        )
-
-    def _soft_delete_existing(
-        self,
-        project: Project,
-        waba_id: str,
-        phone_number_id: str,
-        old_waba_id: str | None = None,
-    ) -> None:
-        existing = Dashboard.objects.filter(
-            project=project,
-            config__is_whatsapp_integration=True,
-        ).filter(
-            self._matching_filter(
-                waba_id=waba_id,
-                phone_number_id=phone_number_id,
-                old_waba_id=old_waba_id,
-            )
-        )
-
-        for dashboard in existing:
-            dashboard.delete()


### PR DESCRIPTION
### What
Updates SaveWhatsappIntegrationUseCase (used by WhatsappIntegrationWebhookView) so WABA migration with old_waba_id recreates every active WhatsApp dashboard under that WABA 1:1 — soft-delete + new dash per phone number, preserving each phone_number and writing migration_data — including main-project copies when applicable. Without old_waba_id, matching is by phone_number.id only, so upserting one number no longer soft-deletes other numbers on the same WABA. Tests cover multi-dashboard migration and same-WABA isolation.

### Why
The webhook previously soft-deleted all dashboards matching the old WABA but created only one new dashboard (from .first() / the payload phone). Projects with multiple phone numbers under the same WABA lost the extra dashboards on migration, which forced manual shell scripts. This makes the webhook safe for multi-number WABAs and aligns create/edit with phone-scoped updates.
