### PR TITLE
feat: waba migration for conversations-by-category endpoint

### DIFF
--- a/insights/metrics/meta/services.py
+++ b/insights/metrics/meta/services.py
@@ -89,9 +89,12 @@ class MetaMessageTemplatesService:
     ) -> dict:
         """
         Get conversations by category.
+
+        When the WABA was migrated, consolidates pricing analytics from the old
+        and current WABA for the requested date range.
         """
 
-        response: dict = self.client.get_conversations_by_category(
+        response: dict = self.waba_analytics.get_conversations_by_category(
             waba_id=waba_id, start_date=start_date, end_date=end_date
         )
 

--- a/insights/metrics/meta/tests/test_services.py
+++ b/insights/metrics/meta/tests/test_services.py
@@ -189,3 +189,82 @@ class TestMetaMessageTemplatesService(TestCase):
             )
 
             self.assertEqual(result, {"SERVICE": 10, "MARKETING": 20})
+
+    def test_get_conversations_by_category_consolidates_migrated_wabas(self):
+        from datetime import date
+        from unittest.mock import patch
+
+        from insights.dashboards.models import Dashboard
+        from insights.projects.models import Project
+
+        project = Project.objects.create(name="Migrated Project")
+        Dashboard.objects.create(
+            project=project,
+            name="Meta dashboard",
+            config={
+                "is_whatsapp_integration": True,
+                "waba_id": "new_waba",
+                "migration_data": {
+                    "waba_id": "old_waba",
+                    "migrated_at": "2026-03-15T12:00:00+00:00",
+                },
+            },
+        )
+
+        with patch.object(
+            self.service.client, "get_conversations_by_category"
+        ) as mock_get:
+            mock_get.side_effect = [
+                {
+                    "pricing_analytics": {
+                        "data": [
+                            {
+                                "data_points": [
+                                    {
+                                        "pricing_category": "MARKETING",
+                                        "volume": 10,
+                                        "cost": 0,
+                                    },
+                                    {
+                                        "pricing_category": "UTILITY",
+                                        "volume": 3,
+                                        "cost": 0,
+                                    },
+                                ]
+                            }
+                        ]
+                    }
+                },
+                {
+                    "pricing_analytics": {
+                        "data": [
+                            {
+                                "data_points": [
+                                    {
+                                        "pricing_category": "MARKETING",
+                                        "volume": 5,
+                                        "cost": 0,
+                                    },
+                                    {
+                                        "pricing_category": "SERVICE",
+                                        "volume": 2,
+                                        "cost": 0,
+                                    },
+                                ]
+                            }
+                        ]
+                    }
+                },
+            ]
+
+            result = self.service.get_conversations_by_category(
+                waba_id="new_waba",
+                start_date=date(2026, 3, 1),
+                end_date=date(2026, 3, 31),
+            )
+
+        self.assertEqual(mock_get.call_count, 2)
+        self.assertEqual(
+            result,
+            {"MARKETING": 15, "UTILITY": 3, "SERVICE": 2},
+        )

--- a/insights/metrics/meta/usecases/tests/test_waba_migration_analytics.py
+++ b/insights/metrics/meta/usecases/tests/test_waba_migration_analytics.py
@@ -10,6 +10,7 @@ from insights.metrics.meta.usecases.waba_migration_analytics import (
     find_exact_template_id_by_name,
     merge_buttons_analytics,
     merge_messages_analytics,
+    merge_pricing_analytics_responses,
     resolve_old_template_id,
     resolve_waba_analytics_periods,
 )
@@ -577,3 +578,183 @@ class TestConsolidateWabaAnalyticsUseCase(TestCase):
             ),
         )
         self.assertEqual(result["data"][0]["total"], 10)
