### PR TITLE
feat: abandoned cart and template orders waba migration

### DIFF
--- a/insights/metrics/meta/usecases/get_templates_metrics_from_multiple_wabas.py
+++ b/insights/metrics/meta/usecases/get_templates_metrics_from_multiple_wabas.py
@@ -1,9 +1,15 @@
 from dataclasses import dataclass
 from datetime import date
 
+from django.conf import settings
+
 from insights.metrics.meta.clients import MetaGraphAPIClient
 from insights.metrics.meta.enums import ProductType
-from django.conf import settings
+from insights.metrics.meta.usecases.waba_migration_analytics import (
+    WabaAnalyticsPeriod,
+    resolve_old_template_id,
+    resolve_waba_analytics_periods,
+)
 
 
 @dataclass
@@ -38,6 +44,28 @@ class GetTemplatesMetricsFromMultipleWabasUseCase:
             data_points.extend(metrics.get("data", {}).get("data_points", []))
         return data_points
 
+    def _template_ids_for_period(
+        self,
+        *,
+        current_waba_id: str,
+        period: WabaAnalyticsPeriod,
+        new_template_ids: list[str],
+    ) -> list[str]:
+        if period.waba_id == current_waba_id:
+            return new_template_ids
+
+        old_template_ids: list[str] = []
+        for new_template_id in new_template_ids:
+            old_template_id = resolve_old_template_id(
+                self.meta_client,
+                old_waba_id=period.waba_id,
+                new_template_id=new_template_id,
+            )
+            if old_template_id:
+                old_template_ids.append(old_template_id)
+
+        return old_template_ids
+
     def execute(
         self,
         waba_templates: list[WabaTemplateIDs],
@@ -47,19 +75,34 @@ class GetTemplatesMetricsFromMultipleWabasUseCase:
         data_points: list[dict] = []
 
         for group in waba_templates:
-            for product_type in (
-                ProductType.CLOUD_API.value,
-                ProductType.MM_LITE.value,
-            ):
-                data_points.extend(
-                    self._fetch_analytics_in_chunks(
-                        waba_id=group.waba_id,
-                        template_ids=group.template_ids,
-                        start_date=start_date,
-                        end_date=end_date,
-                        product_type=product_type,
-                    )
+            periods = resolve_waba_analytics_periods(
+                current_waba_id=group.waba_id,
+                start_date=start_date,
+                end_date=end_date,
+            )
+
+            for period in periods:
+                template_ids = self._template_ids_for_period(
+                    current_waba_id=group.waba_id,
+                    period=period,
+                    new_template_ids=group.template_ids,
                 )
+                if not template_ids:
+                    continue
+
+                for product_type in (
+                    ProductType.CLOUD_API.value,
+                    ProductType.MM_LITE.value,
+                ):
+                    data_points.extend(
+                        self._fetch_analytics_in_chunks(
+                            waba_id=period.waba_id,
+                            template_ids=template_ids,
+                            start_date=period.start_date,
+                            end_date=period.end_date,
+                            product_type=product_type,
+                        )
+                    )
 
         result = {
             "sent": 0,

--- a/insights/metrics/meta/usecases/get_templates_metrics_from_multiple_wabas.py
+++ b/insights/metrics/meta/usecases/get_templates_metrics_from_multiple_wabas.py
@@ -1,7 +1,9 @@
+import logging
 from dataclasses import dataclass
 from datetime import date
 
 from django.conf import settings
+from sentry_sdk import capture_exception
 
 from insights.metrics.meta.clients import MetaGraphAPIClient
 from insights.metrics.meta.enums import ProductType
@@ -10,6 +12,15 @@ from insights.metrics.meta.usecases.waba_migration_analytics import (
     resolve_old_template_id,
     resolve_waba_analytics_periods,
 )
+
+logger = logging.getLogger(__name__)
+
+EMPTY_TEMPLATE_METRICS = {
+    "sent": 0,
+    "delivered": 0,
+    "read": 0,
+    "clicked": 0,
+}
 
 
 @dataclass
@@ -56,15 +67,69 @@ class GetTemplatesMetricsFromMultipleWabasUseCase:
 
         old_template_ids: list[str] = []
         for new_template_id in new_template_ids:
-            old_template_id = resolve_old_template_id(
-                self.meta_client,
-                old_waba_id=period.waba_id,
-                new_template_id=new_template_id,
-            )
+            try:
+                old_template_id = resolve_old_template_id(
+                    self.meta_client,
+                    old_waba_id=period.waba_id,
+                    new_template_id=new_template_id,
+                )
+            except Exception as error:
+                capture_exception(error)
+                logger.warning(
+                    "Failed to resolve old template id for new_template_id=%s "
+                    "on old_waba_id=%s; skipping this template. Error: %s",
+                    new_template_id,
+                    period.waba_id,
+                    error,
+                    exc_info=True,
+                )
+                continue
+
             if old_template_id:
                 old_template_ids.append(old_template_id)
 
-        return old_template_ids
+        # Same template name across languages can resolve to the same old ID.
+        return list(dict.fromkeys(old_template_ids))
+
+    def _fetch_period_data_points(
+        self,
+        *,
+        current_waba_id: str,
+        period: WabaAnalyticsPeriod,
+        template_ids: list[str],
+    ) -> list[dict]:
+        is_old_waba = period.waba_id != current_waba_id
+        data_points: list[dict] = []
+
+        for product_type in (
+            ProductType.CLOUD_API.value,
+            ProductType.MM_LITE.value,
+        ):
+            try:
+                data_points.extend(
+                    self._fetch_analytics_in_chunks(
+                        waba_id=period.waba_id,
+                        template_ids=template_ids,
+                        start_date=period.start_date,
+                        end_date=period.end_date,
+                        product_type=product_type,
+                    )
+                )
+            except Exception as error:
+                if not is_old_waba:
+                    raise
+
+                capture_exception(error)
+                logger.warning(
+                    "Failed to fetch analytics for old_waba_id=%s "
+                    "product_type=%s; skipping this period/product. Error: %s",
+                    period.waba_id,
+                    product_type,
+                    error,
+                    exc_info=True,
+                )
+
+        return data_points
 
     def execute(
         self,
@@ -90,26 +155,15 @@ class GetTemplatesMetricsFromMultipleWabasUseCase:
                 if not template_ids:
                     continue
 
-                for product_type in (
-                    ProductType.CLOUD_API.value,
-                    ProductType.MM_LITE.value,
-                ):
-                    data_points.extend(
-                        self._fetch_analytics_in_chunks(
-                            waba_id=period.waba_id,
-                            template_ids=template_ids,
-                            start_date=period.start_date,
-                            end_date=period.end_date,
-                            product_type=product_type,
-                        )
+                data_points.extend(
+                    self._fetch_period_data_points(
+                        current_waba_id=group.waba_id,
+                        period=period,
+                        template_ids=template_ids,
                     )
+                )
 
-        result = {
-            "sent": 0,
-            "delivered": 0,
-            "read": 0,
-            "clicked": 0,
-        }
+        result = dict(EMPTY_TEMPLATE_METRICS)
 
         for day_data in data_points:
             result["sent"] += day_data["sent"]

--- a/insights/metrics/meta/usecases/tests/test_usecases.py
+++ b/insights/metrics/meta/usecases/tests/test_usecases.py
@@ -571,3 +571,145 @@ class TestGetTemplatesMetricsFromMultipleWabasUseCase(TestCase):
         self.assertEqual(result["delivered"], 4)
         self.assertEqual(result["read"], 2)
         self.assertEqual(result["clicked"], 0)
+
+    @patch("insights.metrics.meta.clients.MetaGraphAPIClient.get_messages_analytics")
+    def test_deduplicates_resolved_old_template_ids(self, mock_analytics):
+        current_waba_id = "new_waba"
+        old_waba_id = "old_waba"
+        self._create_migrated_dashboard(
+            current_waba_id=current_waba_id,
+            old_waba_id=old_waba_id,
+        )
+        mock_analytics.return_value = {
+            "data": {
+                "data_points": [
+                    {"sent": 1, "delivered": 1, "read": 1, "clicked": 1},
+                ]
+            }
+        }
+
+        with (
+            patch(
+                "insights.metrics.meta.clients.MetaGraphAPIClient.get_template_preview"
+            ) as mock_preview,
+            patch(
+                "insights.metrics.meta.clients.MetaGraphAPIClient.get_templates_list"
+            ) as mock_list,
+        ):
+            mock_preview.return_value = {"name": "weni_abandoned_cart"}
+            mock_list.return_value = {
+                "data": [{"name": "weni_abandoned_cart", "id": "old_t1"}]
+            }
+
+            usecase = GetTemplatesMetricsFromMultipleWabasUseCase()
+            usecase.execute(
+                waba_templates=[
+                    WabaTemplateIDs(
+                        waba_id=current_waba_id,
+                        template_ids=["new_t1", "new_t2"],
+                    ),
+                ],
+                start_date=date(2026, 3, 1),
+                end_date=date(2026, 3, 10),
+            )
+
+        for call in mock_analytics.call_args_list:
+            self.assertEqual(call.kwargs["template_id"], ["old_t1"])
+
+    @patch("insights.metrics.meta.clients.MetaGraphAPIClient.get_messages_analytics")
+    def test_skips_old_template_when_resolve_raises(self, mock_analytics):
+        current_waba_id = "new_waba"
+        old_waba_id = "old_waba"
+        self._create_migrated_dashboard(
+            current_waba_id=current_waba_id,
+            old_waba_id=old_waba_id,
+        )
+        mock_analytics.return_value = {
+            "data": {
+                "data_points": [
+                    {"sent": 3, "delivered": 2, "read": 1, "clicked": 0},
+                ]
+            }
+        }
+
+        with patch(
+            "insights.metrics.meta.usecases.get_templates_metrics_from_multiple_wabas"
+            ".resolve_old_template_id",
+            side_effect=Exception("meta unavailable"),
+        ):
+            usecase = GetTemplatesMetricsFromMultipleWabasUseCase()
+            result = usecase.execute(
+                waba_templates=[
+                    WabaTemplateIDs(
+                        waba_id=current_waba_id, template_ids=["new_t1"]
+                    ),
+                ],
+                start_date=date(2026, 3, 1),
+                end_date=date(2026, 3, 31),
+            )
+
+        self.assertEqual(mock_analytics.call_count, 2)
+        for call in mock_analytics.call_args_list:
+            self.assertEqual(call.kwargs["waba_id"], current_waba_id)
+
+        self.assertEqual(result["sent"], 6)
+        self.assertEqual(result["delivered"], 4)
+        self.assertEqual(result["read"], 2)
+        self.assertEqual(result["clicked"], 0)
+
+    @patch("insights.metrics.meta.clients.MetaGraphAPIClient.get_messages_analytics")
+    def test_skips_old_waba_fetch_when_analytics_raises(self, mock_analytics):
+        current_waba_id = "new_waba"
+        old_waba_id = "old_waba"
+        self._create_migrated_dashboard(
+            current_waba_id=current_waba_id,
+            old_waba_id=old_waba_id,
+        )
+
+        def analytics_side_effect(**kwargs):
+            if kwargs["waba_id"] == old_waba_id:
+                raise Exception("old waba analytics failed")
+            return {
+                "data": {
+                    "data_points": [
+                        {"sent": 4, "delivered": 3, "read": 2, "clicked": 1},
+                    ]
+                }
+            }
+
+        mock_analytics.side_effect = analytics_side_effect
+
+        with (
+            patch(
+                "insights.metrics.meta.clients.MetaGraphAPIClient.get_template_preview"
+            ) as mock_preview,
+            patch(
+                "insights.metrics.meta.clients.MetaGraphAPIClient.get_templates_list"
+            ) as mock_list,
+        ):
+            mock_preview.return_value = {"name": "weni_abandoned_cart"}
+            mock_list.return_value = {
+                "data": [{"name": "weni_abandoned_cart", "id": "old_t1"}]
+            }
+
+            usecase = GetTemplatesMetricsFromMultipleWabasUseCase()
+            result = usecase.execute(
+                waba_templates=[
+                    WabaTemplateIDs(
+                        waba_id=current_waba_id, template_ids=["new_t1"]
+                    ),
+                ],
+                start_date=date(2026, 3, 1),
+                end_date=date(2026, 3, 31),
+            )
+
+        new_calls = [
+            call
+            for call in mock_analytics.call_args_list
+            if call.kwargs["waba_id"] == current_waba_id
+        ]
+        self.assertEqual(len(new_calls), 2)
+        self.assertEqual(result["sent"], 8)
+        self.assertEqual(result["delivered"], 6)
+        self.assertEqual(result["read"], 4)
+        self.assertEqual(result["clicked"], 2)

--- a/insights/metrics/meta/usecases/tests/test_usecases.py
+++ b/insights/metrics/meta/usecases/tests/test_usecases.py
@@ -1,3 +1,4 @@
+from datetime import date
 from unittest.mock import patch
 
 from django.test import TestCase
@@ -335,3 +336,238 @@ class TestGetTemplatesMetricsFromMultipleWabasUseCase(TestCase):
         )
 
         self.assertEqual(result, {"sent": 0, "delivered": 0, "read": 0, "clicked": 0})
+
+    def _create_migrated_dashboard(
+        self,
+        *,
+        current_waba_id: str,
+        old_waba_id: str,
+        migrated_at: str = "2026-03-15T12:00:00+00:00",
+    ):
+        project = Project.objects.create(name="Migration Project")
+        Dashboard.objects.create(
+            project=project,
+            name="Meta dashboard",
+            config={
+                "is_whatsapp_integration": True,
+                "waba_id": current_waba_id,
+                "migration_data": {
+                    "waba_id": old_waba_id,
+                    "migrated_at": migrated_at,
+                },
+            },
+        )
+        return project
+
+    @patch("insights.metrics.meta.clients.MetaGraphAPIClient.get_messages_analytics")
+    def test_queries_only_old_waba_when_range_is_before_migration(
+        self, mock_analytics
+    ):
+        current_waba_id = "new_waba"
+        old_waba_id = "old_waba"
+        self._create_migrated_dashboard(
+            current_waba_id=current_waba_id,
+            old_waba_id=old_waba_id,
+        )
+        mock_analytics.return_value = {
+            "data": {
+                "data_points": [
+                    {"sent": 10, "delivered": 8, "read": 5, "clicked": 2},
+                ]
+            }
+        }
+
+        with (
+            patch(
+                "insights.metrics.meta.clients.MetaGraphAPIClient.get_template_preview"
+            ) as mock_preview,
+            patch(
+                "insights.metrics.meta.clients.MetaGraphAPIClient.get_templates_list"
+            ) as mock_list,
+        ):
+            mock_preview.return_value = {"name": "weni_abandoned_cart"}
+            mock_list.return_value = {
+                "data": [{"name": "weni_abandoned_cart", "id": "old_t1"}]
+            }
+
+            usecase = GetTemplatesMetricsFromMultipleWabasUseCase()
+            result = usecase.execute(
+                waba_templates=[
+                    WabaTemplateIDs(
+                        waba_id=current_waba_id, template_ids=["new_t1"]
+                    ),
+                ],
+                start_date=date(2026, 3, 1),
+                end_date=date(2026, 3, 10),
+            )
+
+        self.assertEqual(mock_analytics.call_count, 2)  # 2 product types
+        for call in mock_analytics.call_args_list:
+            self.assertEqual(call.kwargs["waba_id"], old_waba_id)
+            self.assertEqual(call.kwargs["template_id"], ["old_t1"])
+            self.assertEqual(call.kwargs["start_date"], date(2026, 3, 1))
+            self.assertEqual(call.kwargs["end_date"], date(2026, 3, 10))
+
+        self.assertEqual(result["sent"], 20)
+        self.assertEqual(result["delivered"], 16)
+        self.assertEqual(result["read"], 10)
+        self.assertEqual(result["clicked"], 4)
+
+    @patch("insights.metrics.meta.clients.MetaGraphAPIClient.get_messages_analytics")
+    def test_queries_only_current_waba_when_range_is_after_migration(
+        self, mock_analytics
+    ):
+        current_waba_id = "new_waba"
+        old_waba_id = "old_waba"
+        self._create_migrated_dashboard(
+            current_waba_id=current_waba_id,
+            old_waba_id=old_waba_id,
+        )
+        mock_analytics.return_value = {
+            "data": {
+                "data_points": [
+                    {"sent": 7, "delivered": 6, "read": 4, "clicked": 1},
+                ]
+            }
+        }
+
+        usecase = GetTemplatesMetricsFromMultipleWabasUseCase()
+        result = usecase.execute(
+            waba_templates=[
+                WabaTemplateIDs(waba_id=current_waba_id, template_ids=["new_t1"]),
+            ],
+            start_date=date(2026, 3, 20),
+            end_date=date(2026, 3, 31),
+        )
+
+        self.assertEqual(mock_analytics.call_count, 2)
+        for call in mock_analytics.call_args_list:
+            self.assertEqual(call.kwargs["waba_id"], current_waba_id)
+            self.assertEqual(call.kwargs["template_id"], ["new_t1"])
+
+        self.assertEqual(result["sent"], 14)
+        self.assertEqual(result["delivered"], 12)
+        self.assertEqual(result["read"], 8)
+        self.assertEqual(result["clicked"], 2)
+
+    @patch("insights.metrics.meta.clients.MetaGraphAPIClient.get_messages_analytics")
+    def test_queries_both_wabas_when_range_crosses_migration(self, mock_analytics):
+        current_waba_id = "new_waba"
+        old_waba_id = "old_waba"
+        self._create_migrated_dashboard(
+            current_waba_id=current_waba_id,
+            old_waba_id=old_waba_id,
+        )
+        mock_analytics.return_value = {
+            "data": {
+                "data_points": [
+                    {"sent": 10, "delivered": 8, "read": 5, "clicked": 2},
+                ]
+            }
+        }
+
+        with (
+            patch(
+                "insights.metrics.meta.clients.MetaGraphAPIClient.get_template_preview"
+            ) as mock_preview,
+            patch(
+                "insights.metrics.meta.clients.MetaGraphAPIClient.get_templates_list"
+            ) as mock_list,
+        ):
+            mock_preview.return_value = {"name": "weni_abandoned_cart"}
+            mock_list.return_value = {
+                "data": [{"name": "weni_abandoned_cart", "id": "old_t1"}]
+            }
+
+            usecase = GetTemplatesMetricsFromMultipleWabasUseCase()
+            result = usecase.execute(
+                waba_templates=[
+                    WabaTemplateIDs(
+                        waba_id=current_waba_id, template_ids=["new_t1"]
+                    ),
+                ],
+                start_date=date(2026, 3, 1),
+                end_date=date(2026, 3, 31),
+            )
+
+        # 2 periods x 2 product types
+        self.assertEqual(mock_analytics.call_count, 4)
+
+        old_calls = [
+            call
+            for call in mock_analytics.call_args_list
+            if call.kwargs["waba_id"] == old_waba_id
+        ]
+        new_calls = [
+            call
+            for call in mock_analytics.call_args_list
+            if call.kwargs["waba_id"] == current_waba_id
+        ]
+        self.assertEqual(len(old_calls), 2)
+        self.assertEqual(len(new_calls), 2)
+
+        for call in old_calls:
+            self.assertEqual(call.kwargs["template_id"], ["old_t1"])
+            self.assertEqual(call.kwargs["start_date"], date(2026, 3, 1))
+            self.assertEqual(call.kwargs["end_date"], date(2026, 3, 15))
+
+        for call in new_calls:
+            self.assertEqual(call.kwargs["template_id"], ["new_t1"])
+            self.assertEqual(call.kwargs["start_date"], date(2026, 3, 15))
+            self.assertEqual(call.kwargs["end_date"], date(2026, 3, 31))
+
+        # 4 calls x (10, 8, 5, 2)
+        self.assertEqual(result["sent"], 40)
+        self.assertEqual(result["delivered"], 32)
+        self.assertEqual(result["read"], 20)
+        self.assertEqual(result["clicked"], 8)
+
+    @patch("insights.metrics.meta.clients.MetaGraphAPIClient.get_messages_analytics")
+    def test_skips_old_waba_when_old_template_cannot_be_resolved(
+        self, mock_analytics
+    ):
+        current_waba_id = "new_waba"
+        old_waba_id = "old_waba"
+        self._create_migrated_dashboard(
+            current_waba_id=current_waba_id,
+            old_waba_id=old_waba_id,
+        )
+        mock_analytics.return_value = {
+            "data": {
+                "data_points": [
+                    {"sent": 3, "delivered": 2, "read": 1, "clicked": 0},
+                ]
+            }
+        }
+
+        with (
+            patch(
+                "insights.metrics.meta.clients.MetaGraphAPIClient.get_template_preview"
+            ) as mock_preview,
+            patch(
+                "insights.metrics.meta.clients.MetaGraphAPIClient.get_templates_list"
+            ) as mock_list,
+        ):
+            mock_preview.return_value = {"name": "weni_abandoned_cart_new"}
+            mock_list.return_value = {"data": []}
+
+            usecase = GetTemplatesMetricsFromMultipleWabasUseCase()
+            result = usecase.execute(
+                waba_templates=[
+                    WabaTemplateIDs(
+                        waba_id=current_waba_id, template_ids=["new_t1"]
+                    ),
+                ],
+                start_date=date(2026, 3, 1),
+                end_date=date(2026, 3, 31),
+            )
+
+        # Only current WABA period (old skipped) x 2 product types
+        self.assertEqual(mock_analytics.call_count, 2)
+        for call in mock_analytics.call_args_list:
+            self.assertEqual(call.kwargs["waba_id"], current_waba_id)
+
+        self.assertEqual(result["sent"], 6)
+        self.assertEqual(result["delivered"], 4)
+        self.assertEqual(result["read"], 2)
+        self.assertEqual(result["clicked"], 0)

--- a/insights/metrics/templates_and_orders/usecases/get_templates_and_orders_metrics.py
+++ b/insights/metrics/templates_and_orders/usecases/get_templates_and_orders_metrics.py
@@ -9,6 +9,7 @@ from insights.metrics.meta.usecases.get_templates_from_prefix import (
     GetTemplatesFromPrefixUseCase,
 )
 from insights.metrics.meta.usecases.get_templates_metrics_from_multiple_wabas import (
+    EMPTY_TEMPLATE_METRICS,
     GetTemplatesMetricsFromMultipleWabasUseCase,
     WabaTemplateIDs,
 )
@@ -117,14 +118,28 @@ class GetTemplatesAndOrdersMetrics:
         limits: MetricsLimits | None = None,
         require_templates: bool = False,
     ) -> dict:
-        template_metrics = self._get_template_metrics(
-            project=project,
-            template_name_prefix=template_name_prefix,
-            start_date=start_date,
-            end_date=end_date,
-            limits=limits,
-            require_templates=require_templates,
-        )
+        try:
+            template_metrics = self._get_template_metrics(
+                project=project,
+                template_name_prefix=template_name_prefix,
+                start_date=start_date,
+                end_date=end_date,
+                limits=limits,
+                require_templates=require_templates,
+            )
+        except TemplatesNotFoundError:
+            raise
+        except Exception as error:
+            capture_exception(error)
+            logger.error(
+                "Error getting template metrics for project=%s; "
+                "returning zeroed template metrics and continuing with orders. "
+                "Error: %s",
+                project.uuid,
+                error,
+                exc_info=True,
+            )
+            template_metrics = dict(EMPTY_TEMPLATE_METRICS)
 
         orders_metrics = self._get_orders_metrics(
             project=project,

--- a/insights/metrics/templates_and_orders/usecases/tests/test_get_templates_and_orders_metrics.py
+++ b/insights/metrics/templates_and_orders/usecases/tests/test_get_templates_and_orders_metrics.py
@@ -490,3 +490,40 @@ class TestGetTemplatesAndOrdersMetrics(TestCase):
             result["template_metrics"],
             {"sent": 0, "delivered": 0, "read": 0, "clicked": 0},
         )
+
+    @patch(
+        "insights.metrics.templates_and_orders.usecases"
+        ".get_templates_and_orders_metrics.OrdersService"
+    )
+    def test_template_metrics_failure_returns_zeroed_templates_and_orders(
+        self, MockOrdersService
+    ):
+        self.mock_get_wabas.execute.return_value = ["waba_1"]
+        self.mock_get_templates.execute.return_value = ["t1"]
+        self.mock_get_metrics.execute.side_effect = Exception("meta unavailable")
+
+        mock_orders_instance = MockOrdersService.return_value
+        mock_orders_instance.get_metrics_from_utm_source.return_value = {
+            "revenue": {
+                "value": 1500,
+                "currency_code": "MXN",
+                "increase_percentage": 0,
+            },
+            "orders_placed": {"value": 10, "increase_percentage": 0},
+        }
+
+        result = self.usecase.execute(
+            project=self.project,
+            start_date=self.start_date,
+            end_date=self.end_date,
+            utm_source=self.utm_source,
+            template_name_prefix=self.template_name_prefix,
+        )
+
+        self.assertEqual(
+            result["template_metrics"],
+            {"sent": 0, "delivered": 0, "read": 0, "clicked": 0},
+        )
+        self.assertEqual(result["orders_metrics"]["revenue"]["value"], 1500)
+        self.assertEqual(result["orders_metrics"]["orders_placed"]["value"], 10)
+        MockOrdersService.assert_called_once()


### PR DESCRIPTION
### What
Makes GetTemplatesMetricsFromMultipleWabasUseCase migration-aware when aggregating Meta template analytics across WABAs.

Uses resolve_waba_analytics_periods to split the requested date range across the old and current WABA based on migration_data on the WhatsApp dashboard.
Uses resolve_old_template_id to map each current template ID to its equivalent on the old WABA (by name) when querying pre-migration periods.
Skips the old WABA period when the equivalent template cannot be resolved, instead of failing or querying with the wrong ID.
Adds tests covering ranges before, after, and across the migration cutover, plus the unresolved-old-template case.
Behavioral impact: consumers that go through this use case — notably abandoned cart via AbandonedCartSkillService → GetTemplatesAndOrdersMetrics → GetTemplatesMetricsFromMultipleWabasUseCase — now get correct sent / delivered / read / clicked totals when a project has migrated WABAs. VTEX order/revenue metrics (UTM) are unchanged.

### Why
After a WABA migration, historical template analytics remain on the old WABA, while the project only holds the current WABA and its template IDs. The multi-WABA templates metrics use case always queried the current WABA for the full range, so abandoned cart (and any other consumer of this shared use case) under-reported message metrics for periods that included pre-migration days.

Single-template Meta dashboard analytics already handled this via ConsolidateWabaAnalyticsUseCase. This change aligns the multi-template / multi-WABA path with the same cutover rules so abandoned cart metrics stay complete across migrations.

### Sequence diagram

```mermaid
sequenceDiagram
    participant ACS as AbandonedCartSkillService
    participant GTO as GetTemplatesAndOrdersMetrics
    participant GTM as TemplatesMetricsUseCase
    participant Mig as MigrationHelpers
    participant Meta as MetaAPI

    ACS->>GTO: request abandoned cart metrics
    GTO->>GTM: request template metrics
    GTM->>Mig: resolve periods by migration
    Mig-->>GTM: old and current periods
    GTM->>Mig: resolve old template id
    Mig->>Meta: lookup template by name
    Meta-->>GTM: old template id
    GTM->>Meta: fetch analytics per period
    Meta-->>GTM: data points
    GTM-->>GTO: aggregated template metrics
    GTO-->>ACS: template plus orders metrics
```