+
+    def test_conversations_by_category_calls_only_old_waba_for_pre_migration_range(self):
+        self.meta_client.get_conversations_by_category.return_value = {
+            "pricing_analytics": {
+                "data": [
+                    {
+                        "data_points": [
+                            {"pricing_category": "MARKETING", "volume": 10, "cost": 0}
+                        ]
+                    }
+                ]
+            }
+        }
+
+        result = self.usecase.get_conversations_by_category(
+            waba_id=self.current_waba_id,
+            start_date=date(2026, 3, 1),
+            end_date=date(2026, 3, 10),
+        )
+
+        self.meta_client.get_conversations_by_category.assert_called_once_with(
+            waba_id=self.old_waba_id,
+            start_date=date(2026, 3, 1),
+            end_date=date(2026, 3, 10),
+        )
+        self.assertEqual(
+            result["pricing_analytics"]["data"][0]["data_points"][0]["volume"], 10
+        )
+
+    def test_conversations_by_category_calls_only_new_waba_for_post_migration_range(
+        self,
+    ):
+        self.meta_client.get_conversations_by_category.return_value = {
+            "pricing_analytics": {
+                "data": [
+                    {
+                        "data_points": [
+                            {"pricing_category": "MARKETING", "volume": 5, "cost": 0}
+                        ]
+                    }
+                ]
+            }
+        }
+
+        self.usecase.get_conversations_by_category(
+            waba_id=self.current_waba_id,
+            start_date=date(2026, 3, 20),
+            end_date=date(2026, 3, 31),
+        )
+
+        self.meta_client.get_conversations_by_category.assert_called_once_with(
+            waba_id=self.current_waba_id,
+            start_date=date(2026, 3, 20),
+            end_date=date(2026, 3, 31),
+        )
+
+    def test_conversations_by_category_merges_both_wabas_when_range_crosses_migration(
+        self,
+    ):
+        self.meta_client.get_conversations_by_category.side_effect = [
+            {
+                "pricing_analytics": {
+                    "data": [
+                        {
+                            "data_points": [
+                                {
+                                    "pricing_category": "MARKETING",
+                                    "volume": 10,
+                                    "cost": 0,
+                                },
+                                {
+                                    "pricing_category": "UTILITY",
+                                    "volume": 3,
+                                    "cost": 0,
+                                },
+                            ]
+                        }
+                    ]
+                }
+            },
+            {
+                "pricing_analytics": {
+                    "data": [
+                        {
+                            "data_points": [
+                                {
+                                    "pricing_category": "MARKETING",
+                                    "volume": 5,
+                                    "cost": 0,
+                                },
+                                {
+                                    "pricing_category": "SERVICE",
+                                    "volume": 2,
+                                    "cost": 0,
+                                },
+                            ]
+                        }
+                    ]
+                }
+            },
+        ]
+
+        result = self.usecase.get_conversations_by_category(
+            waba_id=self.current_waba_id,
+            start_date=date(2026, 3, 1),
+            end_date=date(2026, 3, 31),
+        )
+
+        self.assertEqual(self.meta_client.get_conversations_by_category.call_count, 2)
+        self.assertEqual(
+            self.meta_client.get_conversations_by_category.call_args_list[0],
+            call(
+                waba_id=self.old_waba_id,
+                start_date=date(2026, 3, 1),
+                end_date=date(2026, 3, 15),
+            ),
+        )
+        self.assertEqual(
+            self.meta_client.get_conversations_by_category.call_args_list[1],
+            call(
+                waba_id=self.current_waba_id,
+                start_date=date(2026, 3, 15),
+                end_date=date(2026, 3, 31),
+            ),
+        )
+        self.assertEqual(
+            len(result["pricing_analytics"]["data"][0]["data_points"]), 4
+        )
+
+
+class TestMergePricingAnalyticsResponses(TestCase):
+    def test_concatenates_data_points_from_multiple_responses(self):
+        responses = [
+            {
+                "pricing_analytics": {
+                    "data": [
+                        {
+                            "data_points": [
+                                {
+                                    "pricing_category": "MARKETING",
+                                    "volume": 10,
+                                    "cost": 0,
+                                }
+                            ]
+                        }
+                    ]
+                }
+            },
+            {
+                "pricing_analytics": {
+                    "data": [
+                        {
+                            "data_points": [
+                                {
+                                    "pricing_category": "MARKETING",
+                                    "volume": 5,
+                                    "cost": 0,
+                                },
+                                {
+                                    "pricing_category": "SERVICE",
+                                    "volume": 2,
+                                    "cost": 0,
+                                },
+                            ]
+                        }
+                    ]
+                }
+            },
+        ]
+
+        merged = merge_pricing_analytics_responses(responses)
+
+        self.assertEqual(
+            merged["pricing_analytics"]["data"][0]["data_points"],
+            [
+                {"pricing_category": "MARKETING", "volume": 10, "cost": 0},
+                {"pricing_category": "MARKETING", "volume": 5, "cost": 0},
+                {"pricing_category": "SERVICE", "volume": 2, "cost": 0},
+            ],
+        )

--- a/insights/metrics/meta/usecases/waba_migration_analytics.py
+++ b/insights/metrics/meta/usecases/waba_migration_analytics.py
@@ -322,6 +322,36 @@ def resolve_old_template_id(
     return old_template_id
 
 
+def extract_pricing_data_points(response: dict | None) -> list:
+    """Extract pricing analytics data_points from a Meta Graph API response."""
+    if not isinstance(response, dict):
+        return []
+
+    data = response.get("pricing_analytics", {}).get("data") or []
+    if not data:
+        return []
+
+    first = data[0] if isinstance(data[0], dict) else {}
+    return list(first.get("data_points") or [])
+
+
+def merge_pricing_analytics_responses(responses: list[dict]) -> dict:
+    """
+    Merge Meta pricing_analytics responses by concatenating data_points.
+
+    Aggregation by category happens later in ConversationsByCategoryAggregations.
+    """
+    all_points: list = []
+    for response in responses:
+        all_points.extend(extract_pricing_data_points(response))
+
+    return {
+        "pricing_analytics": {
+            "data": [{"data_points": all_points}],
+        }
+    }
+
+
 class ConsolidateWabaAnalyticsUseCase:
     """
     Intermediate layer between the service and the Meta client.
@@ -349,6 +379,39 @@ class ConsolidateWabaAnalyticsUseCase:
             merge=merge_buttons_analytics,
             fetch_kwargs=kwargs,
         )
+
+    def get_conversations_by_category(
+        self,
+        *,
+        waba_id: str,
+        start_date: date | datetime,
+        end_date: date | datetime,
+    ) -> dict:
+        """
+        Fetch pricing analytics by category, splitting across WABAs when needed.
+
+        Unlike template analytics, this endpoint is WABA-scoped and does not
+        require template_id remapping.
+        """
+        periods = resolve_waba_analytics_periods(
+            current_waba_id=waba_id,
+            start_date=start_date,
+            end_date=end_date,
+        )
+
+        responses = [
+            self.meta_client.get_conversations_by_category(
+                waba_id=period.waba_id,
+                start_date=period.start_date,
+                end_date=period.end_date,
+            )
+            for period in periods
+        ]
+
+        if len(responses) == 1:
+            return responses[0]
+
+        return merge_pricing_analytics_responses(responses)
 
     def _periods_with_template_ids(
         self,


### PR DESCRIPTION
### What
Makes the WhatsApp templates conversations-by-category metric migration-aware.

GET /v1/metrics/meta/whatsapp-message-templates/conversations-by-category/ still has the same contract
MetaMessageTemplatesService.get_conversations_by_category now goes through ConsolidateWabaAnalyticsUseCase instead of calling Meta directly
Uses resolve_waba_analytics_periods to split the date range across old and current WABA from migration_data
Merges Meta pricing_analytics data_points from both WABAs, then aggregates volumes by category as before
No template_id remapping — this metric is WABA-scoped
Behavioral impact: after a WABA migration, the first dashboard tile (volume by pricing category such as MARKETING / UTILITY / SERVICE) includes historical data from the old WABA when the selected range crosses the cutover.

### Why
Template message/button analytics already consolidated old and new WABA data. Conversations-by-category did not, so post-migration the category tile only reflected the current WABA and undercounted historical volume. This aligns that endpoint with the same migration cutover rules.

### Sequence diagram
### Sequence diagram

```mermaid
sequenceDiagram
    participant Client
    participant View
    participant Service
    participant UseCase
    participant Meta

    Client->>View: get conversations by category
    View->>Service: get conversations by category
    Service->>UseCase: consolidate by migration
    UseCase->>UseCase: resolve periods from migration data
    UseCase->>Meta: fetch pricing analytics per period
    Meta-->>UseCase: pricing data points
    UseCase-->>Service: merged pricing response
    Service-->>View: volumes by category
    View-->>Client: category metrics
```